### PR TITLE
Fix UnsignedByteArray.of builder method

### DIFF
--- a/xrpl4j-address-codec/src/main/java/com/ripple/xrpl4j/codec/addresses/UnsignedByteArray.java
+++ b/xrpl4j-address-codec/src/main/java/com/ripple/xrpl4j/codec/addresses/UnsignedByteArray.java
@@ -46,7 +46,7 @@ public class UnsignedByteArray {
     List<UnsignedByte> unsignedBytes = new ArrayList<>();
     unsignedBytes.add(first);
     for (int i = 0; i < rest.length; i++) {
-      unsignedBytes.add(i, rest[i]);
+      unsignedBytes.add(rest[i]);
     }
     return new UnsignedByteArray(unsignedBytes);
   }

--- a/xrpl4j-address-codec/src/test/java/com/ripple/xrpl4j/codec/addresses/UnsignedByteArrayTest.java
+++ b/xrpl4j-address-codec/src/test/java/com/ripple/xrpl4j/codec/addresses/UnsignedByteArrayTest.java
@@ -1,0 +1,32 @@
+package com.ripple.xrpl4j.codec.addresses;
+
+import static com.ripple.xrpl4j.codec.addresses.UnsignedByteArray.of;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+
+public class UnsignedByteArrayTest {
+
+  static byte MAX_BYTE = (byte) 255;
+
+  @Test
+  public void ofByteArray() {
+
+    assertThat(of(new byte[] {0}).hexValue()).isEqualTo("00");
+    assertThat(of(new byte[] {MAX_BYTE}).hexValue()).isEqualTo("FF");
+    assertThat(of(new byte[] {0, MAX_BYTE}).hexValue()).isEqualTo("00FF");
+    assertThat(of(new byte[] {MAX_BYTE, 0}).hexValue()).isEqualTo("FF00");
+    assertThat(of(new byte[] {MAX_BYTE, MAX_BYTE}).hexValue()).isEqualTo("FFFF");
+  }
+
+  @Test
+  public void ofUnsignedByteArray() {
+    assertThat(of(UnsignedByte.of(0)).hexValue()).isEqualTo("00");
+    assertThat(of(UnsignedByte.of(MAX_BYTE)).hexValue()).isEqualTo("FF");
+    assertThat(of(UnsignedByte.of(0), UnsignedByte.of((MAX_BYTE))).hexValue()).isEqualTo("00FF");
+    assertThat(of(UnsignedByte.of(MAX_BYTE), UnsignedByte.of((0))).hexValue()).isEqualTo("FF00");
+    assertThat(of(UnsignedByte.of(MAX_BYTE), UnsignedByte.of((MAX_BYTE))).hexValue()).isEqualTo("FFFF");
+  }
+
+}

--- a/xrpl4j-binary-codec/src/test/java/com/ripple/xrpl4j/codec/binary/XrplBinaryCodecTest.java
+++ b/xrpl4j-binary-codec/src/test/java/com/ripple/xrpl4j/codec/binary/XrplBinaryCodecTest.java
@@ -91,6 +91,17 @@ class XrplBinaryCodecTest {
   }
 
   @Test
+  void encodeDecodeBigBlob() throws JsonProcessingException {
+    String bigValue = Strings.repeat("A", 50000);
+    String json = "{\"Domain\":\"" + bigValue + "\"}";
+    String blobType = "77";
+    String lengthInHex = "F130E7"; // 50000 encoded in XRPL hex length encoding
+    String hex = blobType + lengthInHex + bigValue;
+    assertThat(encoder.encode(json)).isEqualTo(hex);
+    assertThat(encoder.decode(hex)).isEqualTo(json);
+  }
+
+  @Test
   void encodeDecodeIssuedCurrency() throws JsonProcessingException {
     String json = "{\"Fee\":{\"currency\":\"USD\",\"value\":\"123\",\"issuer\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\"}}";
     String hex = "68D5045EADB112E00000000000000000000000000055534400000000005E7B112523F68D2F5E879DB4EAC51C6698A69304";


### PR DESCRIPTION
This method was not assembly the bytes in the correct order which was causing large blobs that
have multibyte length headers to fail.