### PR TITLE
Fix unit tests

### DIFF
--- a/xrpl4j-model/pom.xml
+++ b/xrpl4j-model/pom.xml
@@ -74,6 +74,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
       <scope>test</scope>

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/AbstractLedgerIndexTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/AbstractLedgerIndexTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 
-public class AbstractLedgerIndexTest {
+public abstract class AbstractLedgerIndexTest {
 
   @Value.Immutable
   @JsonSerialize(as = ImmutableLedgerIndexContainer.class)

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/LedgerIndexDeserializerTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/LedgerIndexDeserializerTest.java
@@ -1,47 +1,49 @@
 package org.xrpl.xrpl4j.model.jackson.modules;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
 
-class LedgerIndexDeserializerTest extends AbstractLedgerIndexTest {
+public class LedgerIndexDeserializerTest extends AbstractLedgerIndexTest {
 
   private final ObjectMapper objectMapper = ObjectMapperFactory.create();
 
   @Test
-  void deserializeCharacterLedgerIndex() throws JsonProcessingException {
+  public void deserializeCharacterLedgerIndex() throws JsonProcessingException {
     final LedgerIndex current = LedgerIndex.CURRENT;
     final LedgerIndex validated = LedgerIndex.VALIDATED;
     final LedgerIndex closed = LedgerIndex.CLOSED;
-    final LedgerIndex foo = LedgerIndex.of("foo");
+
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      LedgerIndex.of("foo");
+    });
 
     final LedgerIndex currentDeserialized = objectMapper.readValue("\"" + current.value() + "\"", LedgerIndex.class);
     assertThat(currentDeserialized).isEqualTo(current);
 
-    final LedgerIndex validatedDeserialized = objectMapper.readValue("\"" + validated.value() + "\"", LedgerIndex.class);
+    final LedgerIndex validatedDeserialized = objectMapper
+      .readValue("\"" + validated.value() + "\"", LedgerIndex.class);
     assertThat(validatedDeserialized).isEqualTo(validated);
 
     final LedgerIndex closedDeserialized = objectMapper.readValue("\"" + closed.value() + "\"", LedgerIndex.class);
     assertThat(closedDeserialized).isEqualTo(closed);
-
-    final LedgerIndex fooDeserialized = objectMapper.readValue("\"" + foo.value() + "\"", LedgerIndex.class);
-    assertThat(fooDeserialized).isEqualTo(foo);
   }
 
   @Test
-  void deserializeNumericalLedgerIndex() throws JsonProcessingException {
+  public void deserializeNumericalLedgerIndex() throws JsonProcessingException {
     final LedgerIndex ledgerIndex = LedgerIndex.of("1");
 
     final LedgerIndex deserialized = objectMapper.readValue("\"1\"", LedgerIndex.class);
     assertThat(deserialized).isEqualTo(ledgerIndex);
 
     LedgerIndexContainer container = LedgerIndexContainer.of(ledgerIndex);
-    final LedgerIndexContainer deserializedContainer = objectMapper.readValue("{\"ledgerIndex\": 1}", LedgerIndexContainer.class);
+    final LedgerIndexContainer deserializedContainer = objectMapper
+      .readValue("{\"ledgerIndex\": 1}", LedgerIndexContainer.class);
     assertThat(deserializedContainer).isEqualTo(container);
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/LedgerIndexSerializerTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/LedgerIndexSerializerTest.java
@@ -5,20 +5,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
 
-class LedgerIndexSerializerTest extends AbstractLedgerIndexTest {
+public class LedgerIndexSerializerTest extends AbstractLedgerIndexTest {
 
   private final ObjectMapper objectMapper = ObjectMapperFactory.create();
 
   @Test
-  void serializeCharacterLedgerIndex() throws JsonProcessingException {
+  public void serializeCharacterLedgerIndex() throws JsonProcessingException {
     final LedgerIndex current = LedgerIndex.CURRENT;
     final LedgerIndex validated = LedgerIndex.VALIDATED;
     final LedgerIndex closed = LedgerIndex.CLOSED;
-    final LedgerIndex foo = LedgerIndex.of("foo");
+
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      LedgerIndex.of("foo");
+    });
 
     final String currentSerialized = objectMapper.writeValueAsString(current);
     assertThat(currentSerialized).isEqualTo("\"" + current.value() + "\"");
@@ -28,9 +32,6 @@ class LedgerIndexSerializerTest extends AbstractLedgerIndexTest {
 
     final String closedSerialized = objectMapper.writeValueAsString(closed);
     assertThat(closedSerialized).isEqualTo("\"" + closed.value() + "\"");
-
-    final String fooSerialized = objectMapper.writeValueAsString(foo);
-    assertThat(fooSerialized).isEqualTo("\"" + foo.value() + "\"");
   }
 
   @Test


### PR DESCRIPTION
JUnit jupiter tests don’t run without the engine dependency. This PR adds that and fixes broken unit tets.

Signed-off-by: David Fuelling <sappenin@gmail.com>