### PR TITLE
Fix issue with Guava android compatibility

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -45,7 +45,7 @@ jobs:
           key: ${{ env.cache-name }}-${{ hashFiles('pom.xml') }}
           restore-keys: ${{ env.cache-name }}-
       - name: Build
-        run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true
+        run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -Pandroid
 
   build_other_java:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>29.0-jre</version>
+        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -241,7 +241,7 @@
     <profile>
       <id>android</id>
       <properties>
-        <guava.version>28.1-android</guava.version>
+        <guava.version>29.0-android</guava.version>
       </properties>
     </profile>
     <!-- Signing profile for signed distributions -->
@@ -318,6 +318,7 @@
     <feign.version>11.0</feign.version>
     <slf4j.version>1.7.30</slf4j.version>
     <junit-jupiter.version>5.7.1</junit-jupiter.version>
+    <guava.version>29.0-jre</guava.version>
   </properties>
 
   <modules>

--- a/xrpl4j-binary-codec/src/main/java/org/xrpl/xrpl4j/codec/binary/definitions/DefaultDefinitionsProvider.java
+++ b/xrpl4j-binary-codec/src/main/java/org/xrpl/xrpl4j/codec/binary/definitions/DefaultDefinitionsProvider.java
@@ -1,12 +1,12 @@
 package org.xrpl.xrpl4j.codec.binary.definitions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.io.Resources;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.function.Supplier;
 
 public class DefaultDefinitionsProvider implements DefinitionsProvider {
 


### PR DESCRIPTION
Guava Android doesn't work with java.util.function.Supplier. You have to use the Guava specific Supplier interface.