### PR TITLE
Fixes #59 (Make UnsignedByteArray.hexValue always upper-cased)

### DIFF
--- a/xrpl4j-address-codec/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
+++ b/xrpl4j-address-codec/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
@@ -3,6 +3,7 @@ package org.xrpl.xrpl4j.codec.addresses;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -77,7 +78,7 @@ public class UnsignedByteArray {
    */
   public static UnsignedByteArray fromHex(String hex) {
     Objects.requireNonNull(hex);
-    List<UnsignedByte> unsignedBytes = ByteUtils.parse(hex);
+    List<UnsignedByte> unsignedBytes = ByteUtils.parse(hex.toUpperCase(Locale.ENGLISH));
     return new UnsignedByteArray(unsignedBytes);
   }
 
@@ -114,12 +115,12 @@ public class UnsignedByteArray {
   }
 
   /**
-   * Get this {@link UnsignedByteArray} as a hex encoded {@link String}.
+   * Get this {@link UnsignedByteArray} as an upper-cased Hex-encoded {@link String}.
    *
    * @return This {@link UnsignedByteArray} as a hex encoded {@link String}.
    */
   public String hexValue() {
-    return ByteUtils.toHex(unsignedBytes);
+    return ByteUtils.toHex(unsignedBytes).toUpperCase(Locale.ENGLISH);
   }
 
   /**

--- a/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArrayTest.java
+++ b/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArrayTest.java
@@ -1,8 +1,9 @@
 package org.xrpl.xrpl4j.codec.addresses;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray.of;
 
-import org.assertj.core.api.Assertions;
+import com.google.common.io.BaseEncoding;
 import org.junit.Test;
 
 
@@ -13,20 +14,32 @@ public class UnsignedByteArrayTest {
   @Test
   public void ofByteArray() {
 
-    Assertions.assertThat(UnsignedByteArray.of(new byte[] {0}).hexValue()).isEqualTo("00");
-    Assertions.assertThat(UnsignedByteArray.of(new byte[] {MAX_BYTE}).hexValue()).isEqualTo("FF");
-    Assertions.assertThat(UnsignedByteArray.of(new byte[] {0, MAX_BYTE}).hexValue()).isEqualTo("00FF");
-    Assertions.assertThat(UnsignedByteArray.of(new byte[] {MAX_BYTE, 0}).hexValue()).isEqualTo("FF00");
-    Assertions.assertThat(UnsignedByteArray.of(new byte[] {MAX_BYTE, MAX_BYTE}).hexValue()).isEqualTo("FFFF");
+    assertThat(UnsignedByteArray.of(new byte[] {0}).hexValue()).isEqualTo("00");
+    assertThat(UnsignedByteArray.of(new byte[] {MAX_BYTE}).hexValue()).isEqualTo("FF");
+    assertThat(UnsignedByteArray.of(new byte[] {0, MAX_BYTE}).hexValue()).isEqualTo("00FF");
+    assertThat(UnsignedByteArray.of(new byte[] {MAX_BYTE, 0}).hexValue()).isEqualTo("FF00");
+    assertThat(UnsignedByteArray.of(new byte[] {MAX_BYTE, MAX_BYTE}).hexValue()).isEqualTo("FFFF");
   }
 
   @Test
   public void ofUnsignedByteArray() {
-    Assertions.assertThat(of(UnsignedByte.of(0)).hexValue()).isEqualTo("00");
-    Assertions.assertThat(of(UnsignedByte.of(MAX_BYTE)).hexValue()).isEqualTo("FF");
-    Assertions.assertThat(of(UnsignedByte.of(0), UnsignedByte.of((MAX_BYTE))).hexValue()).isEqualTo("00FF");
-    Assertions.assertThat(of(UnsignedByte.of(MAX_BYTE), UnsignedByte.of((0))).hexValue()).isEqualTo("FF00");
-    Assertions.assertThat(of(UnsignedByte.of(MAX_BYTE), UnsignedByte.of((MAX_BYTE))).hexValue()).isEqualTo("FFFF");
+    assertThat(of(UnsignedByte.of(0)).hexValue()).isEqualTo("00");
+    assertThat(of(UnsignedByte.of(MAX_BYTE)).hexValue()).isEqualTo("FF");
+    assertThat(of(UnsignedByte.of(0), UnsignedByte.of((MAX_BYTE))).hexValue()).isEqualTo("00FF");
+    assertThat(of(UnsignedByte.of(MAX_BYTE), UnsignedByte.of((0))).hexValue()).isEqualTo("FF00");
+    assertThat(of(UnsignedByte.of(MAX_BYTE), UnsignedByte.of((MAX_BYTE))).hexValue()).isEqualTo("FFFF");
+  }
+
+  @Test
+  public void lowerCaseOrUpperCase() {
+    assertThat(UnsignedByteArray.fromHex("Ff").hexValue()).isEqualTo("FF");
+    assertThat(UnsignedByteArray.fromHex("00fF").hexValue()).isEqualTo("00FF");
+    assertThat(UnsignedByteArray.fromHex("00ff").hexValue()).isEqualTo("00FF");
+    assertThat(UnsignedByteArray.fromHex("00FF").hexValue()).isEqualTo("00FF");
+    assertThat(UnsignedByteArray.fromHex("fF00").hexValue()).isEqualTo("FF00");
+    assertThat(UnsignedByteArray.fromHex("ff00").hexValue()).isEqualTo("FF00");
+    assertThat(UnsignedByteArray.fromHex("FF00").hexValue()).isEqualTo("FF00");
+    assertThat(UnsignedByteArray.fromHex("abcdef0123").hexValue()).isEqualTo("ABCDEF0123");
   }
 
 }


### PR DESCRIPTION
Use upper-case HEX encoding to play nicely with BaseEncoder.

Signed-off-by: David Fuelling <sappenin@gmail.com>