### PR TITLE
Add XAddress wrapper type

### DIFF
--- a/xrpl4j-address-codec/README.md
+++ b/xrpl4j-address-codec/README.md
@@ -45,13 +45,13 @@ Encoded seed: sEdTM1uX8pu2do5XvTnutH6HsouMaM2
 Similarly, XRPL addresses can be decoded from their Base58 format and vice versa:
 ```java
 AddressCodec addressCodec = AddressCodec.getInstance();
-String address = "rJrRMgiRgrU6hDF4pgu5DXQdWyPbY35ErN";
+Address address = Address.of("rJrRMgiRgrU6hDF4pgu5DXQdWyPbY35ErN");
 System.out.println("Address: " + address);
 
 UnsignedByteArray decoded = addressCodec.decodeAccountId(address);
 System.out.println("Decoded: " + decoded.hexValue());
 
-String encoded = addressCodec.encodeAccountId(decoded);
+Address encoded = addressCodec.encodeAccountId(decoded);
 
 System.out.println("Encoded Address: " + encoded);
 ```
@@ -67,11 +67,11 @@ An `AddressCodec` is also responsible for converting between Classic Addresses a
 ```java
 AddressCodec addressCodec = AddressCodec.getInstance();
 
-String address = "rJrRMgiRgrU6hDF4pgu5DXQdWyPbY35ErN";
+Address address = Address.of("rJrRMgiRgrU6hDF4pgu5DXQdWyPbY35ErN");
 UnsignedInteger tag = UnsignedInteger.valueOf(2345664);
 System.out.println(String.format("Address: %s; Tag: %s", address, tag));
 
-String xAddress = addressCodec.classicAddressToXAddress(address, tag, true);
+XAddress xAddress = addressCodec.classicAddressToXAddress(address, tag, true);
 System.out.println("X-Address: " + xAddress);
 
 ClassicAddress classicAddress = addressCodec.xAddressToClassicAddress(xAddress);

--- a/xrpl4j-address-codec/pom.xml
+++ b/xrpl4j-address-codec/pom.xml
@@ -33,6 +33,10 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.xrpl</groupId>
+      <artifactId>xrpl4j-model</artifactId>
+    </dependency>
   </dependencies>
 
 

--- a/xrpl4j-address-codec/src/main/java/org/xrpl/xrpl4j/codec/addresses/AddressCodec.java
+++ b/xrpl4j-address-codec/src/main/java/org/xrpl/xrpl4j/codec/addresses/AddressCodec.java
@@ -7,6 +7,7 @@ import com.google.common.primitives.UnsignedInteger;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.DecodeException;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodeException;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodingFormatException;
+import org.xrpl.xrpl4j.model.transactions.Address;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -64,10 +65,12 @@ public class AddressCodec {
    * @param accountId An {@link UnsignedByteArray} containing the AccountID to be encoded.
    * @return The Base58 representation of accountId.
    */
-  public String encodeAccountId(final UnsignedByteArray accountId) {
+  public Address encodeAccountId(final UnsignedByteArray accountId) {
     Objects.requireNonNull(accountId);
 
-    return AddressBase58.encode(accountId, Lists.newArrayList(Version.ACCOUNT_ID), UnsignedInteger.valueOf(20));
+    return Address.of(
+      AddressBase58.encode(accountId, Lists.newArrayList(Version.ACCOUNT_ID), UnsignedInteger.valueOf(20))
+    );
   }
 
   /**
@@ -77,10 +80,14 @@ public class AddressCodec {
    * @return An {@link UnsignedByteArray} containing the decoded AccountID.
    * @see "https://xrpl.org/base58-encodings.html"
    */
-  public UnsignedByteArray decodeAccountId(final String accountId) {
+  public UnsignedByteArray decodeAccountId(final Address accountId) {
     Objects.requireNonNull(accountId);
 
-    return AddressBase58.decode(accountId, Lists.newArrayList(Version.ACCOUNT_ID), UnsignedInteger.valueOf(20)).bytes();
+    return AddressBase58.decode(
+      accountId.value(),
+      Lists.newArrayList(Version.ACCOUNT_ID),
+      UnsignedInteger.valueOf(20)
+    ).bytes();
   }
 
   /**
@@ -150,7 +157,7 @@ public class AddressCodec {
    *                       for Mainnet.
    * @return The X-Address representation of the classic address and destination tag.
    */
-  public String classicAddressToXAddress(final String classicAddress, final UnsignedInteger tag, final boolean test) {
+  public String classicAddressToXAddress(final Address classicAddress, final UnsignedInteger tag, final boolean test) {
     Objects.requireNonNull(classicAddress);
     Objects.requireNonNull(tag);
 
@@ -165,7 +172,7 @@ public class AddressCodec {
    *                       for Mainnet.
    * @return The X-Address representation of the classic address.
    */
-  public String classicAddressToXAddress(final String classicAddress, final boolean test) {
+  public String classicAddressToXAddress(final Address classicAddress, final boolean test) {
     Objects.requireNonNull(classicAddress);
 
     return classicAddressToXAddress(classicAddress, Optional.empty(), test);
@@ -181,7 +188,7 @@ public class AddressCodec {
    * @return The X-Address representation of the classic address and destination tag.
    */
   public String classicAddressToXAddress(
-      final String classicAddress,
+      final Address classicAddress,
       final Optional<UnsignedInteger> tag,
       final boolean test
   ) {
@@ -246,7 +253,7 @@ public class AddressCodec {
     Objects.requireNonNull(xAddress);
 
     DecodedXAddress decodedXAddress = decodeXAddress(xAddress);
-    String classicAddress = encodeAccountId(decodedXAddress.accountId());
+    Address classicAddress = encodeAccountId(decodedXAddress.accountId());
 
     return ClassicAddress.builder()
         .classicAddress(classicAddress)
@@ -338,7 +345,7 @@ public class AddressCodec {
    * @param address A potentially valid Classic Address.
    * @return {@code true} if the given address is a valid Classic Address, {@code false} if not.
    */
-  public boolean isValidClassicAddress(final String address) {
+  public boolean isValidClassicAddress(final Address address) {
     try {
       decodeAccountId(address);
     } catch (Exception e) {

--- a/xrpl4j-address-codec/src/main/java/org/xrpl/xrpl4j/codec/addresses/ClassicAddress.java
+++ b/xrpl4j-address-codec/src/main/java/org/xrpl/xrpl4j/codec/addresses/ClassicAddress.java
@@ -23,9 +23,9 @@ public interface ClassicAddress {
   }
 
   /**
-   * A classic address, as a {@link String}.
+   * A classic address, as an {@link Address}.
    *
-   * @return A {@link String} containing the classic address.
+   * @return An {@link Address} containing the classic address.
    */
   Address classicAddress();
 

--- a/xrpl4j-address-codec/src/main/java/org/xrpl/xrpl4j/codec/addresses/ClassicAddress.java
+++ b/xrpl4j-address-codec/src/main/java/org/xrpl/xrpl4j/codec/addresses/ClassicAddress.java
@@ -2,6 +2,7 @@ package org.xrpl.xrpl4j.codec.addresses;
 
 import com.google.common.primitives.UnsignedInteger;
 import org.immutables.value.Value;
+import org.xrpl.xrpl4j.model.transactions.Address;
 
 /**
  * An address on the XRP Ledger represented in Classic Address form.  This form includes a Base58Check encoded
@@ -26,7 +27,7 @@ public interface ClassicAddress {
    *
    * @return A {@link String} containing the classic address.
    */
-  String classicAddress();
+  Address classicAddress();
 
   /**
    * The tag of the classic address.

--- a/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/AddressCodecTest.java
+++ b/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/AddressCodecTest.java
@@ -9,6 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodeException;
+import org.xrpl.xrpl4j.model.transactions.Address;
 
 import java.util.function.Function;
 
@@ -124,8 +125,8 @@ public class AddressCodecTest {
   @Test
   public void encodeDecodeAccountId() {
     testEncodeDecode(
-        accountId -> addressCodec.encodeAccountId(accountId),
-        accountId -> addressCodec.decodeAccountId(accountId),
+        accountId -> addressCodec.encodeAccountId(accountId).value(),
+        accountId -> addressCodec.decodeAccountId(Address.of(accountId)),
         unsignedByteArrayFromHex("BA8E78626EE42C41B46D46C3048DF3A1C3C87072"),
         "rJrRMgiRgrU6hDF4pgu5DXQdWyPbY35ErN"
     );

--- a/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/XAddressTest.java
+++ b/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/XAddressTest.java
@@ -14,6 +14,7 @@ import org.junit.runners.Parameterized;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.DecodeException;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodingFormatException;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.XAddress;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -27,8 +28,8 @@ public class XAddressTest {
 
     Address classicAddressAccountId;
     UnsignedInteger tag;
-    String mainnetXAddress;
-    String testnetXAddress;
+    XAddress mainnetXAddress;
+    XAddress testnetXAddress;
 
     AddressCodec addressCodec;
 
@@ -48,8 +49,8 @@ public class XAddressTest {
     ) {
       this.classicAddressAccountId = Address.of(classicAddressAccountId);
       this.tag = tag;
-      this.mainnetXAddress = mainnetXAddress;
-      this.testnetXAddress = testnetXAddress;
+      this.mainnetXAddress = XAddress.of(mainnetXAddress);
+      this.testnetXAddress = XAddress.of(testnetXAddress);
       this.addressCodec = new AddressCodec();
     }
 
@@ -208,7 +209,11 @@ public class XAddressTest {
 
       assertThat(fromXAddress).isEqualTo(classicAddress);
 
-      String xAddress = addressCodec.classicAddressToXAddress(classicAddressAccountId, Optional.ofNullable(tag), false);
+      XAddress xAddress = addressCodec.classicAddressToXAddress(
+        classicAddressAccountId,
+        Optional.ofNullable(tag),
+        false
+      );
       assertThat(xAddress).isEqualTo(mainnetXAddress);
 
       assertThat(addressCodec.isValidClassicAddress(fromXAddress.classicAddress()));
@@ -226,7 +231,11 @@ public class XAddressTest {
 
       assertThat(fromXAddress).isEqualTo(classicAddress);
 
-      String xAddress = addressCodec.classicAddressToXAddress(classicAddressAccountId, Optional.ofNullable(tag), true);
+      XAddress xAddress = addressCodec.classicAddressToXAddress(
+        classicAddressAccountId,
+        Optional.ofNullable(tag),
+        true
+      );
       assertThat(xAddress).isEqualTo(testnetXAddress);
 
       assertThat(addressCodec.isValidClassicAddress(fromXAddress.classicAddress()));
@@ -248,7 +257,7 @@ public class XAddressTest {
 
     @Test
     public void xAddressWithBadChecksum() {
-      String xAddress = "XVLhHMPHU98es4dbozjVtdWzVrDjtV5fdx1mHp98tDMoQXa";
+      XAddress xAddress = XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV5fdx1mHp98tDMoQXa");
 
       expectedException.expect(EncodingFormatException.class);
       expectedException.expectMessage("Checksum does not validate");
@@ -258,7 +267,7 @@ public class XAddressTest {
 
     @Test
     public void xAddressWithBadPrefix() {
-      String xAddress = "dGzKGt8CVpWoa8aWL1k18tAdy9Won3PxynvbbpkAqp3V47g";
+      XAddress xAddress = XAddress.of("dGzKGt8CVpWoa8aWL1k18tAdy9Won3PxynvbbpkAqp3V47g");
 
       expectedException.expect(DecodeException.class);
       expectedException.expectMessage("Invalid X-Address: Bad Prefix");
@@ -267,7 +276,7 @@ public class XAddressTest {
 
     @Test
     public void xAddressWith64BitTag() {
-      String xAddress = "XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8zeUygYrCgrPh";
+      XAddress xAddress = XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8zeUygYrCgrPh");
 
       expectedException.expect(DecodeException.class);
       expectedException.expectMessage("Unsupported X-Address: 64-bit tags are not supported");

--- a/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/XAddressTest.java
+++ b/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/XAddressTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.DecodeException;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodingFormatException;
+import org.xrpl.xrpl4j.model.transactions.Address;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -24,7 +25,7 @@ public class XAddressTest {
   @RunWith(Parameterized.class)
   public static class XAddressParameterizedTests {
 
-    String classicAddressAccountId;
+    Address classicAddressAccountId;
     UnsignedInteger tag;
     String mainnetXAddress;
     String testnetXAddress;
@@ -45,7 +46,7 @@ public class XAddressTest {
         String mainnetXAddress,
         String testnetXAddress
     ) {
-      this.classicAddressAccountId = classicAddressAccountId;
+      this.classicAddressAccountId = Address.of(classicAddressAccountId);
       this.tag = tag;
       this.mainnetXAddress = mainnetXAddress;
       this.testnetXAddress = testnetXAddress;

--- a/xrpl4j-binary-codec/src/main/java/org/xrpl/xrpl4j/codec/binary/types/AccountIdType.java
+++ b/xrpl4j-binary-codec/src/main/java/org/xrpl/xrpl4j/codec/binary/types/AccountIdType.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import org.xrpl.xrpl4j.codec.addresses.AddressCodec;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
 import org.xrpl.xrpl4j.codec.binary.serdes.BinaryParser;
+import org.xrpl.xrpl4j.model.transactions.Address;
 
 /**
  * Codec for XRPL AccountID type.
@@ -34,12 +35,12 @@ public class AccountIdType extends Hash160Type {
     }
     return HEX_REGEX.matcher(textValue).matches() ?
       new AccountIdType(UnsignedByteArray.fromHex(textValue))
-      : new AccountIdType(addressCodec.decodeAccountId(textValue));
+      : new AccountIdType(addressCodec.decodeAccountId(Address.of(textValue)));
   }
 
   @Override
   public JsonNode toJson() {
-    return new TextNode(addressCodec.encodeAccountId(value()));
+    return new TextNode(addressCodec.encodeAccountId(value()).value());
   }
 
 }

--- a/xrpl4j-keypairs/src/main/java/org/xrpl/xrpl4j/keypairs/AbstractKeyPairService.java
+++ b/xrpl4j-keypairs/src/main/java/org/xrpl/xrpl4j/keypairs/AbstractKeyPairService.java
@@ -43,7 +43,7 @@ public abstract class AbstractKeyPairService implements KeyPairService {
 
   @Override
   public Address deriveAddress(UnsignedByteArray publicKey) {
-    return Address.of(addressCodec.encodeAccountId(computePublicKeyHash(publicKey)));
+    return addressCodec.encodeAccountId(computePublicKeyHash(publicKey));
   }
 
   /**

--- a/xrpl4j-keypairs/src/main/java/org/xrpl/xrpl4j/wallet/DefaultWalletFactory.java
+++ b/xrpl4j-keypairs/src/main/java/org/xrpl/xrpl4j/wallet/DefaultWalletFactory.java
@@ -64,7 +64,7 @@ public class DefaultWalletFactory implements WalletFactory {
         .publicKey(keyPair.publicKey())
         .isTest(isTest)
         .classicAddress(classicAddress)
-        .xAddress(addressCodec.classicAddressToXAddress(classicAddress.value(), isTest))
+        .xAddress(addressCodec.classicAddressToXAddress(classicAddress, isTest))
         .build();
   }
 

--- a/xrpl4j-keypairs/src/main/java/org/xrpl/xrpl4j/wallet/Wallet.java
+++ b/xrpl4j-keypairs/src/main/java/org/xrpl/xrpl4j/wallet/Wallet.java
@@ -46,7 +46,6 @@ public interface Wallet {
    *
    * @return A {@link String} containing the X-Address of this wallet.
    */
-  // TODO: Create wrapper type (https://github.com/XRPLF/xrpl4j/issues/19)
   @SuppressWarnings("MethodName")
   String xAddress();
 

--- a/xrpl4j-keypairs/src/main/java/org/xrpl/xrpl4j/wallet/Wallet.java
+++ b/xrpl4j-keypairs/src/main/java/org/xrpl/xrpl4j/wallet/Wallet.java
@@ -2,6 +2,7 @@ package org.xrpl.xrpl4j.wallet;
 
 import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.XAddress;
 
 import java.util.Optional;
 
@@ -44,10 +45,10 @@ public interface Wallet {
   /**
    * The XRPL address of this wallet, in the X-Address form.
    *
-   * @return A {@link String} containing the X-Address of this wallet.
+   * @return An {@link XAddress} containing the X-Address of this wallet.
    */
   @SuppressWarnings("MethodName")
-  String xAddress();
+  XAddress xAddress();
 
   /**
    * Whether or not this wallet is on XRPL testnet or mainnet.

--- a/xrpl4j-keypairs/src/test/java/org/xrpl/xrpl4j/wallet/DefaultWalletFactoryTest.java
+++ b/xrpl4j-keypairs/src/test/java/org/xrpl/xrpl4j/wallet/DefaultWalletFactoryTest.java
@@ -3,6 +3,7 @@ package org.xrpl.xrpl4j.wallet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
+import org.xrpl.xrpl4j.model.transactions.XAddress;
 
 @SuppressWarnings("LocalVariableName")
 public class DefaultWalletFactoryTest {
@@ -12,7 +13,7 @@ public class DefaultWalletFactoryTest {
   @Test
   public void generateMainnetWalletFromEd25519Seed() {
     String seed = "sEdSKaCy2JT7JaM7v95H9SxkhP9wS2r";
-    String xAddress = "XVYaPuwjbmRPA9pdyiXAGXsw8NhgJqESZxvSGuTLKhngUD4";
+    XAddress xAddress = XAddress.of("XVYaPuwjbmRPA9pdyiXAGXsw8NhgJqESZxvSGuTLKhngUD4");
 
     Wallet wallet = walletFactory.fromSeed(seed, false);
     assertThat(wallet.xAddress()).isEqualTo(xAddress);
@@ -23,7 +24,7 @@ public class DefaultWalletFactoryTest {
     String seed = "snYP7oArxKepd3GPDcrjMsJYiJeJB";
 
     Wallet wallet = walletFactory.fromSeed(seed, false);
-    assertThat(wallet.xAddress()).isEqualTo("XVnJMYQFqA8EAijpKh5EdjEY5JqyxykMKKSbrUX8uchF6U8");
+    assertThat(wallet.xAddress()).isEqualTo(XAddress.of("XVnJMYQFqA8EAijpKh5EdjEY5JqyxykMKKSbrUX8uchF6U8"));
   }
 
   @Test

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -33,7 +33,7 @@ public class Wrappers {
   }
 
   /**
-   * A wrapped {@link String} representing an address on the XRPL.
+   * A wrapped {@link String} representing an X-Address on the XRPL.
    */
   @Value.Immutable(intern = true)
   @Wrapped

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -33,6 +33,22 @@ public class Wrappers {
   }
 
   /**
+   * A wrapped {@link String} representing an address on the XRPL.
+   */
+  @Value.Immutable(intern = true)
+  @Wrapped
+  @JsonSerialize(as = XAddress.class)
+  @JsonDeserialize(as = XAddress.class)
+  abstract static class _XAddress extends Wrapper<String> implements Serializable {
+
+    @Override
+    public String toString() {
+      return this.value();
+    }
+
+  }
+
+  /**
    * A wrapped {@link String} containing the Hex representation of a 256-bit Hash.
    */
   @Value.Immutable


### PR DESCRIPTION
Adds an `XAddress` immutable wrapper, which wraps a `String`.  Also converts method signatures in `AddressCodec` and elsewhere to use `Address` and `XAddress` instead of just `String`s