### PR TITLE
Fixes #79 providing context to getResource

### DIFF
--- a/xrpl4j-binary-codec/src/main/java/org/xrpl/xrpl4j/codec/binary/definitions/DefaultDefinitionsProvider.java
+++ b/xrpl4j-binary-codec/src/main/java/org/xrpl/xrpl4j/codec/binary/definitions/DefaultDefinitionsProvider.java
@@ -23,7 +23,7 @@ public class DefaultDefinitionsProvider implements DefinitionsProvider {
 
     this.supplier = Suppliers.memoize(() -> {
       try {
-        return objectMapper.readerFor(Definitions.class).readValue(Resources.getResource("definitions.json"));
+        return objectMapper.readerFor(Definitions.class).readValue(Resources.getResource(DefaultDefinitionsProvider.class, "/definitions.json"));
       } catch (IOException e) {
         throw new IllegalStateException("Cannot read definition.json file", e);
       }


### PR DESCRIPTION
I added context for getResource as I was getting `java.lang.IllegalArgumentException: resource definitions.json not found` even if it was in it's place. The classLoader can get it wrong in some scenarios