### PR TITLE
Fixes issue #69 (Conform equals/hashcode in `Hash256`)

### DIFF
--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -11,6 +11,7 @@ import org.xrpl.xrpl4j.model.immutables.Wrapper;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.util.Locale;
 
 /**
  * Wrapped immutable classes for providing type-safe objects.
@@ -74,7 +75,12 @@ public class Wrappers {
         return false;
       }
 
-      return this.value().toUpperCase().equals(((Hash256) obj).value().toUpperCase());
+      return this.value().equalsIgnoreCase(((Hash256) obj).value());
+    }
+
+    @Override
+    public int hashCode() {
+      return value().toUpperCase(Locale.ENGLISH).hashCode();
     }
   }
 

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -75,7 +75,7 @@ public class Wrappers {
         return false;
       }
 
-      return this.value().equalsIgnoreCase(((Hash256) obj).value());
+      return this.value().toUpperCase(Locale.ENGLISH).equals(((Hash256) obj).value().toUpperCase(Locale.ENGLISH));
     }
 
     @Override

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/Hash256Test.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/Hash256Test.java
@@ -1,0 +1,36 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link Hash256}.
+ */
+public class Hash256Test {
+
+  @Test
+  public void hashEquality() {
+    assertThat(Hash256.of("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"))
+      .isEqualTo(Hash256.of("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"));
+
+    assertThat(Hash256.of("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"))
+      .isEqualTo(Hash256.of("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+
+    assertThat(Hash256.of("0000000000000000000000000000000000000000000000000000000000000000"))
+      .isNotEqualTo(Hash256.of("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"));
+  }
+
+  @Test
+  public void hashHashcode() {
+    assertThat(Hash256.of("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").hashCode())
+      .isEqualTo(Hash256.of("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").hashCode());
+
+    assertThat(Hash256.of("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").hashCode())
+      .isEqualTo(Hash256.of("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").hashCode());
+
+    assertThat(Hash256.of("0000000000000000000000000000000000000000000000000000000000000000").hashCode())
+      .isNotEqualTo(Hash256.of("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").hashCode());
+  }
+
+}


### PR DESCRIPTION
* Align `equals` and `hashcode`
* Add unit test coverage.

Signed-off-by: David Fuelling <sappenin@gmail.com>