### PR TITLE
Fixes Issue #49 (Make it easier to get the amount of an XRP payment as BigDecimal)

### DIFF
--- a/xrpl4j-model/pom.xml
+++ b/xrpl4j-model/pom.xml
@@ -69,6 +69,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
       <scope>test</scope>

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmount.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmount.java
@@ -1,5 +1,9 @@
 package org.xrpl.xrpl4j.model.transactions;
 
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
 /**
  * Marker interface for XRPL Currency Amounts.
  *
@@ -7,4 +11,54 @@ package org.xrpl.xrpl4j.model.transactions;
  */
 public interface CurrencyAmount {
 
+  /**
+   * Handle this {@link CurrencyAmount} depending on its actualy polymorphic sub-type.
+   *
+   * @param xrpCurrencyAmountHandler     A {@link Consumer} that is called if this instance is of type {@link
+   *                                     XrpCurrencyAmount}.
+   * @param issuedCurrencyAmountConsumer A {@link Consumer} that is called if this instance is of type {@link
+   *                                     IssuedCurrencyAmount}.
+   */
+  default void handle(
+    final Consumer<XrpCurrencyAmount> xrpCurrencyAmountHandler,
+    final Consumer<IssuedCurrencyAmount> issuedCurrencyAmountConsumer
+  ) {
+    Objects.requireNonNull(xrpCurrencyAmountHandler);
+    Objects.requireNonNull(issuedCurrencyAmountConsumer);
+
+    if (XrpCurrencyAmount.class.isAssignableFrom(this.getClass())) {
+      xrpCurrencyAmountHandler.accept((XrpCurrencyAmount) this);
+    } else if (IssuedCurrencyAmount.class.isAssignableFrom(this.getClass())) {
+      issuedCurrencyAmountConsumer.accept((IssuedCurrencyAmount) this);
+    } else {
+      throw new IllegalStateException(String.format("Unsupported CurrencyAmount Type: %s", this.getClass()));
+    }
+  }
+
+  /**
+   * Map this {@link CurrencyAmount} to an instance of {@link R}, depending on its actualy polymorphic sub-type.
+   *
+   * @param xrpCurrencyAmountMapper    A {@link Function} that is called if this instance is of type {@link
+   *                                   XrpCurrencyAmount}.
+   * @param issuedCurrencyAmountMapper A {@link Function} that is called if this instance is  of type {@link
+   *                                   IssuedCurrencyAmount}.
+   * @param <R>                        The type of object to return after mapping.
+   *
+   * @return A {@link R} that is constructed by the appropriate mapper function.
+   */
+  default <R> R map(
+    final Function<XrpCurrencyAmount, R> xrpCurrencyAmountMapper,
+    final Function<IssuedCurrencyAmount, R> issuedCurrencyAmountMapper
+  ) {
+    Objects.requireNonNull(xrpCurrencyAmountMapper);
+    Objects.requireNonNull(issuedCurrencyAmountMapper);
+
+    if (XrpCurrencyAmount.class.isAssignableFrom(this.getClass())) {
+      return xrpCurrencyAmountMapper.apply((XrpCurrencyAmount) this);
+    } else if (IssuedCurrencyAmount.class.isAssignableFrom(this.getClass())) {
+      return issuedCurrencyAmountMapper.apply((IssuedCurrencyAmount) this);
+    } else {
+      throw new IllegalStateException(String.format("Unsupported CurrencyAmount Type: %s", this.getClass()));
+    }
+  }
 }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/IssuedCurrencyAmount.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/IssuedCurrencyAmount.java
@@ -6,6 +6,8 @@ import org.immutables.value.Value;
 
 /**
  * A {@link CurrencyAmount} for Issued Currencies on the XRP Ledger.
+ *
+ * @see "https://xrpl.org/rippleapi-reference.html#value"
  */
 @Value.Immutable
 @JsonSerialize(as = ImmutableIssuedCurrencyAmount.class)
@@ -17,8 +19,11 @@ public interface IssuedCurrencyAmount extends CurrencyAmount {
   }
 
   /**
-   * Quoted decimal representation of the amount of currency. This can include scientific notation, such as
-   * 1.23e11 meaning 123,000,000,000. Both e and E may be used.
+   * Quoted decimal representation of the amount of currency. This can include scientific notation, such as 1.23e11
+   * meaning 123,000,000,000. Both e and E may be used. Note that while this implementation merely holds a {@link
+   * String} with no value restrictions, the XRP Ledger does not tolerate unlimited precision values. Instead, non-XRP
+   * values (i.e., values held in this object) can have up to 16 decimal digits of precision, with a maximum value of
+   * 9999999999999999e80. The smallest positive non-XRP value is 1e-81.
    *
    * @return A {@link String} containing the amount of this issued currency.
    */
@@ -32,8 +37,8 @@ public interface IssuedCurrencyAmount extends CurrencyAmount {
   String currency();
 
   /**
-   * Unique account {@link Address} of the entity issuing the currency. In other words, the person or business where
-   * the currency can be redeemed.
+   * Unique account {@link Address} of the entity issuing the currency. In other words, the person or business where the
+   * currency can be redeemed.
    *
    * @return The {@link Address} of the account of the issuer of this currency.
    */

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Payment.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Payment.java
@@ -1,13 +1,10 @@
 package org.xrpl.xrpl4j.model.transactions;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.primitives.UnsignedInteger;
 import org.immutables.value.Value;
-import org.immutables.value.Value.Derived;
-import org.immutables.value.Value.Lazy;
 import org.xrpl.xrpl4j.model.flags.Flags;
 import org.xrpl.xrpl4j.model.flags.Flags.PaymentFlags;
 
@@ -51,24 +48,6 @@ public interface Payment extends Transaction {
    */
   @JsonProperty("Amount")
   CurrencyAmount amount();
-
-  /**
-   * A typed variant of {@link #amount()} which produces a value in XRP Drops if that result is an instance of {@link
-   * XrpCurrencyAmount}.
-   *
-   * @return The amount of this payment if this payment is denominated in XRP (i.e., if the result of calling {@link
-   *   #amount()} is an instance of {@link XrpCurrencyAmount}); otherwise, returns {@link Optional#empty()} (e.g., if
-   *   this payment is denominated in an Issued Currency).
-   */
-  @Derived
-  @JsonIgnore
-  default Optional<XrpCurrencyAmount> amountAsXrp() {
-    if (XrpCurrencyAmount.class.isAssignableFrom(amount().getClass())) {
-      return Optional.of((XrpCurrencyAmount) amount());
-    } else {
-      return Optional.empty();
-    }
-  }
 
   /**
    * The unique {@link Address} of the account receiving the payment. Maybe be empty for an AccountSet or other

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -135,15 +135,13 @@ public class Wrappers {
     }
 
     /**
-     * Convert the supplied amount of XRP drops into a decimal value representing a value denominated in whole XRP
-     * units.
+     * Convert this XRP amount into a decimal representing a value denominated in whole XRP units. For example, a value
+     * of `1.0` represents 1 unit of XRP; a value of `0.5` represents a half of an XRP unit.
      *
-     * @param xrpCurrencyAmount A {@link XrpCurrencyAmount} representing an amount of XRP drops.
-     *
-     * @return A {@link BigDecimal} representing a value denominated in whole XRP units.
+     * @return A {@link BigDecimal} representing this value denominated in whole XRP units.
      */
-    static BigDecimal toXrp(final XrpCurrencyAmount xrpCurrencyAmount) {
-      return new BigDecimal(xrpCurrencyAmount.value().bigIntegerValue())
+    public BigDecimal toXrp() {
+      return new BigDecimal(this.value().bigIntegerValue())
         .divide(BigDecimal.valueOf(ONE_XRP_IN_DROPS), MathContext.DECIMAL128);
     }
 

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -144,7 +144,7 @@ public class Wrappers {
      */
     static BigDecimal toXrp(final XrpCurrencyAmount xrpCurrencyAmount) {
       return new BigDecimal(xrpCurrencyAmount.value().bigIntegerValue())
-        .divide(BigDecimal.valueOf(1000000), MathContext.DECIMAL128);
+        .divide(BigDecimal.valueOf(ONE_XRP_IN_DROPS), MathContext.DECIMAL128);
     }
 
     /**

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmountTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmountTest.java
@@ -1,0 +1,122 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.xrpl.xrpl4j.model.transactions.Wrappers._XrpCurrencyAmount.MAX_XRP;
+import static org.xrpl.xrpl4j.model.transactions.Wrappers._XrpCurrencyAmount.MAX_XRP_IN_DROPS;
+import static org.xrpl.xrpl4j.model.transactions.Wrappers._XrpCurrencyAmount.ONE_XRP_IN_DROPS;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.function.Consumer;
+
+/**
+ * Unit tests for {@link CurrencyAmount}.
+ */
+public class CurrencyAmountTest {
+
+  @Test
+  public void handleXrp() {
+    XrpCurrencyAmount xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(0L);
+
+    xrpCurrencyAmount.handle(
+      ($) -> assertThat($.value()).isEqualTo(UnsignedLong.ZERO),
+      ($) -> fail()
+    );
+
+    // null xrpCurrencyAmountHandler
+    assertThrows(NullPointerException.class, () ->
+      xrpCurrencyAmount.handle(null, ($) -> new Object())
+    );
+
+    // null issuedCurrencyAmountConsumer
+    assertThrows(NullPointerException.class, () ->
+      xrpCurrencyAmount.handle(($) -> new Object(), null)
+    );
+
+    // Unhandled...
+    CurrencyAmount currencyAmount = new CurrencyAmount() {
+    };
+    assertThrows(IllegalStateException.class, () ->
+      currencyAmount.handle(($) -> new Object(), ($) -> new Object())
+    );
+  }
+
+
+  @Test
+  public void handleIssuance() {
+    final IssuedCurrencyAmount issuedCurrencyAmount = IssuedCurrencyAmount.builder()
+      .issuer(Address.of("foo"))
+      .currency("USD")
+      .value("100")
+      .build();
+
+    issuedCurrencyAmount.handle(
+      ($) -> fail(),
+      ($) -> assertThat($.value()).isEqualTo("100")
+    );
+
+    // null xrpCurrencyAmountHandler
+    assertThrows(NullPointerException.class, () ->
+      issuedCurrencyAmount.handle(null, ($) -> new Object())
+    );
+    // null issuedCurrencyAmountConsumer
+    assertThrows(NullPointerException.class, () ->
+      issuedCurrencyAmount.handle(($) -> new Object(), null)
+    );
+  }
+
+  @Test
+  public void mapXrp() {
+    XrpCurrencyAmount xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(0L);
+
+    String actual = xrpCurrencyAmount.map(
+      ($) -> "success",
+      ($) -> "fail"
+    );
+    assertThat(actual).isEqualTo("success");
+
+    // null xrpCurrencyAmountHandler
+    assertThrows(NullPointerException.class, () ->
+      xrpCurrencyAmount.map(null, ($) -> new Object())
+    );
+    // null issuedCurrencyAmountConsumer
+    assertThrows(NullPointerException.class, () ->
+      xrpCurrencyAmount.map(($) -> new Object(), null)
+    );
+
+    // Unhandled...
+    CurrencyAmount currencyAmount = new CurrencyAmount() {
+    };
+    assertThrows(IllegalStateException.class, () ->
+      currencyAmount.map(($) -> new Object(), ($) -> new Object())
+    );
+  }
+
+  @Test
+  public void mapIssuance() {
+    final IssuedCurrencyAmount issuedCurrencyAmount = IssuedCurrencyAmount.builder()
+      .issuer(Address.of("foo"))
+      .currency("USD")
+      .value("100")
+      .build();
+
+    String actual = issuedCurrencyAmount.map(
+      ($) -> "fail",
+      ($) -> "success"
+    );
+    assertThat(actual).isEqualTo("success");
+
+    // null xrpCurrencyAmountHandler
+    assertThrows(NullPointerException.class, () ->
+      issuedCurrencyAmount.map(null, ($) -> new Object())
+    );
+    // null issuedCurrencyAmountConsumer
+    assertThrows(NullPointerException.class, () ->
+      issuedCurrencyAmount.map(($) -> new Object(), null)
+    );
+  }
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/PaymentTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/PaymentTest.java
@@ -13,11 +13,17 @@ public class PaymentTest {
   @Test
   public void paymentBuilder() {
     assertThat(xrpPayment()).isNotNull();
+    assertThat(issuedCurrencyPayment()).isNotNull();
   }
 
   @Test
-  public void flags() {
+  public void flagsForXrpPayment() {
     assertThat(xrpPayment().flags().tfFullyCanonicalSig()).isTrue();
+  }
+
+  @Test
+  public void flagsForIssuedCurrency() {
+    assertThat(issuedCurrencyPayment().flags().tfFullyCanonicalSig()).isTrue();
   }
 
   //////////////////

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/PaymentTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/PaymentTest.java
@@ -1,0 +1,48 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.primitives.UnsignedInteger;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link Payment}.
+ */
+public class PaymentTest {
+
+  @Test
+  public void paymentBuilder() {
+    assertThat(xrpPayment()).isNotNull();
+  }
+
+  @Test
+  public void flags() {
+    assertThat(xrpPayment().flags().tfFullyCanonicalSig()).isTrue();
+  }
+
+  @Test
+  public void amountAsXrp() {
+    assertThat(xrpPayment().amountAsXrp()).isPresent();
+    assertThat(issuedCurrencyPayment().amountAsXrp()).isEmpty();
+  }
+
+  private Payment xrpPayment() {
+    return Payment.builder()
+      .sequence(UnsignedInteger.ONE)
+      .account(Address.of("foo"))
+      .destination(Address.of("dest"))
+      .fee(XrpCurrencyAmount.ofDrops(1000L))
+      .amount(XrpCurrencyAmount.ofDrops(2000L))
+      .build();
+  }
+
+  private Payment issuedCurrencyPayment() {
+    return Payment.builder()
+      .sequence(UnsignedInteger.ONE)
+      .account(Address.of("foo"))
+      .destination(Address.of("dest"))
+      .fee(XrpCurrencyAmount.ofDrops(1000L))
+      .amount(IssuedCurrencyAmount.builder().currency("USD").issuer(Address.of("foo")).value("500").build())
+      .build();
+  }
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/PaymentTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/PaymentTest.java
@@ -20,11 +20,9 @@ public class PaymentTest {
     assertThat(xrpPayment().flags().tfFullyCanonicalSig()).isTrue();
   }
 
-  @Test
-  public void amountAsXrp() {
-    assertThat(xrpPayment().amountAsXrp()).isPresent();
-    assertThat(issuedCurrencyPayment().amountAsXrp()).isEmpty();
-  }
+  //////////////////
+  // Private Helpers
+  //////////////////
 
   private Payment xrpPayment() {
     return Payment.builder()

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
@@ -1,0 +1,68 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.xrpl.xrpl4j.model.transactions.Wrappers._XrpCurrencyAmount.MAX_XRP;
+import static org.xrpl.xrpl4j.model.transactions.Wrappers._XrpCurrencyAmount.MAX_XRP_IN_DROPS;
+import static org.xrpl.xrpl4j.model.transactions.Wrappers._XrpCurrencyAmount.ONE_XRP_IN_DROPS;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+/**
+ * Unit tests for {@link XrpCurrencyAmount}.
+ */
+public class XrpCurrencyAmountTest {
+
+  @Test
+  public void ofDropsLong() {
+    assertThat(XrpCurrencyAmount.ofDrops(0L).value()).isEqualTo(UnsignedLong.ZERO);
+    assertThat(XrpCurrencyAmount.ofDrops(1L).value()).isEqualTo(UnsignedLong.ONE);
+    assertThat(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS).value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
+    assertThat(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS).value()).isEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS));
+    assertThrows(IllegalStateException.class, () -> XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS + 1));
+  }
+
+  @Test
+  public void ofDropsUnsignedLong() {
+    assertThat(XrpCurrencyAmount.ofDrops(UnsignedLong.ZERO).value()).isEqualTo(UnsignedLong.ZERO);
+    assertThat(XrpCurrencyAmount.ofDrops(UnsignedLong.ONE).value()).isEqualTo(UnsignedLong.ONE);
+    assertThat(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS).value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
+    assertThat(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS).value()).isEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS));
+
+    // Too big
+    assertThrows(IllegalStateException.class,
+      () -> XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(MAX_XRP_IN_DROPS + 1)));
+  }
+
+  @Test
+  public void ofXrpBigDecimal() {
+    assertThat(XrpCurrencyAmount.ofXrp(BigDecimal.ZERO).value()).isEqualTo(UnsignedLong.ZERO);
+    assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001")).value()).isEqualTo(UnsignedLong.ONE);
+    assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("0.1")).value()).isEqualTo(UnsignedLong.valueOf(100000));
+    assertThat(XrpCurrencyAmount.ofXrp(BigDecimal.ONE).value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
+    assertThat(XrpCurrencyAmount.ofXrp(BigDecimal.valueOf(MAX_XRP)).value())
+      .isEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS));
+
+    // Too big
+    assertThrows(IllegalStateException.class, () -> XrpCurrencyAmount.ofXrp(BigDecimal.valueOf(MAX_XRP + 1)));
+    // Too small
+    assertThrows(IllegalArgumentException.class, () -> XrpCurrencyAmount.ofXrp(new BigDecimal("0.0000001")));
+  }
+
+  @Test
+  public void ofXrp() {
+    assertThat(XrpCurrencyAmount.toXrp(XrpCurrencyAmount.ofDrops(0L))).isEqualTo(BigDecimal.ZERO);
+    assertThat(XrpCurrencyAmount.toXrp(XrpCurrencyAmount.ofDrops(1L))).isEqualTo(new BigDecimal("0.000001"));
+    assertThat(XrpCurrencyAmount.toXrp(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS))).isEqualTo(BigDecimal.ONE);
+    assertThat(XrpCurrencyAmount.toXrp(XrpCurrencyAmount.ofDrops(33))).isEqualTo(new BigDecimal("0.000033"));
+    assertThat(XrpCurrencyAmount.toXrp(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS))).isEqualTo(new BigDecimal(MAX_XRP));
+
+    // Too small (the largest number with the largest decimal component (99B plus nearly 1 drop)).
+    assertThat(XrpCurrencyAmount.toXrp(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS - 1)))
+      .isEqualTo(new BigDecimal("99999999999.999999"));
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
@@ -53,16 +53,15 @@ public class XrpCurrencyAmountTest {
   }
 
   @Test
-  public void ofXrp() {
-    assertThat(XrpCurrencyAmount.toXrp(XrpCurrencyAmount.ofDrops(0L))).isEqualTo(BigDecimal.ZERO);
-    assertThat(XrpCurrencyAmount.toXrp(XrpCurrencyAmount.ofDrops(1L))).isEqualTo(new BigDecimal("0.000001"));
-    assertThat(XrpCurrencyAmount.toXrp(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS))).isEqualTo(BigDecimal.ONE);
-    assertThat(XrpCurrencyAmount.toXrp(XrpCurrencyAmount.ofDrops(33))).isEqualTo(new BigDecimal("0.000033"));
-    assertThat(XrpCurrencyAmount.toXrp(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS))).isEqualTo(new BigDecimal(MAX_XRP));
+  public void toXrp() {
+    assertThat(XrpCurrencyAmount.ofDrops(0L).toXrp()).isEqualTo(BigDecimal.ZERO);
+    assertThat(XrpCurrencyAmount.ofDrops(1L).toXrp()).isEqualTo(new BigDecimal("0.000001"));
+    assertThat(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS).toXrp()).isEqualTo(BigDecimal.ONE);
+    assertThat(XrpCurrencyAmount.ofDrops(33).toXrp()).isEqualTo(new BigDecimal("0.000033"));
+    assertThat(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS).toXrp()).isEqualTo(new BigDecimal(MAX_XRP));
 
     // Too small (the largest number with the largest decimal component (99B plus nearly 1 drop)).
-    assertThat(XrpCurrencyAmount.toXrp(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS - 1)))
-      .isEqualTo(new BigDecimal("99999999999.999999"));
+    assertThat(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS - 1).toXrp()).isEqualTo(new BigDecimal("99999999999.999999"));
   }
 
 }


### PR DESCRIPTION
* Make it easier to get the amout of an XRP Payment as a BigDecimal.
* Improve the boundary checking of the XrpCurrencyAmount.
* Add unit test coverage.

Signed-off-by: David Fuelling <sappenin@gmail.com>