### PR TITLE
Add option to retrieve domain value in ledger transactions

### DIFF
--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
@@ -216,4 +216,13 @@ public interface Transaction {
   @JsonProperty("ledger_index")
   Optional<LedgerIndex> ledgerIndex();
 
+  /**
+   * The domain that owns this account, as a string of hex representing the ASCII for the domain in lowercase
+   *
+   *
+   * @return An {@link Optional} {@link String} containing the domain value.
+   */
+  @JsonProperty("domain")
+  Optional<String> domain();
+
 }


### PR DESCRIPTION
In preparation for NFT Wallet Based Marketplace, NFT Indexer is crucial to get a glimpse of total XLS-19d and at the same time know the content of Wallet Based NFT... 
But by calling `AccountRootObject` continuously will result in `The server is too busy to help you now  `...

XLS-19d Indexer: https://github.com/francisrosario/NFTIndexer_backend-JavaEE
Information regarding XLS-19d: https://github.com/XRPLF/XRPL-Standards/discussions/40

By adding the code below is a much efficient way of indexing the xrp ledger without needing to call  `AccountRootObject` or using Sleep as a workaround for `The server is too busy to help you now  `
```
  /**
   * The domain that owns this account, as a string of hex representing the ASCII for the domain in lowercase
   *
   *
   * @return An {@link Optional} {@link String} containing the domain value.
   */
  @JsonProperty("domain")
  Optional<String> domain();
```