### PR TITLE
Fix for types in ServerInfo to reflect rippled response

### DIFF
--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/server/ServerInfo.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/server/ServerInfo.java
@@ -14,6 +14,7 @@ import org.immutables.value.Value.Immutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -192,60 +193,60 @@ public interface ServerInfo {
    * individual server's load factor, the cluster's load factor, the open ledger cost and the overall network's load
    * factor.
    *
-   * @return An optionally-present {@link Double} representing the load factor.
+   * @return An optionally-present {@link BigDecimal} representing the load factor.
    */
   @JsonProperty("load_factor")
-  Optional<Double> loadFactor();
+  Optional<BigDecimal> loadFactor();
 
   /**
    * Current multiplier to the transaction cost based on load to this server.
    *
-   * @return An optionally-present {@link Double} representing the local load factor.
+   * @return An optionally-present {@link BigDecimal} representing the local load factor.
    */
   @JsonProperty("load_factor_local")
-  Optional<Double> loadFactorLocal();
+  Optional<BigDecimal> loadFactorLocal();
 
   /**
    * Current multiplier to the transaction cost being used by the rest of the network (estimated from other servers'
    * reported load values).
    *
-   * @return An optionally-present {@link UnsignedInteger} representing the network load factor.
+   * @return An optionally-present {@link BigDecimal} representing the network load factor.
    */
   @JsonProperty("load_factor_net")
-  Optional<UnsignedInteger> loadFactorNet();
+  Optional<BigDecimal> loadFactorNet();
 
   /**
    * Current multiplier to the transaction cost based on load to servers in this cluster.
    *
-   * @return An optionally-present {@link Double} representing the cluster load factor.
+   * @return An optionally-present {@link BigDecimal} representing the cluster load factor.
    */
   @JsonProperty("load_factor_cluster")
-  Optional<Double> loadFactorCluster();
+  Optional<BigDecimal> loadFactorCluster();
 
   /**
    * The current multiplier to the transaction cost that a transaction must pay to get into the open ledger.
    *
-   * @return An optionally-present {@link Double} representing the open ledger load factor.
+   * @return An optionally-present {@link BigDecimal} representing the open ledger load factor.
    */
   @JsonProperty("load_factor_fee_escalation")
-  Optional<Double> loadFactorFeeEscalation();
+  Optional<BigDecimal> loadFactorFeeEscalation();
 
   /**
    * The current multiplier to the transaction cost that a transaction must pay to get into the queue, if the queue is
    * full.
    *
-   * @return An optionally-present {@link Double} representing the queue load factor.
+   * @return An optionally-present {@link BigDecimal} representing the queue load factor.
    */
   @JsonProperty("load_factor_fee_queue")
-  Optional<Double> loadFactorFeeQueue();
+  Optional<BigDecimal> loadFactorFeeQueue();
 
   /**
    * The load factor the server is enforcing, not including the open ledger cost.
    *
-   * @return An optionally-present {@link Double} representing the server load factor.
+   * @return An optionally-present {@link BigDecimal} representing the server load factor.
    */
   @JsonProperty("load_factor_server")
-  Optional<Double> loadFactorServer();
+  Optional<BigDecimal> loadFactorServer();
 
   /**
    * How many other rippled servers this one is currently connected to.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/server/ServerInfo.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/server/ServerInfo.java
@@ -163,10 +163,10 @@ public interface ServerInfo {
    * network. For detailed recommendations of future-proof server specifications, see
    * <a href="https://xrpl.org/capacity-planning.html">Capacity Planning</a>.
    *
-   * @return A {@link String}.
+   * @return An optionally-present {@link String}.
    */
   @JsonProperty("jq_trans_overflow")
-  String jqTransOverflow();
+  Optional<String> jqTransOverflow();
 
   /**
    * Information about the last time the server closed a ledger, including the amount of time it took to reach a
@@ -192,18 +192,18 @@ public interface ServerInfo {
    * individual server's load factor, the cluster's load factor, the open ledger cost and the overall network's load
    * factor.
    *
-   * @return An {@link UnsignedInteger} representing the load factor.
+   * @return An optionally-present {@link Double} representing the load factor.
    */
   @JsonProperty("load_factor")
-  UnsignedInteger loadFactor();
+  Optional<Double> loadFactor();
 
   /**
    * Current multiplier to the transaction cost based on load to this server.
    *
-   * @return An optionally-present {@link UnsignedInteger} representing the local load factor.
+   * @return An optionally-present {@link Double} representing the local load factor.
    */
   @JsonProperty("load_factor_local")
-  Optional<UnsignedInteger> loadFactorLocal();
+  Optional<Double> loadFactorLocal();
 
   /**
    * Current multiplier to the transaction cost being used by the rest of the network (estimated from other servers'
@@ -217,42 +217,42 @@ public interface ServerInfo {
   /**
    * Current multiplier to the transaction cost based on load to servers in this cluster.
    *
-   * @return An optionally-present {@link UnsignedInteger} representing the cluster load factor.
+   * @return An optionally-present {@link Double} representing the cluster load factor.
    */
   @JsonProperty("load_factor_cluster")
-  Optional<UnsignedInteger> loadFactorCluster();
+  Optional<Double> loadFactorCluster();
 
   /**
    * The current multiplier to the transaction cost that a transaction must pay to get into the open ledger.
    *
-   * @return An optionally-present {@link UnsignedInteger} representing the open ledger load factor.
+   * @return An optionally-present {@link Double} representing the open ledger load factor.
    */
   @JsonProperty("load_factor_fee_escalation")
-  Optional<UnsignedInteger> loadFactorFeeEscalation();
+  Optional<Double> loadFactorFeeEscalation();
 
   /**
    * The current multiplier to the transaction cost that a transaction must pay to get into the queue, if the queue is
    * full.
    *
-   * @return An optionally-present {@link UnsignedInteger} representing the queue load factor.
+   * @return An optionally-present {@link Double} representing the queue load factor.
    */
   @JsonProperty("load_factor_fee_queue")
-  Optional<UnsignedInteger> loadFactorFeeQueue();
+  Optional<Double> loadFactorFeeQueue();
 
   /**
    * The load factor the server is enforcing, not including the open ledger cost.
    *
-   * @return An optionally-present {@link UnsignedInteger} representing the server load factor.
+   * @return An optionally-present {@link Double} representing the server load factor.
    */
   @JsonProperty("load_factor_server")
-  Optional<UnsignedInteger> loadFactorServer();
+  Optional<Double> loadFactorServer();
 
   /**
    * How many other rippled servers this one is currently connected to.
    *
-   * @return An {@link UnsignedInteger} representing the number of peers of this server.
+   * @return An optionally-present {@link UnsignedInteger} representing the number of peers of this server.
    */
-  UnsignedInteger peers();
+  Optional<UnsignedInteger> peers();
 
   /**
    * Public key used to verify this server for peer-to-peer communications. This node key pair is automatically

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/server/ServerInfoLedger.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/server/ServerInfoLedger.java
@@ -8,6 +8,8 @@ import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 
+import java.math.BigDecimal;
+
 /**
  * Information about a recent ledger, as represented in {@link ServerInfoResult}s.
  */
@@ -57,5 +59,13 @@ public interface ServerInfoLedger {
    */
   @JsonProperty("seq")
   LedgerIndex sequence();
+
+  /**
+   * The base XRP cost of transaction.
+   *
+   * @return A {@link BigDecimal} representing base fee amount in XRP.
+   */
+  @JsonProperty("base_fee_xrp")
+  BigDecimal baseFeeXrp();
 
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/server/ServerInfoResultTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/server/ServerInfoResultTests.java
@@ -335,7 +335,7 @@ public class ServerInfoResultTests extends AbstractJsonTest {
         )
         .threads(UnsignedLong.valueOf(6))
         .build())
-      .loadFactor(UnsignedInteger.ONE)
+      .loadFactor(1.0)
       .peers(UnsignedInteger.valueOf(21))
       .publicKeyNode("n9KUjqxCr5FKThSNXdzb7oqN8rYwScB2dUnNqxQxbEA17JkaWy5x")
       .publicKeyValidator("nHBk5DPexBjinXV8qHn7SEKzoxh2W92FxSbNTPgGtQYBzEF4msn9")

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/server/ServerInfoResultTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/server/ServerInfoResultTests.java
@@ -12,6 +12,7 @@ import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 
+import java.math.BigDecimal;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -335,7 +336,7 @@ public class ServerInfoResultTests extends AbstractJsonTest {
         )
         .threads(UnsignedLong.valueOf(6))
         .build())
-      .loadFactor(1.0)
+      .loadFactor(BigDecimal.ONE)
       .peers(UnsignedInteger.valueOf(21))
       .publicKeyNode("n9KUjqxCr5FKThSNXdzb7oqN8rYwScB2dUnNqxQxbEA17JkaWy5x")
       .publicKeyValidator("nHBk5DPexBjinXV8qHn7SEKzoxh2W92FxSbNTPgGtQYBzEF4msn9")

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/server/ServerInfoResultTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/server/ServerInfoResultTests.java
@@ -97,6 +97,7 @@ public class ServerInfoResultTests extends AbstractJsonTest {
       "      \"uptime\": 1984,\n" +
       "      \"validated_ledger\": {\n" +
       "        \"age\": 2,\n" +
+      "        \"base_fee_xrp\": 0.00001,\n" +
       "        \"hash\": \"0D2D30837E05995AAAAA117294BB45AB0699AB1219605FFD23318E050C7166E9\",\n" +
       "        \"reserve_base_xrp\": 20,\n" +
       "        \"reserve_inc_xrp\": 5,\n" +
@@ -108,6 +109,50 @@ public class ServerInfoResultTests extends AbstractJsonTest {
       "  }";
 
     assertCanSerializeAndDeserialize(result, json);
+  }
+
+  @Test
+  public void testJsonDeserialization() throws JsonProcessingException, JSONException {
+
+    ServerInfoResult result = ServerInfoResult.builder().info(updatedServerInfo()).build();
+
+    String json = "{\n" +
+            "    \"info\": {\n" +
+            "      \"build_version\": \"1.7.0\",\n" +
+            "      \"amendment_blocked\": false,\n" +
+            "      \"complete_ledgers\": \"61881385-62562429\",\n" +
+            "      \"hostid\": \"LARD\",\n" +
+            "      \"io_latency_ms\": 2,\n" +
+            "      \"jq_trans_overflow\": \"0\",\n" +
+            "      \"last_close\": {\n" +
+            "        \"converge_time_s\": 3.002,\n" +
+            "        \"proposers\": 38\n" +
+            "      },\n" +
+            "      \"load_factor\": 511.83203125,\n" +
+            "      \"load_factor_server\": 1,\n" +
+            "      \"peers\": 261,\n" +
+            "      \"pubkey_node\": \"n9MozjnGB3tpULewtTsVtuudg5JqYFyV3QFdAtVLzJaxHcBaxuXD\",\n" +
+            "      \"server_state\": \"full\",\n" +
+            "      \"server_state_duration_us\": \"2274468435925\",\n" +
+            "      \"time\": \"2021-Mar-30 15:37:51.486384 UTC\",\n" +
+            "      \"uptime\": 2274704,\n" +
+            "      \"validated_ledger\": {\n" +
+            "        \"age\": 4,\n" +
+            "        \"base_fee_xrp\": 0.00001,\n" +
+            "        \"hash\": \"E5A958048D98D4EFEEDD2BC3F36D23893BBC1D9354CB3E739068D2DFDE3D1AA3\",\n" +
+            "        \"reserve_base_xrp\": 20,\n" +
+            "        \"reserve_inc_xrp\": 5,\n" +
+            "        \"seq\": 62562429\n" +
+            "      },\n" +
+            "      \"validation_quorum\": 31\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"status\": \"success\",\n" +
+            "  \"type\": \"response\"\n" +
+            "}";
+
+    assertCanSerializeAndDeserialize(result, json);
+
   }
 
   @Test
@@ -351,8 +396,48 @@ public class ServerInfoResultTests extends AbstractJsonTest {
         .reserveBaseXrp(UnsignedInteger.valueOf(20))
         .reserveIncXrp(UnsignedInteger.valueOf(5))
         .sequence(LedgerIndex.of(UnsignedLong.valueOf(54300729)))
+        .baseFeeXrp(new BigDecimal("0.00001"))
         .build())
       .validationQuorum(UnsignedInteger.valueOf(29))
+      .build();
+  }
+
+  /**
+   * Helper method to construct an instance of {@link ServerInfo} with {@code completeLedgers} in {@link
+   * ServerInfo#completeLedgers()}.
+   *
+   * @return An instance of {@link ServerInfo}.
+   */
+  private ServerInfo updatedServerInfo() {
+
+    return ServerInfo.builder()
+      .buildVersion("1.7.0")
+      .completeLedgers("61881385-62562429")
+      .hostId("LARD")
+      .ioLatencyMs(UnsignedLong.valueOf(2))
+      .jqTransOverflow("0")
+      .lastClose(ServerInfoLastClose.builder()
+        .convergeTimeSeconds(3.002)
+        .proposers(UnsignedInteger.valueOf(38))
+        .build())
+      .loadFactor(new BigDecimal("511.83203125"))
+      .loadFactorServer(BigDecimal.ONE)
+      .peers(UnsignedInteger.valueOf(261))
+      .publicKeyNode("n9MozjnGB3tpULewtTsVtuudg5JqYFyV3QFdAtVLzJaxHcBaxuXD")
+      .serverState("full")
+      .serverStateDurationUs("2274468435925")
+      .time(ZonedDateTime.parse("2021-Mar-30 15:37:51.486384 UTC",
+        DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss.SSSSSS z")).withZoneSameLocal(ZoneId.of("UTC")))
+      .upTime(UnsignedLong.valueOf(2274704))
+      .validatedLedger(ServerInfoLedger.builder()
+        .age(UnsignedInteger.valueOf(4))
+        .hash(Hash256.of("E5A958048D98D4EFEEDD2BC3F36D23893BBC1D9354CB3E739068D2DFDE3D1AA3"))
+        .reserveBaseXrp(UnsignedInteger.valueOf(20))
+        .reserveIncXrp(UnsignedInteger.valueOf(5))
+        .sequence(LedgerIndex.of(UnsignedLong.valueOf(62562429)))
+        .baseFeeXrp(new BigDecimal("0.00001"))
+        .build())
+      .validationQuorum(UnsignedInteger.valueOf(31))
       .build();
   }
 }


### PR DESCRIPTION
Serveral 'load' properties now Double instead od UnsignedInteger

Peers, loadFactor, jqTransOverflow made Optional

I did not create a _Load wrapper as @nkramer44  suggested [here](https://github.com/XRPLF/xrpl4j/issues/85#issuecomment-811388126) as it seemed unnecessary. 