### PR TITLE
transaction result metadata lite

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SubmitPaymentIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SubmitPaymentIT.java
@@ -16,6 +16,8 @@ import org.xrpl.xrpl4j.wallet.Wallet;
 
 public class SubmitPaymentIT extends AbstractIT {
 
+  public static final String SUCCESS_STATUS = "tesSUCCESS";
+
   @Test
   public void sendPayment() throws JsonRpcClientErrorException {
     Wallet sourceWallet = createRandomAccount();
@@ -23,17 +25,18 @@ public class SubmitPaymentIT extends AbstractIT {
 
     FeeResult feeResult = xrplClient.fee();
     AccountInfoResult accountInfo = this.scanForResult(() -> this.getValidatedAccountInfo(sourceWallet.classicAddress()));
+    XrpCurrencyAmount amount = XrpCurrencyAmount.ofDrops(12345);
     Payment payment = Payment.builder()
         .account(sourceWallet.classicAddress())
         .fee(feeResult.drops().openLedgerFee())
         .sequence(accountInfo.accountData().sequence())
         .destination(destinationWallet.classicAddress())
-        .amount(XrpCurrencyAmount.ofDrops(12345))
+        .amount(amount)
         .signingPublicKey(sourceWallet.publicKey())
         .build();
 
     SubmitResult<Payment> result = xrplClient.submit(sourceWallet, payment);
-    assertThat(result.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(result.engineResult()).isNotEmpty().get().isEqualTo(SUCCESS_STATUS);
     logger.info("Payment successful: https://testnet.xrpl.org/transactions/" + result.transactionResult().hash());
 
     TransactionResult<Payment> validatedPayment = this.scanForResult(
@@ -41,6 +44,9 @@ public class SubmitPaymentIT extends AbstractIT {
             result.transactionResult().hash(),
             Payment.class)
     );
+
+    assertThat(validatedPayment.metadata().get().deliveredAmount()).hasValue(amount);
+    assertThat(validatedPayment.metadata().get().transactionResult()).isEqualTo(SUCCESS_STATUS);
 
     assertPaymentCloseTimeMatchesLedgerCloseTime(validatedPayment);
   }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResult.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.util.Optional;
 import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.client.XrplResult;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
@@ -12,6 +11,8 @@ import org.xrpl.xrpl4j.model.jackson.modules.TransactionResultDeserializer;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.Transaction;
 import org.xrpl.xrpl4j.model.transactions.TransactionMetadata;
+
+import java.util.Optional;
 
 /**
  * The result of a tx rippled API method call.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResult.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Optional;
 import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.client.XrplResult;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.jackson.modules.TransactionResultDeserializer;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.Transaction;
-
-import java.util.Optional;
+import org.xrpl.xrpl4j.model.transactions.TransactionMetadata;
 
 /**
  * The result of a tx rippled API method call.
@@ -60,5 +60,12 @@ public interface TransactionResult<TxnType extends Transaction> extends XrplResu
     return false;
   }
 
-  // TODO: Add tx metadata if people need it
+  /**
+   * Metadata about the transaction if this data is from a validated ledger version.
+   *
+   * @return metadata or empty for non-validated transactions.
+   */
+  @JsonProperty("meta")
+  Optional<TransactionMetadata> metadata();
+
 }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/TransactionResultDeserializer.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/TransactionResultDeserializer.java
@@ -7,13 +7,14 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.IOException;
-import java.util.Optional;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.client.transactions.TransactionResult;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.Transaction;
 import org.xrpl.xrpl4j.model.transactions.TransactionMetadata;
+
+import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Custom deserializer for {@link TransactionResult}, which wraps the {@link Transaction} fields in the result JSON.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/TransactionResultDeserializer.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/TransactionResultDeserializer.java
@@ -1,20 +1,19 @@
 package org.xrpl.xrpl4j.model.jackson.modules;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.Optional;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.client.transactions.TransactionResult;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.Transaction;
-
-import java.io.IOException;
-import java.util.Optional;
+import org.xrpl.xrpl4j.model.transactions.TransactionMetadata;
 
 /**
  * Custom deserializer for {@link TransactionResult}, which wraps the {@link Transaction} fields in the result JSON.
@@ -37,7 +36,7 @@ public class TransactionResultDeserializer<T extends Transaction> extends StdDes
 
     JavaType javaType = objectMapper.getTypeFactory().constructType(new TypeReference<T>() {
     });
-    T transaction = objectMapper.readValue(objectNode.toString(), javaType);
+    T transaction = objectMapper.convertValue(objectNode, javaType);
 
     LedgerIndex ledgerIndex = objectNode.has("ledger_index") ?
         LedgerIndex.of(objectNode.get("ledger_index").asText()) :
@@ -45,6 +44,7 @@ public class TransactionResultDeserializer<T extends Transaction> extends StdDes
     Hash256 hash = Hash256.of(objectNode.get("hash").asText());
     String status = objectNode.has("status") ? objectNode.get("status").asText() : null;
     boolean validated = objectNode.has("validated") && objectNode.get("validated").asBoolean();
+    Optional<TransactionMetadata> metadata = getTransactionMetadata(objectMapper, objectNode);
 
     return TransactionResult.<T>builder()
         .transaction(transaction)
@@ -52,6 +52,15 @@ public class TransactionResultDeserializer<T extends Transaction> extends StdDes
         .hash(hash)
         .status(Optional.ofNullable(status))
         .validated(validated)
+        .metadata(metadata)
         .build();
   }
+
+  private Optional<TransactionMetadata> getTransactionMetadata(ObjectMapper objectMapper, ObjectNode objectNode) {
+    if (objectNode.has("meta")) {
+      return Optional.of(objectMapper.convertValue(objectNode.get("meta"), TransactionMetadata.class));
+    }
+    return Optional.empty();
+  }
+
 }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/TransactionMetadata.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/TransactionMetadata.java
@@ -1,0 +1,54 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.primitives.UnsignedInteger;
+import java.util.Optional;
+import org.immutables.value.Value.Immutable;
+
+/**
+ * Transaction metadata is a section of data that gets added to a transaction after it is processed.
+ * Any transaction that gets included in a ledger has metadata, regardless of whether it is successful.
+ * The transaction metadata describes the outcome of the transaction in detail.
+ * @see "https://xrpl.org/transaction-metadata.html"
+ */
+@Immutable
+@JsonSerialize(as = ImmutableTransactionMetadata.class)
+@JsonDeserialize(as = ImmutableTransactionMetadata.class)
+public interface TransactionMetadata {
+
+  static ImmutableTransactionMetadata.Builder builder() {
+    return ImmutableTransactionMetadata.builder();
+  }
+
+  /**
+   * The transaction's position within the ledger that included it. This is zero-indexed.
+   * For example, the value 2 means it was the 3rd transaction in that ledger.
+   *
+   * @return index of transaction within ledger.
+   */
+  @JsonProperty("TransactionIndex")
+  UnsignedInteger transactionIndex();
+
+  /**
+   * A result code indicating whether the transaction succeeded or how it failed.
+   *
+   * @return transaction result code.
+   */
+  @JsonProperty("TransactionResult")
+  String transactionResult();
+
+  /**
+   * The Currency Amount actually received by the Destination account.
+   * Use this field to determine how much was delivered, regardless of whether the transaction is a partial payment.
+   * Omitted for non-Payment transactions.
+   *
+   * @return delivered amount for payments, otherwise empty for non-payments.
+   */
+  @JsonProperty("delivered_amount")
+  Optional<CurrencyAmount> deliveredAmount();
+
+  // TODO: map the AffectedNodes object graph if needed
+
+}

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/TransactionMetadata.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/TransactionMetadata.java
@@ -4,8 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.primitives.UnsignedInteger;
-import java.util.Optional;
 import org.immutables.value.Value.Immutable;
+
+import java.util.Optional;
 
 /**
  * Transaction metadata is a section of data that gets added to a transaction after it is processed.

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultJsonTests.java
@@ -5,9 +5,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import org.json.JSONException;
 import org.junit.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
@@ -17,6 +14,10 @@ import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.TransactionMetadata;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 public class TransactionResultJsonTests extends AbstractJsonTest {
 

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultJsonTests.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import org.json.JSONException;
 import org.junit.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
@@ -12,21 +15,19 @@ import org.xrpl.xrpl4j.model.flags.Flags;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.Payment;
+import org.xrpl.xrpl4j.model.transactions.TransactionMetadata;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
-
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 
 public class TransactionResultJsonTests extends AbstractJsonTest {
 
   @Test
   public void testPaymentTransactionResultJson() throws JsonProcessingException, JSONException {
+    XrpCurrencyAmount amount = XrpCurrencyAmount.of(UnsignedLong.valueOf(1000000000));
     TransactionResult<Payment> paymentResult = TransactionResult.<Payment>builder()
         .hash(Hash256.of("E939C30F233E3E6B0A9F829BDDA258CB9DA38D11C0F66C7D60E38B9D9FA987B8"))
         .transaction(Payment.builder()
             .account(Address.of("rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe"))
-            .amount(XrpCurrencyAmount.of(UnsignedLong.valueOf(1000000000)))
+            .amount(amount)
             .destination(Address.of("r3ubyDp4gPGKH5bJx9KMmzpTSTW7EtRixS"))
             .closeDate(UnsignedLong.valueOf(666212460))
             .fee(XrpCurrencyAmount.of(UnsignedLong.valueOf(12)))
@@ -37,6 +38,12 @@ public class TransactionResultJsonTests extends AbstractJsonTest {
             .transactionSignature("3045022100AA15E1F82455712B7D3CE138F6B913238CFBFF56DCB3E2DE39624EE4C6" +
                 "39F190022003A04CE739D93DF23BB7F646E274191F550AC73975737FA5436BCF8FEF29E4DD")
             .build())
+        .metadata(TransactionMetadata.builder()
+            .transactionResult("tesSUCCESS")
+            .transactionIndex(UnsignedInteger.MAX_VALUE)
+            .deliveredAmount(amount)
+            .build()
+        )
         .build();
 
     assertThat(paymentResult.transaction().closeDateHuman()).hasValue(
@@ -58,7 +65,12 @@ public class TransactionResultJsonTests extends AbstractJsonTest {
         "                    \"TxnSignature\": \"3045022100AA15E1F82455712B7D3CE138F6B913238CFBFF56DCB3E2DE3962" +
         "4EE4C639F190022003A04CE739D93DF23BB7F646E274191F550AC73975737FA5436BCF8FEF29E4DD\",\n" +
         "                    \"validated\": false,\n" +
-        "                    \"hash\": \"E939C30F233E3E6B0A9F829BDDA258CB9DA38D11C0F66C7D60E38B9D9FA987B8\"\n" +
+        "                    \"hash\": \"E939C30F233E3E6B0A9F829BDDA258CB9DA38D11C0F66C7D60E38B9D9FA987B8\",\n" +
+        "                    \"meta\": {" +
+        "                        \"TransactionIndex\": 4294967295,\n" +
+        "                        \"TransactionResult\": \"tesSUCCESS\",\n" +
+        "                        \"delivered_amount\": \"1000000000\"\n" +
+        "                     }\n" +
         "                }";
 
     assertCanSerializeAndDeserialize(paymentResult, json);


### PR DESCRIPTION
Map basic metadata in TransactionResults.

Deferring mapping of AffectedNodes for later or never.