### PR TITLE
map undocumented transaction date

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-guava</artifactId>
         <version>${jackson.version}</version>

--- a/xrpl4j-client/src/main/java/org/xrpl/xrpl4j/client/JsonRpcClientErrorException.java
+++ b/xrpl4j-client/src/main/java/org/xrpl/xrpl4j/client/JsonRpcClientErrorException.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.client;
 /**
  * Wrapper for errors related to calling rippled JSON RPC API.
  */
-public class JsonRpcClientErrorException extends Throwable {
+public class JsonRpcClientErrorException extends Exception {
 
   public JsonRpcClientErrorException(String error) {
     super(error);

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
@@ -5,12 +5,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
 import com.google.common.primitives.UnsignedLong;
-import java.time.Instant;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import org.awaitility.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +36,13 @@ import org.xrpl.xrpl4j.wallet.DefaultWalletFactory;
 import org.xrpl.xrpl4j.wallet.SeedWalletGenerationResult;
 import org.xrpl.xrpl4j.wallet.Wallet;
 import org.xrpl.xrpl4j.wallet.WalletFactory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public abstract class AbstractIT {
 

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
@@ -5,6 +5,12 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
 import com.google.common.primitives.UnsignedLong;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.awaitility.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,13 +42,6 @@ import org.xrpl.xrpl4j.wallet.DefaultWalletFactory;
 import org.xrpl.xrpl4j.wallet.SeedWalletGenerationResult;
 import org.xrpl.xrpl4j.wallet.Wallet;
 import org.xrpl.xrpl4j.wallet.WalletFactory;
-
-import java.time.Instant;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 public abstract class AbstractIT {
 
@@ -162,7 +161,7 @@ public abstract class AbstractIT {
           .ledgerIndex(LedgerIndex.VALIDATED)
           .build();
       return xrplClient.accountInfo(params);
-    } catch (Exception | JsonRpcClientErrorException e) {
+    } catch (Exception e) {
       throw new RuntimeException(e.getMessage(), e);
     }
   }

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/LocalRippledEnvironment.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/LocalRippledEnvironment.java
@@ -3,7 +3,6 @@ package org.xrpl.xrpl4j.tests.environment;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.math.BigDecimal;
 import org.slf4j.Logger;
 import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
 import org.xrpl.xrpl4j.client.XrplClient;
@@ -16,6 +15,8 @@ import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 import org.xrpl.xrpl4j.wallet.Wallet;
+
+import java.math.BigDecimal;
 
 /**
  * Environment that runs a local rippled inside docker in standalone mode.

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/LocalRippledEnvironment.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/LocalRippledEnvironment.java
@@ -3,6 +3,7 @@ package org.xrpl.xrpl4j.tests.environment;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.math.BigDecimal;
 import org.slf4j.Logger;
 import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
 import org.xrpl.xrpl4j.client.XrplClient;
@@ -15,8 +16,6 @@ import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 import org.xrpl.xrpl4j.wallet.Wallet;
-
-import java.math.BigDecimal;
 
 /**
  * Environment that runs a local rippled inside docker in standalone mode.
@@ -50,7 +49,7 @@ public class LocalRippledEnvironment implements XrplEnvironment {
           .ledgerIndex(LedgerIndex.CURRENT)
           .build();
       return getXrplClient().accountInfo(params);
-    } catch (Exception | JsonRpcClientErrorException e) {
+    } catch (Exception e) {
       throw new RuntimeException(e.getMessage(), e);
     }
   }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
@@ -1,21 +1,27 @@
 package org.xrpl.xrpl4j.model.transactions;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
-import org.xrpl.xrpl4j.model.ledger.SignerListObject;
-
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import org.immutables.value.Value.Auxiliary;
+import org.xrpl.xrpl4j.model.ledger.SignerListObject;
 
 /**
  * Provides an abstract interface for all concrete XRPL transactions.
  */
 public interface Transaction {
+
+  long RIPPLE_EPOCH = 946684800;
 
   BiMap<Class<? extends Transaction>, TransactionType> typeMap =
       new ImmutableBiMap.Builder<Class<? extends Transaction>, TransactionType>()
@@ -167,5 +173,24 @@ public interface Transaction {
    */
   @JsonProperty("TxnSignature")
   Optional<String> transactionSignature();
+
+  /**
+   * The approximate close time (using Ripple Epoch) of the ledger containing this transaction.
+   * This is an undocumented field.
+   */
+  @JsonProperty("date")
+  Optional<UnsignedLong> closeDate();
+
+  /**
+   * The approximate close time in UTC offset.
+   * This is derived from undocumented field.
+   */
+  @JsonIgnore
+  @Auxiliary
+  default Optional<ZonedDateTime> closeDateHuman() {
+    return closeDate().map(secondsSinceRippleEpoch ->
+      Instant.ofEpochSecond(RIPPLE_EPOCH + secondsSinceRippleEpoch.longValue()).atZone(ZoneId.of("UTC"))
+    );
+  }
 
 }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
@@ -7,14 +7,15 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
+import org.immutables.value.Value.Auxiliary;
+import org.xrpl.xrpl4j.model.ledger.SignerListObject;
+
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import org.immutables.value.Value.Auxiliary;
-import org.xrpl.xrpl4j.model.ledger.SignerListObject;
 
 /**
  * Provides an abstract interface for all concrete XRPL transactions.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
@@ -22,6 +22,7 @@ import java.util.Optional;
  */
 public interface Transaction {
 
+  // XRP Ledger represents dates using a custom epoch called Ripple Epoch
   long RIPPLE_EPOCH = 946684800;
 
   BiMap<Class<? extends Transaction>, TransactionType> typeMap =

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultJsonTests.java
@@ -1,5 +1,7 @@
 package org.xrpl.xrpl4j.model.client.transactions;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
@@ -11,6 +13,10 @@ import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 public class TransactionResultJsonTests extends AbstractJsonTest {
 
@@ -32,6 +38,10 @@ public class TransactionResultJsonTests extends AbstractJsonTest {
                 "39F190022003A04CE739D93DF23BB7F646E274191F550AC73975737FA5436BCF8FEF29E4DD")
             .build())
         .build();
+
+    assertThat(paymentResult.transaction().closeDateHuman()).hasValue(
+      ZonedDateTime.of(LocalDateTime.of(2021, 2, 9, 19, 1, 0), ZoneId.of("UTC"))
+    );
 
     String json = "{\n" +
         "                    \"Account\": \"rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe\",\n" +

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultJsonTests.java
@@ -22,6 +22,7 @@ public class TransactionResultJsonTests extends AbstractJsonTest {
             .account(Address.of("rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe"))
             .amount(XrpCurrencyAmount.of(UnsignedLong.valueOf(1000000000)))
             .destination(Address.of("r3ubyDp4gPGKH5bJx9KMmzpTSTW7EtRixS"))
+            .closeDate(UnsignedLong.valueOf(666212460))
             .fee(XrpCurrencyAmount.of(UnsignedLong.valueOf(12)))
             .flags(Flags.PaymentFlags.of(2147483648L))
             .lastLedgerSequence(UnsignedInteger.valueOf(13010048))
@@ -35,6 +36,7 @@ public class TransactionResultJsonTests extends AbstractJsonTest {
     String json = "{\n" +
         "                    \"Account\": \"rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe\",\n" +
         "                    \"Amount\": \"1000000000\",\n" +
+        "                    \"date\": 666212460,\n" +
         "                    \"Destination\": \"r3ubyDp4gPGKH5bJx9KMmzpTSTW7EtRixS\",\n" +
         "                    \"Fee\": \"12\",\n" +
         "                    \"Flags\": 2147483648,\n" +


### PR DESCRIPTION
The `Transaction` object in the JSON RPC API has an undocumented `date` field that contains the close time. This change maps that undocumented field as an Optional field with a convenience method to get the date as a proper `ZonedDateTime`.

Changed JsonRpcClientErrorException to extend Exception instead of Throwable because Throwable is not meant to be subclassed directly in general and doing so causes pain with lambdas.