### PR TITLE
Improve flaky ITs

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
@@ -71,6 +71,8 @@ public class AccountTransactionsIT {
     LedgerIndex minLedger = LedgerIndex.of(UnsignedLong.valueOf(61486000));
     LedgerIndex maxLedger = LedgerIndex.of(UnsignedLong.valueOf(61487000));
 
+    // Sometimes we will get a "server busy" error back in this test, so if we do get that, we should just wait
+    // a few seconds until asking again.
     AccountTransactionsResult results = given()
       .pollInterval(Duration.FIVE_SECONDS)
       .await()

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/EscrowIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/EscrowIT.java
@@ -48,7 +48,7 @@ public class EscrowIT extends AbstractIT {
         .fee(feeResult.drops().openLedgerFee())
         .amount(XrpCurrencyAmount.ofDrops(123456))
         .destination(receiverWallet.classicAddress())
-        .cancelAfter(instantToXrpTimestamp(getMinExpirationTime().plus(Duration.ofSeconds(10))))
+        .cancelAfter(instantToXrpTimestamp(getMinExpirationTime().plus(Duration.ofSeconds(100))))
         .finishAfter(instantToXrpTimestamp(getMinExpirationTime().plus(Duration.ofSeconds(5))))
         .signingPublicKey(senderWallet.publicKey())
         .build();
@@ -80,7 +80,7 @@ public class EscrowIT extends AbstractIT {
           FluentCompareTo.is(ledgerResult.ledger().closeTime().orElse(UnsignedLong.ZERO))
             .greaterThan(
               createResult.transactionResult().transaction().finishAfter()
-                .map(cancelAfter -> cancelAfter.plus(UnsignedLong.valueOf(5)))
+                .map(finishAfter -> finishAfter.plus(UnsignedLong.valueOf(5)))
                 .orElse(UnsignedLong.MAX_VALUE)
             )
     );
@@ -220,7 +220,7 @@ public class EscrowIT extends AbstractIT {
         () -> this.getValidatedTransaction(
             cancelResult.transactionResult().transaction().hash()
               .orElseThrow(() -> new RuntimeException("Result didn't have hash.")),
-            EscrowFinish.class
+            EscrowCancel.class
         )
     );
 
@@ -432,7 +432,7 @@ public class EscrowIT extends AbstractIT {
         () -> this.getValidatedTransaction(
             cancelResult.transactionResult().transaction().hash()
               .orElseThrow(() -> new RuntimeException("Result didn't have hash.")),
-            EscrowFinish.class
+            EscrowCancel.class
         )
     );
 

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/EscrowIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/EscrowIT.java
@@ -77,11 +77,12 @@ public class EscrowIT extends AbstractIT {
     this.scanForResult(
         this::getValidatedLedger,
         ledgerResult ->
-            ledgerResult
-                .ledger()
-                .closeTime()
-                .orElse(UnsignedLong.ZERO)
-                .compareTo(createResult.transactionResult().transaction().finishAfter().orElse(UnsignedLong.MAX_VALUE)) > 0
+          FluentCompareTo.is(ledgerResult.ledger().closeTime().orElse(UnsignedLong.ZERO))
+            .greaterThan(
+              createResult.transactionResult().transaction().finishAfter()
+                .map(cancelAfter -> cancelAfter.plus(UnsignedLong.valueOf(5)))
+                .orElse(UnsignedLong.MAX_VALUE)
+            )
     );
 
     //////////////////////
@@ -287,11 +288,13 @@ public class EscrowIT extends AbstractIT {
     // Wait until the close time on the current validated ledger is after the finishAfter time on the Escrow
     this.scanForResult(
         this::getValidatedLedger,
-        ledgerResult -> ledgerResult
-            .ledger()
-            .closeTime()
-            .orElse(UnsignedLong.ZERO)
-            .compareTo(createResult.transactionResult().transaction().finishAfter().orElse(UnsignedLong.MAX_VALUE)) > 0
+        ledgerResult ->
+          FluentCompareTo.is(ledgerResult.ledger().closeTime().orElse(UnsignedLong.ZERO))
+            .greaterThan(
+              createResult.transactionResult().transaction().finishAfter()
+                .map(cancelAfter -> cancelAfter.plus(UnsignedLong.valueOf(5)))
+                .orElse(UnsignedLong.MAX_VALUE)
+            )
     );
 
     //////////////////////
@@ -397,15 +400,12 @@ public class EscrowIT extends AbstractIT {
     this.scanForResult(
         this::getValidatedLedger,
         ledgerResult ->
-            ledgerResult
-                .ledger()
-                .closeTime()
-                .orElse(UnsignedLong.ZERO)
-                .compareTo(
-                    createResult.transactionResult().transaction().cancelAfter()
-                        .map(cancelAfter -> cancelAfter.plus(UnsignedLong.valueOf(5)))
-                        .orElse(UnsignedLong.MAX_VALUE)
-                ) > 0
+          FluentCompareTo.is(ledgerResult.ledger().closeTime().orElse(UnsignedLong.ZERO))
+            .greaterThan(
+              createResult.transactionResult().transaction().cancelAfter()
+                .map(cancelAfter -> cancelAfter.plus(UnsignedLong.valueOf(5)))
+                .orElse(UnsignedLong.MAX_VALUE)
+            )
     );
 
     //////////////////////

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/XrplEnvironment.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/XrplEnvironment.java
@@ -1,5 +1,7 @@
 package org.xrpl.xrpl4j.tests.environment;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xrpl.xrpl4j.client.XrplClient;
 import org.xrpl.xrpl4j.model.transactions.Address;
 
@@ -8,6 +10,8 @@ import org.xrpl.xrpl4j.model.transactions.Address;
  * need to interact to the with the ledger.
  */
 public interface XrplEnvironment {
+
+  Logger logger = LoggerFactory.getLogger(XrplEnvironment.class);
 
   /**
    * Gets the XRPL environment to use (based on existence of -DuseTestnet property).
@@ -18,6 +22,9 @@ public interface XrplEnvironment {
     // Use the local rippled environment by default because it's faster and more predictable for testing.
     // TestnetEnvironment can make it easier to debug transactions using in the testnet explorer website.
     boolean isTestnetEnabled = System.getProperty("useTestnet") != null;
+    logger.info("useTestnet set to {}, using {} for testing.",
+      isTestnetEnabled, isTestnetEnabled ? "testnet" : "local rippled"
+    );
     return isTestnetEnabled ? new TestnetEnvironment() : new LocalRippledEnvironment();
   }
 


### PR DESCRIPTION
We were setting the `CancelAfter` time on the flaky IT to `t + 10` and the `FinishAfter` time to `t + 5`, which caused the test to fail if one ledger closes right before the `FinishAfter` time, but the next ledger doesn't close until after `CancelAfter`.  In this case, we cannot finish the escrow in either ledger, because in the first, the `FinishAFter` time has not been reached, and in the second, the escrow has expired.

