### PR TITLE
add validation to LedgerIndex

### DIFF
--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/common/LedgerIndex.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/common/LedgerIndex.java
@@ -47,14 +47,12 @@ public class LedgerIndex {
    */
   public static LedgerIndex of(String value)
   throws NumberFormatException {
-    if (value == null) {
-      throw new NullPointerException();
-    }
-    LedgerIndex li = new LedgerIndex(value);
-    if (li.isValid()) {
-      return li;
+    Objects.requireNonNull(value);
+    if (isValidShortcut(value)) {
+      return new LedgerIndex(value);
     } else {
-      throw new NumberFormatException(value);
+      UnsignedLong.valueOf(value);
+      return new LedgerIndex(value);
     }
   }
 
@@ -68,9 +66,7 @@ public class LedgerIndex {
    * @throws NullPointerException if value is null
    */
   public static LedgerIndex of(UnsignedLong value) {
-    if (value == null) {
-      throw new NullPointerException();
-    }
+    Objects.requireNonNull(value);
     return new LedgerIndex(value.toString());
   }
 
@@ -109,22 +105,11 @@ public class LedgerIndex {
     return plus(other.unsignedLongValue());
   }
 
-  /**
-   * Check whether or not the index wrapped by this {@link LedgerIndex} is valid.
-   * A valid index is a shortcut or an unsigned long.
-   *
-   * @return true if the wrapped index is valid, false otherwise.
-   */
-  public boolean isValid() {
+  public static boolean isValidShortcut(String value) {
     if (value.equals("current")) return true;
     if (value.equals("validated")) return true;
     if (value.equals("closed")) return true;
-    try {
-      unsignedLongValue();
-      return true;
-    } catch (NumberFormatException e) {
-      return false;
-    }
+    return false;
   }
 
   @Override

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/common/LedgerIndex.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/common/LedgerIndex.java
@@ -41,16 +41,18 @@ public class LedgerIndex {
    *
    * @return A {@link LedgerIndex} with the given value.
    *
+   * @throws NullPointerException if value is null
+   *
    * @throws NumberFormatException if value is an invalid index
    */
   public static LedgerIndex of(String value)
   throws NumberFormatException {
     if (value == null) {
-      throw new NumberFormatException("Cannot build LedgerIndex from null value.");
+      throw new NullPointerException();
     }
     LedgerIndex li = new LedgerIndex(value);
     if (li.isValid()) {
-      return new LedgerIndex(value);
+      return li;
     } else {
       throw new NumberFormatException(value);
     }
@@ -62,11 +64,12 @@ public class LedgerIndex {
    * @param value An {@link UnsignedLong} specifying a ledger index.
    *
    * @return A {@link LedgerIndex} with the given value as a {@link String}.
+   *
+   * @throws NullPointerException if value is null
    */
-  public static LedgerIndex of(UnsignedLong value)
-  throws NumberFormatException {
+  public static LedgerIndex of(UnsignedLong value) {
     if (value == null) {
-      throw new NumberFormatException("Cannot build LedgerIndex from null value.");
+      throw new NullPointerException();
     }
     return new LedgerIndex(value.toString());
   }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/common/LedgerIndex.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/common/LedgerIndex.java
@@ -63,7 +63,8 @@ public class LedgerIndex {
    *
    * @return A {@link LedgerIndex} with the given value as a {@link String}.
    */
-  public static LedgerIndex of(UnsignedLong value) {
+  public static LedgerIndex of(UnsignedLong value)
+  throws NumberFormatException {
     if (value == null) {
       throw new NumberFormatException("Cannot build LedgerIndex from null value.");
     }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/common/LedgerIndex.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/common/LedgerIndex.java
@@ -34,9 +34,17 @@ public class LedgerIndex {
    * @param value A {@link String} containing either an integer or a shortcut.
    *
    * @return A {@link LedgerIndex} with the given value.
+   *
+   * @throws NumberFormatException if value is an invalid index
    */
-  public static LedgerIndex of(String value) {
-    return new LedgerIndex(value);
+  public static LedgerIndex of(String value)
+  throws NumberFormatException {
+    LedgerIndex li = new LedgerIndex(value);
+    if (li.isValid()) {
+      return new LedgerIndex(value);
+    } else {
+      throw new NumberFormatException(value);
+    }
   }
 
   /**
@@ -83,6 +91,24 @@ public class LedgerIndex {
    */
   public LedgerIndex plus(LedgerIndex other) {
     return plus(other.unsignedLongValue());
+  }
+
+  /**
+   * Check whether or not the index wrapped by this {@link LedgerIndex} is valid.
+   * A valid index is a shortcut or an unsigned long.
+   *
+   * @return true if the wrapped index is valid, false otherwise.
+   */
+  public boolean isValid() {
+    if (value.equals("current")) return true;
+    if (value.equals("validated")) return true;
+    if (value.equals("closed")) return true;
+    try {
+      unsignedLongValue();
+      return true;
+    } catch (NumberFormatException e) {
+      return false;
+    }
   }
 
   @Override

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/common/LedgerIndex.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/common/LedgerIndex.java
@@ -23,7 +23,13 @@ public class LedgerIndex {
    * Public constructor.
    *
    * @param value The ledger index value as a {@link String}.
+   *
+   * @deprecated Does not check if the given value is a valid index.
+   *    This constructor should be made private in the future.
+   *    Only the {@link #of(String value)} and {@link #of(UnsignedLong value)} 
+   *    factory methods should be used to construct {@link LedgerIndex} objects.
    */
+  @Deprecated
   public LedgerIndex(String value) {
     this.value = value;
   }
@@ -39,6 +45,9 @@ public class LedgerIndex {
    */
   public static LedgerIndex of(String value)
   throws NumberFormatException {
+    if (value == null) {
+      throw new NumberFormatException("Cannot build LedgerIndex from null value.");
+    }
     LedgerIndex li = new LedgerIndex(value);
     if (li.isValid()) {
       return new LedgerIndex(value);
@@ -55,6 +64,9 @@ public class LedgerIndex {
    * @return A {@link LedgerIndex} with the given value as a {@link String}.
    */
   public static LedgerIndex of(UnsignedLong value) {
+    if (value == null) {
+      throw new NumberFormatException("Cannot build LedgerIndex from null value.");
+    }
     return new LedgerIndex(value.toString());
   }
 

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsJsonTests.java
@@ -53,8 +53,8 @@ public class AccountTransactionsRequestParamsJsonTests extends AbstractJsonTest 
   public void testWithJsonWithLedgerIndex() throws JsonProcessingException, JSONException {
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams.builder()
       .account(Address.of("rLNaPoKeeBjZe2qs6x52yVPZpZ8td4dc6w"))
-      .ledgerIndexMin(LedgerIndex.of("-1"))
-      .ledgerIndexMax(LedgerIndex.of("-1"))
+      .ledgerIndexMin(LedgerIndex.of("0"))
+      .ledgerIndexMax(LedgerIndex.of("0"))
       .ledgerIndex(LedgerIndex.CURRENT)
       .limit(UnsignedInteger.valueOf(2))
       .build();
@@ -63,8 +63,8 @@ public class AccountTransactionsRequestParamsJsonTests extends AbstractJsonTest 
       "            \"account\": \"rLNaPoKeeBjZe2qs6x52yVPZpZ8td4dc6w\",\n" +
       "            \"binary\": false,\n" +
       "            \"forward\": false,\n" +
-      "            \"ledger_index_max\": -1,\n" +
-      "            \"ledger_index_min\": -1,\n" +
+      "            \"ledger_index_max\": 0,\n" +
+      "            \"ledger_index_min\": 0,\n" +
       "            \"ledger_index\": \"current\",\n" +
       "            \"limit\": 2\n" +
       "        }";

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/common/LedgerIndexTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/common/LedgerIndexTest.java
@@ -79,24 +79,4 @@ class LedgerIndexTest {
     final LedgerIndex added = ledgerIndex.plus(fromUnsignedLong);
     assertThat(added).isEqualTo(LedgerIndex.of("2"));
   }
-
-  @Test
-  void createInvalidNumericalLedgerIndex() {
-    final LedgerIndex fooLedgerIndex = LedgerIndex.of("foo");
-    assertThrows(
-      NumberFormatException.class,
-      fooLedgerIndex::unsignedLongValue
-    );
-
-    final LedgerIndex negativeLedgerIndex = LedgerIndex.of("-1");
-    assertThrows(
-      NumberFormatException.class,
-      negativeLedgerIndex::unsignedLongValue
-    );
-
-    assertThrows(
-      NumberFormatException.class,
-      () -> fooLedgerIndex.plus(negativeLedgerIndex)
-    );
-  }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/common/LedgerIndexTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/common/LedgerIndexTest.java
@@ -18,15 +18,13 @@ class LedgerIndexTest {
 
   @Test
   void createInvalidLedgerIndex() {
-    String nullStr = null;
-    UnsignedLong nullUL = null;
     assertThrows(
-      NumberFormatException.class,
-      () -> LedgerIndex.of(nullStr)
+      NullPointerException.class,
+      () -> LedgerIndex.of((String) null)
     );
     assertThrows(
-      NumberFormatException.class,
-      () -> LedgerIndex.of(nullUL)
+      NullPointerException.class,
+      () -> LedgerIndex.of((UnsignedLong) null)
     );
     assertThrows(
       NumberFormatException.class,
@@ -36,6 +34,34 @@ class LedgerIndexTest {
       NumberFormatException.class,
       () -> LedgerIndex.of("-1")
     );
+  }
+
+  @Test
+  void testEquality() {
+    LedgerIndex fromString = LedgerIndex.of("42");
+    assertThat(fromString).isEqualTo(fromString);
+    assertThat(fromString).isNotEqualTo("42");
+
+    UnsignedLong ul = UnsignedLong.valueOf("42");
+    LedgerIndex fromUnsignedLong = LedgerIndex.of(ul);
+    assertThat(fromString).isEqualTo(fromUnsignedLong);
+    assertThat(fromString).isNotEqualTo(LedgerIndex.CURRENT);
+  }
+
+  @Test
+  void testToString() {
+    LedgerIndex fromString = LedgerIndex.of("42");
+    assertThat(fromString.toString()).isEqualTo("42");
+    assertThat(LedgerIndex.CURRENT.toString()).isEqualTo("current");
+
+    UnsignedLong ul = UnsignedLong.valueOf("42");
+    LedgerIndex fromUnsignedLong = LedgerIndex.of(ul);
+    assertThat(fromString.toString()).isEqualTo(fromUnsignedLong.toString());
+  }
+
+  @Test
+  void testAddition() {
+    LedgerIndex fromString = LedgerIndex.of("42");
   }
 
   @Test

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/common/LedgerIndexTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/common/LedgerIndexTest.java
@@ -9,6 +9,36 @@ import org.junit.jupiter.api.Test;
 class LedgerIndexTest {
 
   @Test
+  void createValidLedgerIndex() {
+    assertDoesNotThrow(() -> LedgerIndex.of("current"));
+    assertDoesNotThrow(() -> LedgerIndex.of("validated"));
+    assertDoesNotThrow(() -> LedgerIndex.of("closed"));
+    assertDoesNotThrow(() -> LedgerIndex.of("1"));
+  }
+
+  @Test
+  void createInvalidLedgerIndex() {
+    String nullStr = null;
+    UnsignedLong nullUL = null;
+    assertThrows(
+      NumberFormatException.class,
+      () -> LedgerIndex.of(nullStr)
+    );
+    assertThrows(
+      NumberFormatException.class,
+      () -> LedgerIndex.of(nullUL)
+    );
+    assertThrows(
+      NumberFormatException.class,
+      () -> LedgerIndex.of("foo")
+    );
+    assertThrows(
+      NumberFormatException.class,
+      () -> LedgerIndex.of("-1")
+    );
+  }
+
+  @Test
   void createValidNumericalLedgerIndex() {
     LedgerIndex ledgerIndex = LedgerIndex.of("1");
     assertThat(ledgerIndex.value()).isEqualTo("1");


### PR DESCRIPTION
Proposed fix for #93 .

Added a method `isValid` to LedgerIndex to check the validity of the wrapped index.

The `LedgerIndex.of` factory method now throws a `NumberFormatException` if the given value is not a valid index.