### PR TITLE
make engineResult not Optional since it isn't

### DIFF
--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResult.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.primitives.UnsignedInteger;
+import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 import org.xrpl.xrpl4j.model.client.XrplResult;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
@@ -30,9 +31,21 @@ public interface SubmitResult<TxnType extends Transaction> extends XrplResult {
    * Text result code indicating the preliminary result of the transaction, for example "tesSUCCESS".
    *
    * @return An optionally-present {@link String} containing the result of the submission.
+   * @deprecated  use {@link #result()} instead.
+   */
+  @Deprecated
+  @Value.Auxiliary
+  default Optional<String> engineResult() {
+    return Optional.of(result());
+  }
+
+  /**
+   * Text result code indicating the preliminary result of the transaction, for example "tesSUCCESS".
+   *
+   * @return {@link String} containing the result of the submission.
    */
   @JsonProperty("engine_result")
-  Optional<String> engineResult();
+  String result();
 
   /**
    * Human-readable explanation of the transaction's preliminary result.

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResultJsonTests.java
@@ -23,7 +23,7 @@ public class SubmitResultJsonTests extends AbstractJsonTest {
         .accountSequenceNext(UnsignedInteger.valueOf(362))
         .applied(true)
         .broadcast(true)
-        .engineResult("tesSUCCESS")
+        .result("tesSUCCESS")
         .engineResultMessage("The transaction was applied. Only final in a validated ledger.")
         .status("success")
         .kept(true)


### PR DESCRIPTION
`SubmitResult#engineResult` has an Optional type which is not correct. Per the docs (https://xrpl.org/submit.html) it is not optional. 