### PR TITLE
Add option to retrieve domain value in ledger transactions

### DIFF
--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
@@ -216,4 +216,13 @@ public interface Transaction {
   @JsonProperty("ledger_index")
   Optional<LedgerIndex> ledgerIndex();
 
+  /**
+   * The domain that owns this account, as a string of hex representing the ASCII for the domain in lowercase
+   *
+   *
+   * @return An {@link Optional} {@link String} containing the domain value.
+   */
+  @JsonProperty("domain")
+  Optional<String> domain();
+
 }


### PR DESCRIPTION
Transaction.java needed to have an option to retrieve transaction domain value... I've been creating an NFT Indexer but it seems I'm only able to retrieve sourceTag, account address, fee, transaction type...

With the changes below, I'm able to retrieve the domain value of a specific ledger transaction.