### PR TITLE
Migrate all Junit4 tests to Junit5 Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,12 +97,6 @@
         <version>1.2.3</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.12</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>3.14.0</version>

--- a/xrpl4j-address-codec/pom.xml
+++ b/xrpl4j-address-codec/pom.xml
@@ -26,8 +26,19 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/AddressBase58Test.java
+++ b/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/AddressBase58Test.java
@@ -1,39 +1,41 @@
 package org.xrpl.xrpl4j.codec.addresses;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.Lists;
 import com.google.common.primitives.UnsignedInteger;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.DecodeException;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodingFormatException;
 
 public class AddressBase58Test {
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void decodeDataWithLengthLessThanFour() {
-    expectedException.expect(EncodingFormatException.class);
-    expectedException.expectMessage("Input must be longer than 3 characters.");
-    AddressBase58.decode("1234", Version.ACCOUNT_ID);
+    assertThrows(
+      EncodingFormatException.class,
+      () -> AddressBase58.decode("1234", Version.ACCOUNT_ID),
+      "Input must be longer than 3 characters."
+    );
   }
 
   @Test
   public void decodeDataWithIncorrectVersion() {
-    expectedException.expect(DecodeException.class);
-    expectedException.expectMessage("Version is invalid. Version bytes do not match any of the provided versions.");
-    AddressBase58.decode("rnaC7gW34M77Kneb78s", Version.ED25519_SEED);
+    assertThrows(
+      DecodeException.class,
+      () -> AddressBase58.decode("rnaC7gW34M77Kneb78s", Version.ED25519_SEED),
+      "Version is invalid. Version bytes do not match any of the provided versions."
+    );
   }
 
   @Test
   public void decodeDataWithInvalidChecksum() {
-    expectedException.expect(EncodingFormatException.class);
-    expectedException.expectMessage("Checksum does not validate");
-    AddressBase58.decode("123456789", Version.ACCOUNT_ID);
+    assertThrows(
+      EncodingFormatException.class,
+      () -> AddressBase58.decode("123456789", Version.ACCOUNT_ID),
+      "Checksum does not validate"
+    );
   }
 
   @Test
@@ -64,19 +66,24 @@ public class AddressBase58Test {
 
   @Test
   public void decodedDatatWithWrongExpectedLength() {
-    expectedException.expect(DecodeException.class);
-    expectedException.expectMessage("Version is invalid. Version bytes do not match any of the provided versions.");
-
-    AddressBase58.decode(
+    assertThrows(
+      DecodeException.class,
+      () ->  AddressBase58.decode(
         "rnaC7gW34M77Kneb78s",
         Lists.newArrayList(Version.ACCOUNT_ID),
         UnsignedInteger.valueOf(8)
+      ),
+      "Version is invalid. Version bytes do not match any of the provided versions."
     );
 
-    AddressBase58.decode(
+    assertThrows(
+      DecodeException.class,
+      () -> AddressBase58.decode(
         "rnaC7gW34M77Kneb78s",
         Lists.newArrayList(Version.ACCOUNT_ID),
         UnsignedInteger.valueOf(10)
+      ),
+      "Version is invalid. Version bytes do not match any of the provided versions."
     );
   }
 

--- a/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/AddressCodecTest.java
+++ b/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/AddressCodecTest.java
@@ -2,21 +2,17 @@ package org.xrpl.xrpl4j.codec.addresses;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.io.BaseEncoding;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodeException;
 import org.xrpl.xrpl4j.model.transactions.Address;
 
 import java.util.function.Function;
 
 public class AddressCodecTest {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   AddressCodec addressCodec;
 
@@ -25,7 +21,7 @@ public class AddressCodecTest {
     return UnsignedByteArray.of(decodedHex);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     addressCodec = new AddressCodec();
   }
@@ -110,16 +106,21 @@ public class AddressCodecTest {
 
   @Test
   public void encodeSeedWithFewerThanSixteenBytes() {
-    expectedException.expect(EncodeException.class);
-    expectedException.expectMessage("entropy must have length 16.");
-    addressCodec.encodeSeed(unsignedByteArrayFromHex("CF2DE378FBDD7E2EE87D486DFB5A7B"), VersionType.SECP256K1);
+    assertThrows(
+      EncodeException.class,
+      () -> addressCodec.encodeSeed(unsignedByteArrayFromHex("CF2DE378FBDD7E2EE87D486DFB5A7B"), VersionType.SECP256K1),
+      "entropy must have length 16."
+    );
   }
 
   @Test
   public void encodeSeedWithGreaterThanSixteenBytes() {
-    expectedException.expect(EncodeException.class);
-    expectedException.expectMessage("entropy must have length 16.");
-    addressCodec.encodeSeed(unsignedByteArrayFromHex("CF2DE378FBDD7E2EE87D486DFB5A7BFFFF"), VersionType.SECP256K1);
+    assertThrows(
+      EncodeException.class,
+      () -> addressCodec
+        .encodeSeed(unsignedByteArrayFromHex("CF2DE378FBDD7E2EE87D486DFB5A7BFFFF"), VersionType.SECP256K1),
+      "entropy must have length 16."
+    );
   }
 
   @Test

--- a/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/Base58Test.java
+++ b/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/Base58Test.java
@@ -1,11 +1,11 @@
 package org.xrpl.xrpl4j.codec.addresses;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.Lists;
 import com.google.common.primitives.UnsignedLong;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodingFormatException;

--- a/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/ByteUtilsTest.java
+++ b/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/ByteUtilsTest.java
@@ -1,8 +1,9 @@
 package org.xrpl.xrpl4j.codec.addresses;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 
@@ -28,9 +29,12 @@ public class ByteUtilsTest {
     ByteUtils.checkSize(4, BigInteger.valueOf(15));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void checkSizeExceedMaxValue() {
-    ByteUtils.checkSize(4, BigInteger.valueOf(17));
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> ByteUtils.checkSize(4, BigInteger.valueOf(17))
+    );
   }
 
   @Test

--- a/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArrayTest.java
+++ b/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArrayTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray.of;
 
 import com.google.common.io.BaseEncoding;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class UnsignedByteArrayTest {

--- a/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteTest.java
+++ b/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteTest.java
@@ -2,7 +2,7 @@ package org.xrpl.xrpl4j.codec.addresses;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 

--- a/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/XAddressTest.java
+++ b/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/XAddressTest.java
@@ -1,16 +1,13 @@
 package org.xrpl.xrpl4j.codec.addresses;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.Lists;
 import com.google.common.primitives.UnsignedInteger;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.DecodeException;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodingFormatException;
 import org.xrpl.xrpl4j.model.transactions.Address;
@@ -19,269 +16,241 @@ import org.xrpl.xrpl4j.model.transactions.XAddress;
 import java.util.Collection;
 import java.util.Optional;
 
-@SuppressWarnings({"ParameterName", "MethodName", "LocalVariableName"})
-@RunWith(Enclosed.class)
+@SuppressWarnings( {"ParameterName", "MethodName", "LocalVariableName"})
 public class XAddressTest {
 
-  @RunWith(Parameterized.class)
-  public static class XAddressParameterizedTests {
+  private final AddressCodec addressCodec = new AddressCodec();
 
-    Address classicAddressAccountId;
-    UnsignedInteger tag;
-    XAddress mainnetXAddress;
-    XAddress testnetXAddress;
-
-    AddressCodec addressCodec;
-
-    /**
-     * Required args constructor.
-     *
-     * @param classicAddressAccountId A {@link String} containing an account ID.
-     * @param tag                     An {@link UnsignedInteger} containing a tag.
-     * @param mainnetXAddress         A {@code String} containing a mainnet X-Address.
-     * @param testnetXAddress         A {@link String} containing a testnet X-Address.
-     */
-    public XAddressParameterizedTests(
-        String classicAddressAccountId,
-        UnsignedInteger tag,
-        String mainnetXAddress,
-        String testnetXAddress
-    ) {
-      this.classicAddressAccountId = Address.of(classicAddressAccountId);
-      this.tag = tag;
-      this.mainnetXAddress = XAddress.of(mainnetXAddress);
-      this.testnetXAddress = XAddress.of(testnetXAddress);
-      this.addressCodec = new AddressCodec();
-    }
-
-    /**
-     * Construct the test cases for this parameterized test.
-     *
-     * @return A {@link Collection} of {@link Object} arrays.
-     */
-    @Parameterized.Parameters
-    public static Collection<Object[]> data() {
-      return Lists.newArrayList(
-          new Object[] {
-              "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-              null,
-              "X7AcgcsBL6XDcUb289X4mJ8djcdyKaB5hJDWMArnXr61cqZ",
-              "T719a5UwUCnEs54UsxG9CJYYDhwmFCqkr7wxCcNcfZ6p5GZ"
-          },
-          new Object[] {
-              "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-              UnsignedInteger.ONE,
-              "X7AcgcsBL6XDcUb289X4mJ8djcdyKaGZMhc9YTE92ehJ2Fu",
-              "T719a5UwUCnEs54UsxG9CJYYDhwmFCvbJNZbi37gBGkRkbE"
-          },
-          new Object[] {
-              "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-              UnsignedInteger.valueOf(14),
-              "X7AcgcsBL6XDcUb289X4mJ8djcdyKaGo2K5VpXpmCqbV2gS",
-              "T719a5UwUCnEs54UsxG9CJYYDhwmFCvqXVCALUGJGSbNV3x"
-          },
-          new Object[] {
-              "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
-              UnsignedInteger.valueOf(11747),
-              "X7AcgcsBL6XDcUb289X4mJ8djcdyKaLFuhLRuNXPrDeJd9A",
-              "T719a5UwUCnEs54UsxG9CJYYDhwmFCziiNHtUukubF2Mg6t"
-          },
-          new Object[] {
-              "rLczgQHxPhWtjkaQqn3Q6UM8AbRbbRvs5K",
-              null,
-              "XVZVpQj8YSVpNyiwXYSqvQoQqgBttTxAZwMcuJd4xteQHyt",
-              "TVVrSWtmQQssgVcmoMBcFQZKKf56QscyWLKnUyiuZW8ALU4"
-          },
-          new Object[] {
-              "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-              null,
-              "X7YenJqxv3L66CwhBSfd3N8RzGXxYqPopMGMsCcpho79rex",
-              "T77wVQzA8ntj9wvCTNiQpNYLT5hmhRsFyXDoMLqYC4BzQtV"
-          },
-          new Object[] {
-              "rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo",
-              UnsignedInteger.valueOf(58),
-              "X7YenJqxv3L66CwhBSfd3N8RzGXxYqV56ZkTCa9UCzgaao1",
-              "T77wVQzA8ntj9wvCTNiQpNYLT5hmhR9kej6uxm4jGcQD7rZ"
-          },
-          new Object[] {
-              "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
-              UnsignedInteger.valueOf(23480),
-              "X7d3eHCXzwBeWrZec1yT24iZerQjYL8m8zCJ16ACxu1BrBY",
-              "T7YChPFWifjCAXLEtg5N74c7fSAYsvSokwcmBPBUZWhxH5P"
-          },
-          new Object[] {
-              "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",
-              UnsignedInteger.valueOf(11747),
-              "X7d3eHCXzwBeWrZec1yT24iZerQjYLo2CJf8oVC5CMWey5m",
-              "T7YChPFWifjCAXLEtg5N74c7fSAYsvTcc7nEfwuEEvn5Q4w"
-          },
-          new Object[] {
-              "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf",
-              null, // false
-              "XVLhHMPHU98es4dbozjVtdWzVrDjtV5fdx1mHp98tDMoQXb",
-              "TVE26TYGhfLC7tQDno7G8dGtxSkYQn49b3qD26PK7FcGSKE"
-          },
-          new Object[] {
-              "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf",
-              UnsignedInteger.ZERO,
-              "XVLhHMPHU98es4dbozjVtdWzVrDjtV8AqEL4xcZj5whKbmc",
-              "TVE26TYGhfLC7tQDno7G8dGtxSkYQnSy8RHqGHoGJ59spi2"
-          },
-          new Object[] {
-              "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf",
-              UnsignedInteger.ONE,
-              "XVLhHMPHU98es4dbozjVtdWzVrDjtV8xvjGQTYPiAx6gwDC",
-              "TVE26TYGhfLC7tQDno7G8dGtxSkYQnSz1uDimDdPYXzSpyw"
-          },
-          new Object[] {
-              "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf",
-              UnsignedInteger.valueOf(2),
-              "XVLhHMPHU98es4dbozjVtdWzVrDjtV8zpDURx7DzBCkrQE7",
-              "TVE26TYGhfLC7tQDno7G8dGtxSkYQnTryP9tG9TW8GeMBmd"
-          },
-          new Object[] {
-              "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf",
-              UnsignedInteger.valueOf(32),
-              "XVLhHMPHU98es4dbozjVtdWzVrDjtVoYiC9UvKfjKar4LJe",
-              "TVE26TYGhfLC7tQDno7G8dGtxSkYQnT2oqaCDzMEuCDAj1j"
-          },
-          new Object[] {
-              "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf",
-              UnsignedInteger.valueOf(276),
-              "XVLhHMPHU98es4dbozjVtdWzVrDjtVoKj3MnFGMXEFMnvJV",
-              "TVE26TYGhfLC7tQDno7G8dGtxSkYQnTMgJJYfAbsiPsc6Zg"
-          },
-          new Object[] {
-              "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf",
-              UnsignedInteger.valueOf(65591),
-              "XVLhHMPHU98es4dbozjVtdWzVrDjtVozpjdhPQVdt3ghaWw",
-              "TVE26TYGhfLC7tQDno7G8dGtxSkYQn7ryu2W6njw7mT1jmS"
-          },
-          new Object[] {
-              "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf",
-              UnsignedInteger.valueOf(16781933),
-              "XVLhHMPHU98es4dbozjVtdWzVrDjtVqrDUk2vDpkTjPsY73",
-              "TVE26TYGhfLC7tQDno7G8dGtxSkYQnVsw45sDtGHhLi27Qa"
-          },
-          new Object[] {
-              "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf",
-              UnsignedInteger.valueOf(4294967294L),
-              "XVLhHMPHU98es4dbozjVtdWzVrDjtV1kAsixQTdMjbWi39u",
-              "TVE26TYGhfLC7tQDno7G8dGtxSkYQnX8tDFQ53itLNqs6vU"
-          },
-          new Object[] {
-              "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf",
-              UnsignedInteger.valueOf(4294967295L),
-              "XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHi",
-              "TVE26TYGhfLC7tQDno7G8dGtxSkYQnXoy6kSDh6rZzApc69"
-          },
-          new Object[] {
-              "rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY",
-              null,
-              "XV5sbjUmgPpvXv4ixFWZ5ptAYZ6PD2gYsjNFQLKYW33DzBm",
-              "TVd2rqMkYL2AyS97NdELcpeiprNBjwLZzuUG5rZnaewsahi"
-          },
-          new Object[] {
-              "rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY",
-              UnsignedInteger.ZERO,
-              "XV5sbjUmgPpvXv4ixFWZ5ptAYZ6PD2m4Er6SnvjVLpMWPjR",
-              "TVd2rqMkYL2AyS97NdELcpeiprNBjwRQUBetPbyrvXSTuxU"
-          },
-          new Object[] {
-              "rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY",
-              UnsignedInteger.valueOf(13371337),
-              "XV5sbjUmgPpvXv4ixFWZ5ptAYZ6PD2qwGkhgc48zzcx6Gkr",
-              "TVd2rqMkYL2AyS97NdELcpeiprNBjwVUDvp3vhpXbNhLwJi"
-          }
-      );
-    }
-
-
-    @Test
-    public void convertBetweenClassicAndXAddressMainnet() {
-      ClassicAddress fromXAddress = addressCodec.xAddressToClassicAddress(mainnetXAddress);
-      ClassicAddress classicAddress = ClassicAddress.builder()
-          .classicAddress(classicAddressAccountId)
-          .tag(tag == null ? UnsignedInteger.ZERO : tag)
-          .test(false)
-          .build();
-
-      assertThat(fromXAddress).isEqualTo(classicAddress);
-
-      XAddress xAddress = addressCodec.classicAddressToXAddress(
-        classicAddressAccountId,
-        Optional.ofNullable(tag),
-        false
-      );
-      assertThat(xAddress).isEqualTo(mainnetXAddress);
-
-      assertThat(addressCodec.isValidClassicAddress(fromXAddress.classicAddress()));
-      assertThat(addressCodec.isValidXAddress(xAddress));
-    }
-
-    @Test
-    public void convertBetweenClassicAndXAddressTestnet() {
-      ClassicAddress fromXAddress = addressCodec.xAddressToClassicAddress(testnetXAddress);
-      ClassicAddress classicAddress = ClassicAddress.builder()
-          .classicAddress(classicAddressAccountId)
-          .tag(tag == null ? UnsignedInteger.ZERO : tag)
-          .test(true)
-          .build();
-
-      assertThat(fromXAddress).isEqualTo(classicAddress);
-
-      XAddress xAddress = addressCodec.classicAddressToXAddress(
-        classicAddressAccountId,
-        Optional.ofNullable(tag),
-        true
-      );
-      assertThat(xAddress).isEqualTo(testnetXAddress);
-
-      assertThat(addressCodec.isValidClassicAddress(fromXAddress.classicAddress()));
-      assertThat(addressCodec.isValidXAddress(xAddress));
-    }
+  /**
+   * Construct the test cases for this parameterized test.
+   *
+   * @return A {@link Collection} of {@link Object} arrays.
+   */
+  public static Collection<Object[]> data() {
+    return Lists.newArrayList(
+      new Object[] {
+        Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"),
+        null,
+        XAddress.of("X7AcgcsBL6XDcUb289X4mJ8djcdyKaB5hJDWMArnXr61cqZ"),
+        XAddress.of("T719a5UwUCnEs54UsxG9CJYYDhwmFCqkr7wxCcNcfZ6p5GZ")
+      },
+      new Object[] {
+        Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"),
+        UnsignedInteger.ONE,
+        XAddress.of("X7AcgcsBL6XDcUb289X4mJ8djcdyKaGZMhc9YTE92ehJ2Fu"),
+        XAddress.of("T719a5UwUCnEs54UsxG9CJYYDhwmFCvbJNZbi37gBGkRkbE")
+      },
+      new Object[] {
+        Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"),
+        UnsignedInteger.valueOf(14),
+        XAddress.of("X7AcgcsBL6XDcUb289X4mJ8djcdyKaGo2K5VpXpmCqbV2gS"),
+        XAddress.of("T719a5UwUCnEs54UsxG9CJYYDhwmFCvqXVCALUGJGSbNV3x")
+      },
+      new Object[] {
+        Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"),
+        UnsignedInteger.valueOf(11747),
+        XAddress.of("X7AcgcsBL6XDcUb289X4mJ8djcdyKaLFuhLRuNXPrDeJd9A"),
+        XAddress.of("T719a5UwUCnEs54UsxG9CJYYDhwmFCziiNHtUukubF2Mg6t")
+      },
+      new Object[] {
+        Address.of("rLczgQHxPhWtjkaQqn3Q6UM8AbRbbRvs5K"),
+        null,
+        XAddress.of("XVZVpQj8YSVpNyiwXYSqvQoQqgBttTxAZwMcuJd4xteQHyt"),
+        XAddress.of("TVVrSWtmQQssgVcmoMBcFQZKKf56QscyWLKnUyiuZW8ALU4")
+      },
+      new Object[] {
+        Address.of("rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo"),
+        null,
+        XAddress.of("X7YenJqxv3L66CwhBSfd3N8RzGXxYqPopMGMsCcpho79rex"),
+        XAddress.of("T77wVQzA8ntj9wvCTNiQpNYLT5hmhRsFyXDoMLqYC4BzQtV")
+      },
+      new Object[] {
+        Address.of("rpZc4mVfWUif9CRoHRKKcmhu1nx2xktxBo"),
+        UnsignedInteger.valueOf(58),
+        XAddress.of("X7YenJqxv3L66CwhBSfd3N8RzGXxYqV56ZkTCa9UCzgaao1"),
+        XAddress.of("T77wVQzA8ntj9wvCTNiQpNYLT5hmhR9kej6uxm4jGcQD7rZ")
+      },
+      new Object[] {
+        Address.of("rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"),
+        UnsignedInteger.valueOf(23480),
+        XAddress.of("X7d3eHCXzwBeWrZec1yT24iZerQjYL8m8zCJ16ACxu1BrBY"),
+        XAddress.of("T7YChPFWifjCAXLEtg5N74c7fSAYsvSokwcmBPBUZWhxH5P")
+      },
+      new Object[] {
+        Address.of("rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"),
+        UnsignedInteger.valueOf(11747),
+        XAddress.of("X7d3eHCXzwBeWrZec1yT24iZerQjYLo2CJf8oVC5CMWey5m"),
+        XAddress.of("T7YChPFWifjCAXLEtg5N74c7fSAYsvTcc7nEfwuEEvn5Q4w")
+      },
+      new Object[] {
+        Address.of("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf"),
+        null, // false
+        XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV5fdx1mHp98tDMoQXb"),
+        XAddress.of("TVE26TYGhfLC7tQDno7G8dGtxSkYQn49b3qD26PK7FcGSKE")
+      },
+      new Object[] {
+        Address.of("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf"),
+        UnsignedInteger.ZERO,
+        XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV8AqEL4xcZj5whKbmc"),
+        XAddress.of("TVE26TYGhfLC7tQDno7G8dGtxSkYQnSy8RHqGHoGJ59spi2")
+      },
+      new Object[] {
+        Address.of("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf"),
+        UnsignedInteger.ONE,
+        XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV8xvjGQTYPiAx6gwDC"),
+        XAddress.of("TVE26TYGhfLC7tQDno7G8dGtxSkYQnSz1uDimDdPYXzSpyw")
+      },
+      new Object[] {
+        Address.of("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf"),
+        UnsignedInteger.valueOf(2),
+        XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV8zpDURx7DzBCkrQE7"),
+        XAddress.of("TVE26TYGhfLC7tQDno7G8dGtxSkYQnTryP9tG9TW8GeMBmd")
+      },
+      new Object[] {
+        Address.of("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf"),
+        UnsignedInteger.valueOf(32),
+        XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtVoYiC9UvKfjKar4LJe"),
+        XAddress.of("TVE26TYGhfLC7tQDno7G8dGtxSkYQnT2oqaCDzMEuCDAj1j")
+      },
+      new Object[] {
+        Address.of("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf"),
+        UnsignedInteger.valueOf(276),
+        XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtVoKj3MnFGMXEFMnvJV"),
+        XAddress.of("TVE26TYGhfLC7tQDno7G8dGtxSkYQnTMgJJYfAbsiPsc6Zg")
+      },
+      new Object[] {
+        Address.of("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf"),
+        UnsignedInteger.valueOf(65591),
+        XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtVozpjdhPQVdt3ghaWw"),
+        XAddress.of("TVE26TYGhfLC7tQDno7G8dGtxSkYQn7ryu2W6njw7mT1jmS")
+      },
+      new Object[] {
+        Address.of("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf"),
+        UnsignedInteger.valueOf(16781933),
+        XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtVqrDUk2vDpkTjPsY73"),
+        XAddress.of("TVE26TYGhfLC7tQDno7G8dGtxSkYQnVsw45sDtGHhLi27Qa")
+      },
+      new Object[] {
+        Address.of("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf"),
+        UnsignedInteger.valueOf(4294967294L),
+        XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV1kAsixQTdMjbWi39u"),
+        XAddress.of("TVE26TYGhfLC7tQDno7G8dGtxSkYQnX8tDFQ53itLNqs6vU")
+      },
+      new Object[] {
+        Address.of("rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf"),
+        UnsignedInteger.valueOf(4294967295L),
+        XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHi"),
+        XAddress.of("TVE26TYGhfLC7tQDno7G8dGtxSkYQnXoy6kSDh6rZzApc69")
+      },
+      new Object[] {
+        Address.of("rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY"),
+        null,
+        XAddress.of("XV5sbjUmgPpvXv4ixFWZ5ptAYZ6PD2gYsjNFQLKYW33DzBm"),
+        XAddress.of("TVd2rqMkYL2AyS97NdELcpeiprNBjwLZzuUG5rZnaewsahi")
+      },
+      new Object[] {
+        Address.of("rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY"),
+        UnsignedInteger.ZERO,
+        XAddress.of("XV5sbjUmgPpvXv4ixFWZ5ptAYZ6PD2m4Er6SnvjVLpMWPjR"),
+        XAddress.of("TVd2rqMkYL2AyS97NdELcpeiprNBjwRQUBetPbyrvXSTuxU")
+      },
+      new Object[] {
+        Address.of("rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY"),
+        UnsignedInteger.valueOf(13371337),
+        XAddress.of("XV5sbjUmgPpvXv4ixFWZ5ptAYZ6PD2qwGkhgc48zzcx6Gkr"),
+        XAddress.of("TVd2rqMkYL2AyS97NdELcpeiprNBjwVUDvp3vhpXbNhLwJi")
+      }
+    );
   }
 
-  public static class XAddressTests {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void convertBetweenClassicAndXAddressMainnet(
+    Address classicAddressAccountId,
+    UnsignedInteger tag,
+    XAddress mainnetXAddress,
+    XAddress testnetXAddress
+  ) {
+    ClassicAddress fromXAddress = addressCodec.xAddressToClassicAddress(mainnetXAddress);
+    ClassicAddress classicAddress = ClassicAddress.builder()
+      .classicAddress(classicAddressAccountId)
+      .tag(tag == null ? UnsignedInteger.ZERO : tag)
+      .test(false)
+      .build();
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+    assertThat(fromXAddress).isEqualTo(classicAddress);
 
-    AddressCodec addressCodec;
+    XAddress xAddress = addressCodec.classicAddressToXAddress(
+      classicAddressAccountId,
+      Optional.ofNullable(tag),
+      false
+    );
+    assertThat(xAddress).isEqualTo(mainnetXAddress);
 
-    @Before
-    public void setUp() throws Exception {
-      addressCodec = new AddressCodec();
-    }
-
-    @Test
-    public void xAddressWithBadChecksum() {
-      XAddress xAddress = XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV5fdx1mHp98tDMoQXa");
-
-      expectedException.expect(EncodingFormatException.class);
-      expectedException.expectMessage("Checksum does not validate");
-      addressCodec.xAddressToClassicAddress(xAddress);
-    }
-
-
-    @Test
-    public void xAddressWithBadPrefix() {
-      XAddress xAddress = XAddress.of("dGzKGt8CVpWoa8aWL1k18tAdy9Won3PxynvbbpkAqp3V47g");
-
-      expectedException.expect(DecodeException.class);
-      expectedException.expectMessage("Invalid X-Address: Bad Prefix");
-      addressCodec.xAddressToClassicAddress(xAddress);
-    }
-
-    @Test
-    public void xAddressWith64BitTag() {
-      XAddress xAddress = XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8zeUygYrCgrPh");
-
-      expectedException.expect(DecodeException.class);
-      expectedException.expectMessage("Unsupported X-Address: 64-bit tags are not supported");
-      addressCodec.xAddressToClassicAddress(xAddress);
-    }
-
+    assertThat(addressCodec.isValidClassicAddress(fromXAddress.classicAddress()));
+    assertThat(addressCodec.isValidXAddress(xAddress));
   }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void convertBetweenClassicAndXAddressTestnet(
+    Address classicAddressAccountId,
+    UnsignedInteger tag,
+    XAddress mainnetXAddress,
+    XAddress testnetXAddress
+  ) {
+    ClassicAddress fromXAddress = addressCodec.xAddressToClassicAddress(testnetXAddress);
+    ClassicAddress classicAddress = ClassicAddress.builder()
+      .classicAddress(classicAddressAccountId)
+      .tag(tag == null ? UnsignedInteger.ZERO : tag)
+      .test(true)
+      .build();
+
+    assertThat(fromXAddress).isEqualTo(classicAddress);
+
+    XAddress xAddress = addressCodec.classicAddressToXAddress(
+      classicAddressAccountId,
+      Optional.ofNullable(tag),
+      true
+    );
+    assertThat(xAddress).isEqualTo(testnetXAddress);
+
+    assertThat(addressCodec.isValidClassicAddress(fromXAddress.classicAddress()));
+    assertThat(addressCodec.isValidXAddress(xAddress));
+  }
+
+  @Test
+  public void xAddressWithBadChecksum() {
+    XAddress xAddress = XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV5fdx1mHp98tDMoQXa");
+
+    assertThrows(
+      EncodingFormatException.class,
+      () -> addressCodec.xAddressToClassicAddress(xAddress),
+      "Checksum does not validate"
+    );
+  }
+
+
+  @Test
+  public void xAddressWithBadPrefix() {
+    XAddress xAddress = XAddress.of("dGzKGt8CVpWoa8aWL1k18tAdy9Won3PxynvbbpkAqp3V47g");
+
+    assertThrows(
+      DecodeException.class,
+      () -> addressCodec.xAddressToClassicAddress(xAddress),
+      "Invalid X-Address: Bad Prefix"
+    );
+  }
+
+  @Test
+  public void xAddressWith64BitTag() {
+    XAddress xAddress = XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8zeUygYrCgrPh");
+
+    assertThrows(
+      DecodeException.class,
+      () -> addressCodec.xAddressToClassicAddress(xAddress),
+      "Unsupported X-Address: 64-bit tags are not supported"
+    );
+  }
+
 }

--- a/xrpl4j-keypairs/pom.xml
+++ b/xrpl4j-keypairs/pom.xml
@@ -37,8 +37,14 @@
       <artifactId>value</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/xrpl4j-keypairs/src/test/java/org/xrpl/xrpl4j/keypairs/DefaultKeyPairServiceTest.java
+++ b/xrpl4j-keypairs/src/test/java/org/xrpl/xrpl4j/keypairs/DefaultKeyPairServiceTest.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.keypairs;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.BaseEncoding;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.transactions.Address;
 
 public class DefaultKeyPairServiceTest {

--- a/xrpl4j-keypairs/src/test/java/org/xrpl/xrpl4j/keypairs/Ed25519KeyPairServiceTest.java
+++ b/xrpl4j-keypairs/src/test/java/org/xrpl/xrpl4j/keypairs/Ed25519KeyPairServiceTest.java
@@ -3,15 +3,15 @@ package org.xrpl.xrpl4j.keypairs;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.BaseEncoding;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.transactions.Address;
 
 public class Ed25519KeyPairServiceTest {
 
   private Ed25519KeyPairService keyPairService;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     keyPairService = Ed25519KeyPairService.getInstance();
   }

--- a/xrpl4j-keypairs/src/test/java/org/xrpl/xrpl4j/keypairs/Secp256k1KeyPairServiceTest.java
+++ b/xrpl4j-keypairs/src/test/java/org/xrpl/xrpl4j/keypairs/Secp256k1KeyPairServiceTest.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.keypairs;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.BaseEncoding;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.transactions.Address;
 
 public class Secp256k1KeyPairServiceTest {

--- a/xrpl4j-keypairs/src/test/java/org/xrpl/xrpl4j/wallet/DefaultWalletFactoryTest.java
+++ b/xrpl4j-keypairs/src/test/java/org/xrpl/xrpl4j/wallet/DefaultWalletFactoryTest.java
@@ -2,7 +2,7 @@ package org.xrpl.xrpl4j.wallet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.transactions.XAddress;
 
 @SuppressWarnings("LocalVariableName")

--- a/xrpl4j-model/pom.xml
+++ b/xrpl4j-model/pom.xml
@@ -54,11 +54,6 @@
       <artifactId>jackson-datatype-cryptoconditions</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -76,6 +71,12 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/xrpl4j-model/pom.xml
+++ b/xrpl4j-model/pom.xml
@@ -74,6 +74,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
       <scope>test</scope>

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/AbstractJsonTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/AbstractJsonTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.json.JSONException;
-import org.junit.Before;
 import org.junit.jupiter.api.BeforeEach;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -19,14 +18,8 @@ public class AbstractJsonTest {
 
   protected ObjectMapper objectMapper;
 
-  @Before
-  @Deprecated // Will be removed once Junit4 is removed.
-  public void setUp() {
-    objectMapper = ObjectMapperFactory.create();
-  }
-
   @BeforeEach
-  public void setUpJunit5() {
+  public void setUp() {
     objectMapper = ObjectMapperFactory.create();
   }
 

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsRequestParamsJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsRequestParamsJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.client.accounts;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResultJsonTests.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoRequestParamsJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoRequestParamsJsonTests.java
@@ -2,7 +2,7 @@ package org.xrpl.xrpl4j.model.client.accounts;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoResultJsonTests.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.flags.Flags;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesRequestParamsJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesRequestParamsJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.client.accounts;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResultJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.client.accounts;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Address;
 

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsRequestParamsJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsRequestParamsJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.client.accounts;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsResultJsonTests.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.flags.Flags;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.client.accounts;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsResultJsonTests.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.client.transactions.TransactionResult;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/channels/ChannelVerifyRequestParamsJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/channels/ChannelVerifyRequestParamsJsonTests.java
@@ -2,7 +2,7 @@ package org.xrpl.xrpl4j.model.client.channels;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/channels/ChannelVerifyResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/channels/ChannelVerifyResultJsonTests.java
@@ -2,7 +2,7 @@ package org.xrpl.xrpl4j.model.client.channels;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 
 public class ChannelVerifyResultJsonTests extends AbstractJsonTest {

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/fees/FeeResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/fees/FeeResultJsonTests.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/ledger/LedgerRequestParamsJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/ledger/LedgerRequestParamsJsonTests.java
@@ -2,7 +2,7 @@ package org.xrpl.xrpl4j.model.client.ledger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/ledger/LedgerResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/ledger/LedgerResultJsonTests.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.ledger.LedgerHeader;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/path/RipplePathFindRequestParamsJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/path/RipplePathFindRequestParamsJsonTests.java
@@ -2,7 +2,7 @@ package org.xrpl.xrpl4j.model.client.path;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/path/RipplePathFindResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/path/RipplePathFindResultJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.client.path;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.assertj.core.util.Lists;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.PathStep;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SignedTransactionTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SignedTransactionTest.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.client.transactions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.primitives.UnsignedInteger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitMultisignedRequestParamsJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitMultisignedRequestParamsJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.client.transactions;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.Flags;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitMultisignedResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitMultisignedResultJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.client.transactions;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.Flags;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitRequestParamsJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitRequestParamsJsonTests.java
@@ -2,7 +2,7 @@ package org.xrpl.xrpl4j.model.client.transactions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 
 public class SubmitRequestParamsJsonTests extends AbstractJsonTest {

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResultJsonTests.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionRequestParamsJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionRequestParamsJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.client.transactions;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultJsonTests.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.Flags;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/AbstractFlagsTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/AbstractFlagsTest.java
@@ -1,11 +1,14 @@
 package org.xrpl.xrpl4j.model.flags;
 
+import org.junit.jupiter.params.provider.Arguments;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class AbstractFlagsTest {
 
-  protected static List<Object[]> getBooleanCombinations(int flagCount) {
+  protected static Stream<Arguments> getBooleanCombinations(int flagCount) {
     // Every combination of 4 booleans
     List<Object[]> params = new ArrayList<>();
     for (int i = 0; i < Math.pow(2, flagCount); i++) {
@@ -23,6 +26,6 @@ public class AbstractFlagsTest {
       params.add(booleans);
     }
 
-    return params;
+    return params.stream().map(Arguments::of);
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/AccountRootFlagsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/AccountRootFlagsTests.java
@@ -2,79 +2,40 @@ package org.xrpl.xrpl4j.model.flags;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
-@RunWith(Parameterized.class)
 public class AccountRootFlagsTests extends AbstractFlagsTest {
 
-  boolean lsfDefaultRipple;
-  boolean lsfDepositAuth;
-  boolean lsfDisableMaster;
-  boolean lsfDisallowXrp;
-  boolean lsfGlobalFreeze;
-  boolean lsfNoFreeze;
-  boolean lsfPasswordSpent;
-  boolean lsfRequireAuth;
-  boolean lsfRequireDestTag;
-
-  long expectedFlags;
-
-  /**
-   * Required-arg constructor.
-   *
-   * @param lsfDefaultRipple  The current value of {@link this.lsfDefaultRipple}.
-   * @param lsfDepositAuth    The current value of {@link this.lsfDepositAuth}.
-   * @param lsfDisableMaster  The current value of {@link this.lsfDisableMaster}.
-   * @param lsfDisallowXrp    The current value of {@link this.lsfDisallowXrp}.
-   * @param lsfGlobalFreeze   The current value of {@link this.lsfGlobalFreeze}.
-   * @param lsfNoFreeze       The current value of {@link this.lsfNoFreeze}.
-   * @param lsfPasswordSpent  The current value of {@link this.lsfPasswordSpent}.
-   * @param lsfRequireAuth    The current value of {@link this.lsfRequireAuth}.
-   * @param lsfRequireDestTag The current value of {@link this.lsfRequireDestTag}.
-   */
-  public AccountRootFlagsTests(
-      boolean lsfDefaultRipple,
-      boolean lsfDepositAuth,
-      boolean lsfDisableMaster,
-      boolean lsfDisallowXrp,
-      boolean lsfGlobalFreeze,
-      boolean lsfNoFreeze,
-      boolean lsfPasswordSpent,
-      boolean lsfRequireAuth,
-      boolean lsfRequireDestTag
-  ) {
-    this.lsfDefaultRipple = lsfDefaultRipple;
-    this.lsfDepositAuth = lsfDepositAuth;
-    this.lsfDisableMaster = lsfDisableMaster;
-    this.lsfDisallowXrp = lsfDisallowXrp;
-    this.lsfGlobalFreeze = lsfGlobalFreeze;
-    this.lsfNoFreeze = lsfNoFreeze;
-    this.lsfPasswordSpent = lsfPasswordSpent;
-    this.lsfRequireAuth = lsfRequireAuth;
-    this.lsfRequireDestTag = lsfRequireDestTag;
-
-    expectedFlags = (lsfDefaultRipple ? Flags.AccountRootFlags.DEFAULT_RIPPLE.getValue() : 0L) |
-        (lsfDepositAuth ? Flags.AccountRootFlags.DEPOSIT_AUTH.getValue() : 0L) |
-        (lsfDisableMaster ? Flags.AccountRootFlags.DISABLE_MASTER.getValue() : 0L) |
-        (lsfDisallowXrp ? Flags.AccountRootFlags.DISALLOW_XRP.getValue() : 0L) |
-        (lsfGlobalFreeze ? Flags.AccountRootFlags.GLOBAL_FREEZE.getValue() : 0L) |
-        (lsfNoFreeze ? Flags.AccountRootFlags.NO_FREEZE.getValue() : 0L) |
-        (lsfPasswordSpent ? Flags.AccountRootFlags.PASSWORD_SPENT.getValue() : 0L) |
-        (lsfRequireAuth ? Flags.AccountRootFlags.REQUIRE_AUTH.getValue() : 0L) |
-        (lsfRequireDestTag ? Flags.AccountRootFlags.REQUIRE_DEST_TAG.getValue() : 0L);
-  }
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  public static Stream<Arguments> data() {
     return getBooleanCombinations(9);
   }
 
-  @Test
-  public void testDeriveIndividualFlagsFromFlags() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDeriveIndividualFlagsFromFlags(
+    boolean lsfDefaultRipple,
+    boolean lsfDepositAuth,
+    boolean lsfDisableMaster,
+    boolean lsfDisallowXrp,
+    boolean lsfGlobalFreeze,
+    boolean lsfNoFreeze,
+    boolean lsfPasswordSpent,
+    boolean lsfRequireAuth,
+    boolean lsfRequireDestTag
+  ) {
+    long expectedFlags = (lsfDefaultRipple ? Flags.AccountRootFlags.DEFAULT_RIPPLE.getValue() : 0L) |
+      (lsfDepositAuth ? Flags.AccountRootFlags.DEPOSIT_AUTH.getValue() : 0L) |
+      (lsfDisableMaster ? Flags.AccountRootFlags.DISABLE_MASTER.getValue() : 0L) |
+      (lsfDisallowXrp ? Flags.AccountRootFlags.DISALLOW_XRP.getValue() : 0L) |
+      (lsfGlobalFreeze ? Flags.AccountRootFlags.GLOBAL_FREEZE.getValue() : 0L) |
+      (lsfNoFreeze ? Flags.AccountRootFlags.NO_FREEZE.getValue() : 0L) |
+      (lsfPasswordSpent ? Flags.AccountRootFlags.PASSWORD_SPENT.getValue() : 0L) |
+      (lsfRequireAuth ? Flags.AccountRootFlags.REQUIRE_AUTH.getValue() : 0L) |
+      (lsfRequireDestTag ? Flags.AccountRootFlags.REQUIRE_DEST_TAG.getValue() : 0L);
     Flags.AccountRootFlags flags = Flags.AccountRootFlags.of(expectedFlags);
 
     assertThat(flags.getValue()).isEqualTo(expectedFlags);

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/OfferCreateFlagsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/OfferCreateFlagsTests.java
@@ -2,59 +2,28 @@ package org.xrpl.xrpl4j.model.flags;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
-@RunWith(Parameterized.class)
 public class OfferCreateFlagsTests extends AbstractFlagsTest {
 
-  boolean tfFullyCanonicalSig;
-  boolean tfPassive;
-  boolean tfImmediateOrCancel;
-  boolean tfFillOrKill;
-  boolean tfSell;
-
-  long expectedFlags;
-
-  /**
-   * Required-args constructor.
-   *
-   * @param tfFullyCanonicalSig The current value of {@link this.tfFullyCanonicalSig}.
-   * @param tfPassive           The current value of {@link this.tfPassive}.
-   * @param tfImmediateOrCancel The current value of {@link this.tfImmediateOrCancel}.
-   * @param tfFillOrKill        The current value of {@link this.tfFillOrKill}.
-   * @param tfSell              The current value of {@link this.tfSell}.
-   */
-  public OfferCreateFlagsTests(
-      boolean tfFullyCanonicalSig,
-      boolean tfPassive,
-      boolean tfImmediateOrCancel,
-      boolean tfFillOrKill,
-      boolean tfSell
-  ) {
-    this.tfFullyCanonicalSig = tfFullyCanonicalSig;
-    this.tfPassive = tfPassive;
-    this.tfImmediateOrCancel = tfImmediateOrCancel;
-    this.tfFillOrKill = tfFillOrKill;
-    this.tfSell = tfSell;
-
-    expectedFlags = (tfFullyCanonicalSig ? Flags.OfferCreateFlags.FULLY_CANONICAL_SIG.getValue() : 0L) |
-        (tfPassive ? Flags.OfferCreateFlags.PASSIVE.getValue() : 0L) |
-        (tfImmediateOrCancel ? Flags.OfferCreateFlags.IMMEDIATE_OR_CANCEL.getValue() : 0L) |
-        (tfFillOrKill ? Flags.OfferCreateFlags.FILL_OR_KILL.getValue() : 0L) |
-        (tfSell ? Flags.OfferCreateFlags.SELL.getValue() : 0L);
-  }
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  public static Stream<Arguments> data() {
     return getBooleanCombinations(5);
   }
 
-  @Test
-  public void testFlagsConstructionWithIndividualFlags() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testFlagsConstructionWithIndividualFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfPassive,
+    boolean tfImmediateOrCancel,
+    boolean tfFillOrKill,
+    boolean tfSell
+  ) {
     Flags.OfferCreateFlags flags = Flags.OfferCreateFlags.builder()
         .tfFullyCanonicalSig(tfFullyCanonicalSig)
         .tfPassive(tfPassive)
@@ -63,11 +32,20 @@ public class OfferCreateFlagsTests extends AbstractFlagsTest {
         .tfSell(tfSell)
         .build();
 
-    assertThat(flags.getValue()).isEqualTo(expectedFlags);
+    assertThat(flags.getValue())
+      .isEqualTo(getExpectedFlags(tfFullyCanonicalSig, tfPassive, tfImmediateOrCancel, tfFillOrKill, tfSell));
   }
 
-  @Test
-  public void testDeriveIndividualFlagsFromFlags() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDeriveIndividualFlagsFromFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfPassive,
+    boolean tfImmediateOrCancel,
+    boolean tfFillOrKill,
+    boolean tfSell
+  ) {
+    long expectedFlags = getExpectedFlags(tfFullyCanonicalSig, tfPassive, tfImmediateOrCancel, tfFillOrKill, tfSell);
     Flags.OfferCreateFlags flags = Flags.OfferCreateFlags.of(expectedFlags);
 
     assertThat(flags.getValue()).isEqualTo(expectedFlags);
@@ -76,5 +54,19 @@ public class OfferCreateFlagsTests extends AbstractFlagsTest {
     assertThat(flags.tfImmediateOrCancel()).isEqualTo(tfImmediateOrCancel);
     assertThat(flags.tfFillOrKill()).isEqualTo(tfFillOrKill);
     assertThat(flags.tfSell()).isEqualTo(tfSell);
+  }
+
+  private long getExpectedFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfPassive,
+    boolean tfImmediateOrCancel,
+    boolean tfFillOrKill,
+    boolean tfSell
+  ) {
+    return (tfFullyCanonicalSig ? Flags.OfferCreateFlags.FULLY_CANONICAL_SIG.getValue() : 0L) |
+      (tfPassive ? Flags.OfferCreateFlags.PASSIVE.getValue() : 0L) |
+      (tfImmediateOrCancel ? Flags.OfferCreateFlags.IMMEDIATE_OR_CANCEL.getValue() : 0L) |
+      (tfFillOrKill ? Flags.OfferCreateFlags.FILL_OR_KILL.getValue() : 0L) |
+      (tfSell ? Flags.OfferCreateFlags.SELL.getValue() : 0L);
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/OfferFlagsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/OfferFlagsTests.java
@@ -2,44 +2,27 @@ package org.xrpl.xrpl4j.model.flags;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
-@RunWith(Parameterized.class)
 public class OfferFlagsTests extends AbstractFlagsTest {
 
-  boolean lsfPassive;
-  boolean lsfSell;
-
-  long expectedFlags;
-
-  /**
-   * Required-args constructor.
-   *
-   * @param lsfPassive The current value of {@link this.lsfPassive}.
-   * @param lsfSell    The current value of {@link this.lsfSell}.
-   */
-  public OfferFlagsTests(
-      boolean lsfPassive,
-      boolean lsfSell
-  ) {
-    this.lsfPassive = lsfPassive;
-    this.lsfSell = lsfSell;
-
-    expectedFlags = (lsfPassive ? Flags.OfferFlags.PASSIVE.getValue() : 0L) |
-        (lsfSell ? Flags.OfferFlags.SELL.getValue() : 0L);
-  }
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  public static Stream<Arguments> data() {
     return getBooleanCombinations(2);
   }
 
-  @Test
-  public void testDeriveIndividualFlagsFromFlags() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDeriveIndividualFlagsFromFlags(
+    boolean lsfPassive,
+    boolean lsfSell
+  ) {
+    long expectedFlags = (lsfPassive ? Flags.OfferFlags.PASSIVE.getValue() : 0L) |
+      (lsfSell ? Flags.OfferFlags.SELL.getValue() : 0L);
+
     Flags.OfferFlags flags = Flags.OfferFlags.of(expectedFlags);
 
     assertThat(flags.getValue()).isEqualTo(expectedFlags);

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/PaymentChannelClaimFlagsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/PaymentChannelClaimFlagsTests.java
@@ -2,60 +2,54 @@ package org.xrpl.xrpl4j.model.flags;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
-@RunWith(Parameterized.class)
 public class PaymentChannelClaimFlagsTests extends AbstractFlagsTest {
 
-  boolean tfFullyCanonicalSig;
-  boolean tfRenew;
-  boolean tfClose;
-  long expectedFlags;
-
-  /**
-   * Required-args constructor.
-   *
-   * @param tfFullyCanonicalSig The current value of {@link this.tfFullyCanonicalSig}.
-   * @param tfRenew             The current value of {@link this.tfRenew}.
-   * @param tfClose             The current value of {@link this.tfClose}.
-   */
-  public PaymentChannelClaimFlagsTests(boolean tfFullyCanonicalSig, boolean tfRenew, boolean tfClose) {
-    this.tfFullyCanonicalSig = tfFullyCanonicalSig;
-    this.tfRenew = tfRenew;
-    this.tfClose = tfClose;
-
-    expectedFlags = (tfFullyCanonicalSig ? Flags.PaymentChannelClaimFlags.FULLY_CANONICAL_SIG.getValue() : 0L) |
-        (tfRenew ? Flags.PaymentChannelClaimFlags.RENEW.getValue() : 0L) |
-        (tfClose ? Flags.PaymentChannelClaimFlags.CLOSE.getValue() : 0L);
-  }
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  public static Stream<Arguments> data() {
     return getBooleanCombinations(3);
   }
 
-  @Test
-  public void testFlagsConstructionWithIndividualFlags() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testFlagsConstructionWithIndividualFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfRenew,
+    boolean tfClose
+  ) {
     Flags.PaymentChannelClaimFlags flags = Flags.PaymentChannelClaimFlags.builder()
-        .tfFullyCanonicalSig(tfFullyCanonicalSig)
-        .tfRenew(tfRenew)
-        .tfClose(tfClose)
-        .build();
+      .tfFullyCanonicalSig(tfFullyCanonicalSig)
+      .tfRenew(tfRenew)
+      .tfClose(tfClose)
+      .build();
 
-    assertThat(flags.getValue()).isEqualTo(expectedFlags);
+    assertThat(flags.getValue()).isEqualTo(getExpectedFlags(tfFullyCanonicalSig, tfRenew, tfClose));
   }
 
-  @Test
-  public void testDeriveIndividualFlagsFromFlags() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDeriveIndividualFlagsFromFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfRenew,
+    boolean tfClose
+  ) {
+    long expectedFlags = getExpectedFlags(tfFullyCanonicalSig, tfRenew, tfClose);
     Flags.PaymentChannelClaimFlags flags = Flags.PaymentChannelClaimFlags.of(expectedFlags);
 
     assertThat(flags.getValue()).isEqualTo(expectedFlags);
     assertThat(flags.tfFullyCanonicalSig()).isEqualTo(tfFullyCanonicalSig);
     assertThat(flags.tfRenew()).isEqualTo(tfRenew);
     assertThat(flags.tfClose()).isEqualTo(tfClose);
+  }
+
+  private long getExpectedFlags(boolean tfFullyCanonicalSig, boolean tfRenew, boolean tfClose) {
+    return (tfFullyCanonicalSig ? Flags.PaymentChannelClaimFlags.FULLY_CANONICAL_SIG.getValue() : 0L) |
+      (tfRenew ? Flags.PaymentChannelClaimFlags.RENEW.getValue() : 0L) |
+      (tfClose ? Flags.PaymentChannelClaimFlags.CLOSE.getValue() : 0L);
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/PaymentFlagsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/PaymentFlagsTests.java
@@ -2,54 +2,26 @@ package org.xrpl.xrpl4j.model.flags;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
-@RunWith(Parameterized.class)
 public class PaymentFlagsTests extends AbstractFlagsTest {
 
-  boolean tfFullyCanonicalSig;
-  boolean tfNoDirectRipple;
-  boolean tfPartialPayment;
-  boolean tfLimitQuality;
-
-  long expectedFlags;
-
-  /**
-   * Required-args constructor.
-   *
-   * @param tfFullyCanonicalSig The current value of {@link this.tfFullyCanonicalSig}.
-   * @param tfNoDirectRipple    The current value of {@link this.tfNoDirectRipple}.
-   * @param tfPartialPayment    The current value of {@link this.tfPartialPayment}.
-   * @param tfLimitQuality      The current value of {@link this.tfLimitQuality}.
-   */
-  public PaymentFlagsTests(
-      boolean tfFullyCanonicalSig,
-      boolean tfNoDirectRipple,
-      boolean tfPartialPayment,
-      boolean tfLimitQuality
-  ) {
-    this.tfFullyCanonicalSig = tfFullyCanonicalSig;
-    this.tfNoDirectRipple = tfNoDirectRipple;
-    this.tfPartialPayment = tfPartialPayment;
-    this.tfLimitQuality = tfLimitQuality;
-
-    expectedFlags = (tfFullyCanonicalSig ? Flags.PaymentFlags.FULLY_CANONICAL_SIG.getValue() : 0L) |
-        (tfNoDirectRipple ? Flags.PaymentFlags.NO_DIRECT_RIPPLE.getValue() : 0L) |
-        (tfPartialPayment ? Flags.PaymentFlags.PARTIAL_PAYMENT.getValue() : 0L) |
-        (tfLimitQuality ? Flags.PaymentFlags.LIMIT_QUALITY.getValue() : 0L);
-  }
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  public static Stream<Arguments> data() {
     return getBooleanCombinations(4);
   }
 
-  @Test
-  public void testFlagsConstructionWithIndividualFlags() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testFlagsConstructionWithIndividualFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfNoDirectRipple,
+    boolean tfPartialPayment,
+    boolean tfLimitQuality
+  ) {
     Flags.PaymentFlags flags = Flags.PaymentFlags.builder()
         .tfFullyCanonicalSig(tfFullyCanonicalSig)
         .tfNoDirectRipple(tfNoDirectRipple)
@@ -57,11 +29,19 @@ public class PaymentFlagsTests extends AbstractFlagsTest {
         .tfLimitQuality(tfLimitQuality)
         .build();
 
-    assertThat(flags.getValue()).isEqualTo(expectedFlags);
+    assertThat(flags.getValue())
+      .isEqualTo(getExpectedFlags(tfFullyCanonicalSig, tfNoDirectRipple, tfPartialPayment, tfLimitQuality));
   }
 
-  @Test
-  public void testDeriveIndividualFlagsFromFlags() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDeriveIndividualFlagsFromFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfNoDirectRipple,
+    boolean tfPartialPayment,
+    boolean tfLimitQuality
+  ) {
+    long expectedFlags = getExpectedFlags(tfFullyCanonicalSig, tfNoDirectRipple, tfPartialPayment, tfLimitQuality);
     Flags.PaymentFlags flags = Flags.PaymentFlags.of(expectedFlags);
 
     assertThat(flags.getValue()).isEqualTo(expectedFlags);
@@ -69,5 +49,17 @@ public class PaymentFlagsTests extends AbstractFlagsTest {
     assertThat(flags.tfNoDirectRipple()).isEqualTo(tfNoDirectRipple);
     assertThat(flags.tfPartialPayment()).isEqualTo(tfPartialPayment);
     assertThat(flags.tfLimitQuality()).isEqualTo(tfLimitQuality);
+  }
+
+  private long getExpectedFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfNoDirectRipple,
+    boolean tfPartialPayment,
+    boolean tfLimitQuality
+  ) {
+    return (tfFullyCanonicalSig ? Flags.PaymentFlags.FULLY_CANONICAL_SIG.getValue() : 0L) |
+      (tfNoDirectRipple ? Flags.PaymentFlags.NO_DIRECT_RIPPLE.getValue() : 0L) |
+      (tfPartialPayment ? Flags.PaymentFlags.PARTIAL_PAYMENT.getValue() : 0L) |
+      (tfLimitQuality ? Flags.PaymentFlags.LIMIT_QUALITY.getValue() : 0L);
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/RippleStateFlagsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/RippleStateFlagsTests.java
@@ -2,75 +2,40 @@ package org.xrpl.xrpl4j.model.flags;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
-@RunWith(Parameterized.class)
 public class RippleStateFlagsTests extends AbstractFlagsTest {
 
-  boolean lsfLowReserve;
-  boolean lsfHighReserve;
-  boolean lsfLowAuth;
-  boolean lsfHighAuth;
-  boolean lsfLowNoRipple;
-  boolean lsfHighNoRipple;
-  boolean lsfLowFreeze;
-  boolean lsfHighFreeze;
-
-  long expectedFlags;
-
-
-  /**
-   * Required-args constructor.
-   *
-   * @param lsfLowReserve   The current value of {@link this.lsfLowReserve}.
-   * @param lsfHighReserve  The current value of {@link this.lsfHighReserve}.
-   * @param lsfLowAuth      The current value of {@link this.lsfLowAuth}.
-   * @param lsfHighAuth     The current value of {@link this.lsfHighAuth}.
-   * @param lsfLowNoRipple  The current value of {@link this.lsfLowNoRipple}.
-   * @param lsfHighNoRipple The current value of {@link this.lsfHighNoRipple}.
-   * @param lsfLowFreeze    The current value of {@link this.lsfLowFreeze}.
-   * @param lsfHighFreeze   The current value of {@link this.lsfHighFreeze}.
-   */
-  public RippleStateFlagsTests(
-      boolean lsfLowReserve,
-      boolean lsfHighReserve,
-      boolean lsfLowAuth,
-      boolean lsfHighAuth,
-      boolean lsfLowNoRipple,
-      boolean lsfHighNoRipple,
-      boolean lsfLowFreeze,
-      boolean lsfHighFreeze
-  ) {
-    this.lsfLowReserve = lsfLowReserve;
-    this.lsfHighReserve = lsfHighReserve;
-    this.lsfLowAuth = lsfLowAuth;
-    this.lsfHighAuth = lsfHighAuth;
-    this.lsfLowNoRipple = lsfLowNoRipple;
-    this.lsfHighNoRipple = lsfHighNoRipple;
-    this.lsfLowFreeze = lsfLowFreeze;
-    this.lsfHighFreeze = lsfHighFreeze;
-
-    expectedFlags = (lsfLowReserve ? Flags.RippleStateFlags.LOW_RESERVE.getValue() : 0L) |
-        (lsfHighReserve ? Flags.RippleStateFlags.HIGH_RESERVE.getValue() : 0L) |
-        (lsfLowAuth ? Flags.RippleStateFlags.LOW_AUTH.getValue() : 0L) |
-        (lsfHighAuth ? Flags.RippleStateFlags.HIGH_AUTH.getValue() : 0L) |
-        (lsfLowNoRipple ? Flags.RippleStateFlags.LOW_NO_RIPPLE.getValue() : 0L) |
-        (lsfHighNoRipple ? Flags.RippleStateFlags.HIGH_NO_RIPPLE.getValue() : 0L) |
-        (lsfLowFreeze ? Flags.RippleStateFlags.LOW_FREEZE.getValue() : 0L) |
-        (lsfHighFreeze ? Flags.RippleStateFlags.HIGH_FREEZE.getValue() : 0L);
-  }
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  public static Stream<Arguments> data() {
     return getBooleanCombinations(8);
   }
 
-  @Test
-  public void testDeriveIndividualFlagsFromFlags() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDeriveIndividualFlagsFromFlags(
+    boolean lsfLowReserve,
+    boolean lsfHighReserve,
+    boolean lsfLowAuth,
+    boolean lsfHighAuth,
+    boolean lsfLowNoRipple,
+    boolean lsfHighNoRipple,
+    boolean lsfLowFreeze,
+    boolean lsfHighFreeze
+  ) {
+    long expectedFlags = getExpectedFlags(
+      lsfLowReserve,
+      lsfHighReserve,
+      lsfLowAuth,
+      lsfHighAuth,
+      lsfLowNoRipple,
+      lsfHighNoRipple,
+      lsfLowFreeze,
+      lsfHighFreeze
+    );
     Flags.RippleStateFlags flags = Flags.RippleStateFlags.of(expectedFlags);
 
     assertThat(flags.getValue()).isEqualTo(expectedFlags);
@@ -82,5 +47,25 @@ public class RippleStateFlagsTests extends AbstractFlagsTest {
     assertThat(flags.lsfHighNoRipple()).isEqualTo(lsfHighNoRipple);
     assertThat(flags.lsfLowFreeze()).isEqualTo(lsfLowFreeze);
     assertThat(flags.lsfHighFreeze()).isEqualTo(lsfHighFreeze);
+  }
+
+  protected long getExpectedFlags(
+    boolean lsfLowReserve,
+    boolean lsfHighReserve,
+    boolean lsfLowAuth,
+    boolean lsfHighAuth,
+    boolean lsfLowNoRipple,
+    boolean lsfHighNoRipple,
+    boolean lsfLowFreeze,
+    boolean lsfHighFreeze
+  ) {
+    return (lsfLowReserve ? Flags.RippleStateFlags.LOW_RESERVE.getValue() : 0L) |
+      (lsfHighReserve ? Flags.RippleStateFlags.HIGH_RESERVE.getValue() : 0L) |
+      (lsfLowAuth ? Flags.RippleStateFlags.LOW_AUTH.getValue() : 0L) |
+      (lsfHighAuth ? Flags.RippleStateFlags.HIGH_AUTH.getValue() : 0L) |
+      (lsfLowNoRipple ? Flags.RippleStateFlags.LOW_NO_RIPPLE.getValue() : 0L) |
+      (lsfHighNoRipple ? Flags.RippleStateFlags.HIGH_NO_RIPPLE.getValue() : 0L) |
+      (lsfLowFreeze ? Flags.RippleStateFlags.LOW_FREEZE.getValue() : 0L) |
+      (lsfHighFreeze ? Flags.RippleStateFlags.HIGH_FREEZE.getValue() : 0L);
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/SignerListObjectFlagsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/SignerListObjectFlagsTests.java
@@ -2,31 +2,23 @@ package org.xrpl.xrpl4j.model.flags;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
-@RunWith(Parameterized.class)
 public class SignerListObjectFlagsTests extends AbstractFlagsTest {
 
-  boolean lsfOneOwnerCount;
-
-  long expectedFlags;
-
-  public SignerListObjectFlagsTests(boolean lsfOneOwnerCount) {
-    this.lsfOneOwnerCount = lsfOneOwnerCount;
-    this.expectedFlags = lsfOneOwnerCount ? Flags.SignerListFlags.ONE_OWNER_COUNT.getValue() : 0L;
-  }
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  public static Stream<Arguments> data() {
     return getBooleanCombinations(1);
   }
 
-  @Test
-  public void testDeriveIndividualFlagsFromFlags() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDeriveIndividualFlagsFromFlags(boolean lsfOneOwnerCount) {
+    long expectedFlags = lsfOneOwnerCount ? Flags.SignerListFlags.ONE_OWNER_COUNT.getValue() : 0L;
     Flags.SignerListFlags flags = Flags.SignerListFlags.of(expectedFlags);
 
     assertThat(flags.getValue()).isEqualTo(expectedFlags);

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/TrustSetFlagsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/TrustSetFlagsTests.java
@@ -2,64 +2,29 @@ package org.xrpl.xrpl4j.model.flags;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
-@RunWith(Parameterized.class)
 public class TrustSetFlagsTests extends AbstractFlagsTest {
 
-  boolean tfFullyCanonicalSig;
-  boolean tfSetfAuth;
-  boolean tfSetNoRipple;
-  boolean tfClearNoRipple;
-  boolean tfSetFreeze;
-  boolean tfClearFreeze;
-
-  long expectedFlags;
-
-  /**
-   * Required-args constructor.
-   *
-   * @param tfFullyCanonicalSig The current value of {@link this.tfFullyCanonicalSig}.
-   * @param tfSetfAuth          The current value of {@link this.tfSetfAuth}.
-   * @param tfSetNoRipple       The current value of {@link this.tfSetNoRipple}.
-   * @param tfClearNoRipple     The current value of {@link this.tfClearNoRipple}.
-   * @param tfSetFreeze         The current value of {@link this.tfSetFreeze}.
-   * @param tfClearFreeze       The current value of {@link this.tfClearFreeze}.
-   */
-  public TrustSetFlagsTests(
-      boolean tfFullyCanonicalSig,
-      boolean tfSetfAuth,
-      boolean tfSetNoRipple,
-      boolean tfClearNoRipple,
-      boolean tfSetFreeze,
-      boolean tfClearFreeze
-  ) {
-    this.tfFullyCanonicalSig = tfFullyCanonicalSig;
-    this.tfSetfAuth = tfSetfAuth;
-    this.tfSetNoRipple = tfSetNoRipple;
-    this.tfClearNoRipple = tfClearNoRipple;
-    this.tfSetFreeze = tfSetFreeze;
-    this.tfClearFreeze = tfClearFreeze;
-
-    expectedFlags = (tfFullyCanonicalSig ? Flags.TrustSetFlags.FULLY_CANONICAL_SIG.getValue() : 0L) |
-        (tfSetfAuth ? Flags.TrustSetFlags.SET_F_AUTH.getValue() : 0L) |
-        (tfSetNoRipple ? Flags.TrustSetFlags.SET_NO_RIPPLE.getValue() : 0L) |
-        (tfClearNoRipple ? Flags.TrustSetFlags.CLEAR_NO_RIPPLE.getValue() : 0L) |
-        (tfSetFreeze ? Flags.TrustSetFlags.SET_FREEZE.getValue() : 0L) |
-        (tfClearFreeze ? Flags.TrustSetFlags.CLEAR_FREEZE.getValue() : 0L);
-  }
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
+  public static Stream<Arguments> data() {
     return getBooleanCombinations(6);
   }
 
-  @Test
-  public void testFlagsConstructionWithIndividualFlags() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testFlagsConstructionWithIndividualFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfSetfAuth,
+    boolean tfSetNoRipple,
+    boolean tfClearNoRipple,
+    boolean tfSetFreeze,
+    boolean tfClearFreeze
+  ) {
     Flags.TrustSetFlags.Builder builder = Flags.TrustSetFlags.builder()
         .tfFullyCanonicalSig(tfFullyCanonicalSig)
         .tfSetfAuth(tfSetfAuth);
@@ -82,11 +47,35 @@ public class TrustSetFlagsTests extends AbstractFlagsTest {
 
     Flags.TrustSetFlags flags = builder.build();
 
+    long expectedFlags = getExpectedFlags(
+      tfFullyCanonicalSig,
+      tfSetfAuth,
+      tfSetNoRipple,
+      tfClearNoRipple,
+      tfSetFreeze,
+      tfClearFreeze
+    );
     assertThat(flags.getValue()).isEqualTo(expectedFlags);
   }
 
-  @Test
-  public void testDeriveIndividualFlagsFromFlags() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDeriveIndividualFlagsFromFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfSetfAuth,
+    boolean tfSetNoRipple,
+    boolean tfClearNoRipple,
+    boolean tfSetFreeze,
+    boolean tfClearFreeze
+  ) {
+    long expectedFlags = getExpectedFlags(
+      tfFullyCanonicalSig,
+      tfSetfAuth,
+      tfSetNoRipple,
+      tfClearNoRipple,
+      tfSetFreeze,
+      tfClearFreeze
+    );
     Flags.TrustSetFlags flags = Flags.TrustSetFlags.of(expectedFlags);
 
     assertThat(flags.getValue()).isEqualTo(expectedFlags);
@@ -96,5 +85,21 @@ public class TrustSetFlagsTests extends AbstractFlagsTest {
     assertThat(flags.tfClearNoRipple()).isEqualTo(tfClearNoRipple);
     assertThat(flags.tfSetFreeze()).isEqualTo(tfSetFreeze);
     assertThat(flags.tfClearFreeze()).isEqualTo(tfClearFreeze);
+  }
+
+  private long getExpectedFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfSetfAuth,
+    boolean tfSetNoRipple,
+    boolean tfClearNoRipple,
+    boolean tfSetFreeze,
+    boolean tfClearFreeze
+  ) {
+    return (tfFullyCanonicalSig ? Flags.TrustSetFlags.FULLY_CANONICAL_SIG.getValue() : 0L) |
+      (tfSetfAuth ? Flags.TrustSetFlags.SET_F_AUTH.getValue() : 0L) |
+      (tfSetNoRipple ? Flags.TrustSetFlags.SET_NO_RIPPLE.getValue() : 0L) |
+      (tfClearNoRipple ? Flags.TrustSetFlags.CLEAR_NO_RIPPLE.getValue() : 0L) |
+      (tfSetFreeze ? Flags.TrustSetFlags.SET_FREEZE.getValue() : 0L) |
+      (tfClearFreeze ? Flags.TrustSetFlags.CLEAR_FREEZE.getValue() : 0L);
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/AbstractLedgerIndexTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/AbstractLedgerIndexTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 
-public class AbstractLedgerIndexTest {
+public abstract class AbstractLedgerIndexTest {
 
   @Value.Immutable
   @JsonSerialize(as = ImmutableLedgerIndexContainer.class)

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/LedgerIndexDeserializerTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/LedgerIndexDeserializerTest.java
@@ -1,47 +1,49 @@
 package org.xrpl.xrpl4j.model.jackson.modules;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
 
-class LedgerIndexDeserializerTest extends AbstractLedgerIndexTest {
+public class LedgerIndexDeserializerTest extends AbstractLedgerIndexTest {
 
   private final ObjectMapper objectMapper = ObjectMapperFactory.create();
 
   @Test
-  void deserializeCharacterLedgerIndex() throws JsonProcessingException {
+  public void deserializeCharacterLedgerIndex() throws JsonProcessingException {
     final LedgerIndex current = LedgerIndex.CURRENT;
     final LedgerIndex validated = LedgerIndex.VALIDATED;
     final LedgerIndex closed = LedgerIndex.CLOSED;
-    final LedgerIndex foo = LedgerIndex.of("foo");
+
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      LedgerIndex.of("foo");
+    });
 
     final LedgerIndex currentDeserialized = objectMapper.readValue("\"" + current.value() + "\"", LedgerIndex.class);
     assertThat(currentDeserialized).isEqualTo(current);
 
-    final LedgerIndex validatedDeserialized = objectMapper.readValue("\"" + validated.value() + "\"", LedgerIndex.class);
+    final LedgerIndex validatedDeserialized = objectMapper
+      .readValue("\"" + validated.value() + "\"", LedgerIndex.class);
     assertThat(validatedDeserialized).isEqualTo(validated);
 
     final LedgerIndex closedDeserialized = objectMapper.readValue("\"" + closed.value() + "\"", LedgerIndex.class);
     assertThat(closedDeserialized).isEqualTo(closed);
-
-    final LedgerIndex fooDeserialized = objectMapper.readValue("\"" + foo.value() + "\"", LedgerIndex.class);
-    assertThat(fooDeserialized).isEqualTo(foo);
   }
 
   @Test
-  void deserializeNumericalLedgerIndex() throws JsonProcessingException {
+  public void deserializeNumericalLedgerIndex() throws JsonProcessingException {
     final LedgerIndex ledgerIndex = LedgerIndex.of("1");
 
     final LedgerIndex deserialized = objectMapper.readValue("\"1\"", LedgerIndex.class);
     assertThat(deserialized).isEqualTo(ledgerIndex);
 
     LedgerIndexContainer container = LedgerIndexContainer.of(ledgerIndex);
-    final LedgerIndexContainer deserializedContainer = objectMapper.readValue("{\"ledgerIndex\": 1}", LedgerIndexContainer.class);
+    final LedgerIndexContainer deserializedContainer = objectMapper
+      .readValue("{\"ledgerIndex\": 1}", LedgerIndexContainer.class);
     assertThat(deserializedContainer).isEqualTo(container);
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/LedgerIndexSerializerTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/LedgerIndexSerializerTest.java
@@ -5,20 +5,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
 
-class LedgerIndexSerializerTest extends AbstractLedgerIndexTest {
+public class LedgerIndexSerializerTest extends AbstractLedgerIndexTest {
 
   private final ObjectMapper objectMapper = ObjectMapperFactory.create();
 
   @Test
-  void serializeCharacterLedgerIndex() throws JsonProcessingException {
+  public void serializeCharacterLedgerIndex() throws JsonProcessingException {
     final LedgerIndex current = LedgerIndex.CURRENT;
     final LedgerIndex validated = LedgerIndex.VALIDATED;
     final LedgerIndex closed = LedgerIndex.CLOSED;
-    final LedgerIndex foo = LedgerIndex.of("foo");
+
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      LedgerIndex.of("foo");
+    });
 
     final String currentSerialized = objectMapper.writeValueAsString(current);
     assertThat(currentSerialized).isEqualTo("\"" + current.value() + "\"");
@@ -28,9 +32,6 @@ class LedgerIndexSerializerTest extends AbstractLedgerIndexTest {
 
     final String closedSerialized = objectMapper.writeValueAsString(closed);
     assertThat(closedSerialized).isEqualTo("\"" + closed.value() + "\"");
-
-    final String fooSerialized = objectMapper.writeValueAsString(foo);
-    assertThat(fooSerialized).isEqualTo("\"" + foo.value() + "\"");
   }
 
   @Test

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/AccountRootObjectJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/AccountRootObjectJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.ledger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.Flags;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/CheckObjectJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/CheckObjectJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.ledger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/DepositPreAuthObjectJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/DepositPreAuthObjectJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.ledger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/EscrowObjectJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/EscrowObjectJsonTests.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/LedgerHeaderJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/LedgerHeaderJsonTests.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/OfferObjectJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/OfferObjectJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.ledger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.Flags;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/PayChannelObjectJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/PayChannelObjectJsonTests.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/RippleStateObjectJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/RippleStateObjectJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.ledger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.Flags;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/SignerListObjectJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/ledger/SignerListObjectJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.ledger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.Flags;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/AccountSetTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/AccountSetTests.java
@@ -1,30 +1,26 @@
 package org.xrpl.xrpl4j.model.transactions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class AccountSetTests {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void simpleAccountSet() {
     AccountSet accountSet = AccountSet.builder()
-        .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
-        .fee(XrpCurrencyAmount.ofDrops(12))
-        .sequence(UnsignedInteger.valueOf(5))
-        .domain("6578616D706C652E636F6D")
-        .setFlag(AccountSet.AccountSetFlag.ACCOUNT_TXN_ID)
-        .messageKey("03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB")
-        .transferRate(UnsignedInteger.valueOf(1000000001))
-        .tickSize(UnsignedInteger.valueOf(15))
-        .build();
+      .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+      .fee(XrpCurrencyAmount.ofDrops(12))
+      .sequence(UnsignedInteger.valueOf(5))
+      .domain("6578616D706C652E636F6D")
+      .setFlag(AccountSet.AccountSetFlag.ACCOUNT_TXN_ID)
+      .messageKey("03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB")
+      .transferRate(UnsignedInteger.valueOf(1000000001))
+      .tickSize(UnsignedInteger.valueOf(15))
+      .build();
 
     assertThat(accountSet.transactionType()).isEqualTo(TransactionType.ACCOUNT_SET);
     assertThat(accountSet.account()).isEqualTo(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"));
@@ -33,90 +29,101 @@ public class AccountSetTests {
     assertThat(accountSet.domain()).isNotEmpty().get().isEqualTo("6578616D706C652E636F6D");
     assertThat(accountSet.setFlag()).isNotEmpty().get().isEqualTo(AccountSet.AccountSetFlag.ACCOUNT_TXN_ID);
     assertThat(accountSet.messageKey()).isNotEmpty().get()
-        .isEqualTo("03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB");
+      .isEqualTo("03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB");
     assertThat(accountSet.transferRate()).isNotEmpty().get().isEqualTo(UnsignedInteger.valueOf(1000000001));
   }
 
   @Test
   public void emailHashTooLong() {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("emailHash must be 32 characters (128 bits), but was 33 characters long.");
-    AccountSet.builder()
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> AccountSet.builder()
         .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
         .fee(XrpCurrencyAmount.ofDrops(12))
         .sequence(UnsignedInteger.valueOf(5))
         .emailHash("f9879d71855b5ff21e4963273a886bfc1")
-        .build();
+        .build(),
+      "emailHash must be 32 characters (128 bits), but was 33 characters long."
+    );
+
   }
 
   @Test
   public void transferRateTooLow() {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("transferRate must be between 1,000,000,000 and 2,000,000,000 or equal to 0.");
-    AccountSet.builder()
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> AccountSet.builder()
         .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
         .fee(XrpCurrencyAmount.ofDrops(12))
         .sequence(UnsignedInteger.valueOf(5))
         .transferRate(UnsignedInteger.valueOf(999999999))
-        .build();
+        .build(),
+      "transferRate must be between 1,000,000,000 and 2,000,000,000 or equal to 0."
+    );
   }
 
   @Test
   public void transferRateTooHigh() {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("transferRate must be between 1,000,000,000 and 2,000,000,000 or equal to 0.");
-    AccountSet.builder()
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> AccountSet.builder()
         .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
         .fee(XrpCurrencyAmount.ofDrops(12))
         .sequence(UnsignedInteger.valueOf(5))
         .transferRate(UnsignedInteger.valueOf(2000000001))
-        .build();
+        .build(),
+      "transferRate must be between 1,000,000,000 and 2,000,000,000 or equal to 0."
+    );
   }
 
   @Test
   public void transferRateIsZero() {
     AccountSet accountSet = AccountSet.builder()
-        .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
-        .fee(XrpCurrencyAmount.ofDrops(12))
-        .sequence(UnsignedInteger.valueOf(5))
-        .transferRate(UnsignedInteger.ZERO)
-        .build();
+      .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+      .fee(XrpCurrencyAmount.ofDrops(12))
+      .sequence(UnsignedInteger.valueOf(5))
+      .transferRate(UnsignedInteger.ZERO)
+      .build();
 
     assertThat(accountSet.transferRate()).isNotEmpty().get().isEqualTo(UnsignedInteger.ZERO);
   }
 
   @Test
   public void tickSizeTooLow() {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("tickSize must be between 3 and 15 inclusive or be equal to 0.");
-    AccountSet.builder()
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> AccountSet.builder()
         .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
         .fee(XrpCurrencyAmount.ofDrops(12))
         .sequence(UnsignedInteger.valueOf(5))
         .tickSize(UnsignedInteger.valueOf(2))
-        .build();
+        .build(),
+      "tickSize must be between 3 and 15 inclusive or be equal to 0."
+    );
   }
 
   @Test
   public void tickSizeTooHigh() {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("tickSize must be between 3 and 15 inclusive or be equal to 0.");
-    AccountSet.builder()
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> AccountSet.builder()
         .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
         .fee(XrpCurrencyAmount.ofDrops(12))
         .sequence(UnsignedInteger.valueOf(5))
         .tickSize(UnsignedInteger.valueOf(16))
-        .build();
+        .build(),
+      "tickSize must be between 3 and 15 inclusive or be equal to 0."
+    );
   }
 
   @Test
   public void tickSizeIsZero() {
     AccountSet accountSet = AccountSet.builder()
-        .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
-        .fee(XrpCurrencyAmount.ofDrops(12))
-        .sequence(UnsignedInteger.valueOf(5))
-        .tickSize(UnsignedInteger.ZERO)
-        .build();
+      .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+      .fee(XrpCurrencyAmount.ofDrops(12))
+      .sequence(UnsignedInteger.valueOf(5))
+      .tickSize(UnsignedInteger.ZERO)
+      .build();
 
     assertThat(accountSet.tickSize()).isNotEmpty().get().isEqualTo(UnsignedInteger.ZERO);
   }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/AccountSetTransactionFlagsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/AccountSetTransactionFlagsTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.transactions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.primitives.UnsignedInteger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AccountSetTransactionFlagsTests {
 

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/CheckTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/CheckTests.java
@@ -1,16 +1,12 @@
 package org.xrpl.xrpl4j.model.transactions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.primitives.UnsignedInteger;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class CheckTests {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void checkCashWithAmount() {
@@ -48,34 +44,31 @@ public class CheckTests {
 
   @Test
   public void checkCashWithoutAmountOrDeliverMinThrows() {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(
-        "The CheckCash transaction must include either amount or deliverMin, but not both."
-    );
-
-    CheckCash.builder()
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> CheckCash.builder()
         .account(Address.of("rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy"))
         .checkId(Hash256.of("838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334"))
         .sequence(UnsignedInteger.ONE)
         .fee(XrpCurrencyAmount.ofDrops(12))
-        .build();
+        .build(),
+      "The CheckCash transaction must include either amount or deliverMin, but not both."
+    );
   }
 
   @Test
   public void checkCashWithAmountAndDeliverMinThrows() {
-
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(
-        "The CheckCash transaction must include either amount or deliverMin, but not both."
-    );
-
-    CheckCash.builder()
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> CheckCash.builder()
         .account(Address.of("rfkE1aSy9G8Upk4JssnwBxhEv5p4mn2KTy"))
         .checkId(Hash256.of("838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334"))
         .sequence(UnsignedInteger.ONE)
         .fee(XrpCurrencyAmount.ofDrops(12))
         .amount(XrpCurrencyAmount.ofDrops(100))
         .deliverMin(XrpCurrencyAmount.ofDrops(100))
-        .build();
+        .build(),
+      "The CheckCash transaction must include either amount or deliverMin, but not both."
+    );
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/DepositPreAuthTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/DepositPreAuthTests.java
@@ -1,16 +1,12 @@
 package org.xrpl.xrpl4j.model.transactions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.primitives.UnsignedInteger;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class DepositPreAuthTests {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void depositPreAuthWithAuthorize() {
@@ -42,31 +38,30 @@ public class DepositPreAuthTests {
 
   @Test
   public void depositPreAuthWithoutAuthorizeOrUnauthorizeThrows() {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(
-        "The DepositPreAuth transaction must include either Authorize or Unauthorize, but not both."
-    );
-
-    DepositPreAuth.builder()
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> DepositPreAuth.builder()
         .account(Address.of("rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8"))
         .fee(XrpCurrencyAmount.ofDrops(10))
         .sequence(UnsignedInteger.valueOf(2))
-        .build();
+        .build(),
+      "The DepositPreAuth transaction must include either Authorize or Unauthorize, but not both."
+    );
   }
 
   @Test
   public void depositPreAuthWithAuthorizeAndUnauthorizeThrows() {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(
-        "The DepositPreAuth transaction must include either Authorize or Unauthorize, but not both."
-    );
-
-    DepositPreAuth.builder()
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> DepositPreAuth.builder()
         .account(Address.of("rsUiUMpnrgxQp24dJYZDhmV4bE3aBtQyt8"))
         .fee(XrpCurrencyAmount.ofDrops(10))
         .sequence(UnsignedInteger.valueOf(2))
         .authorize(Address.of("rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de"))
         .unauthorize(Address.of("rEhxGqkqPPSxQ3P25J66ft5TwpzV14k2de"))
-        .build();
+        .build(),
+      "The DepositPreAuth transaction must include either Authorize or Unauthorize, but not both."
+    );
+
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/EscrowCreateTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/EscrowCreateTest.java
@@ -1,18 +1,16 @@
 package org.xrpl.xrpl4j.model.transactions;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link EscrowCreate}.
  */
 public class EscrowCreateTest {
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testWithNeitherCancelNorFinish() {
@@ -27,12 +25,9 @@ public class EscrowCreateTest {
 
   @Test
   public void testCancelBeforeFinish() {
-    expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage(
-        "If both CancelAfter and FinishAfter are specified, the FinishAfter time must be before the CancelAfter time."
-    );
-
-    EscrowCreate.builder()
+    assertThrows(
+      IllegalStateException.class,
+      () -> EscrowCreate.builder()
         .sequence(UnsignedInteger.ONE)
         .fee(XrpCurrencyAmount.ofDrops(1))
         .account(Address.of("account"))
@@ -40,7 +35,9 @@ public class EscrowCreateTest {
         .destination(Address.of("destination"))
         .cancelAfter(UnsignedLong.ONE)
         .finishAfter(UnsignedLong.valueOf(2L))
-        .build();
+        .build(),
+      "If both CancelAfter and FinishAfter are specified, the FinishAfter time must be before the CancelAfter time."
+    );
   }
 
   @Test
@@ -58,12 +55,9 @@ public class EscrowCreateTest {
 
   @Test
   public void testCancelEqualsFinish() {
-    expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage(
-        "If both CancelAfter and FinishAfter are specified, the FinishAfter time must be before the CancelAfter time."
-    );
-
-    EscrowCreate.builder()
+    assertThrows(
+      IllegalStateException.class,
+      () -> EscrowCreate.builder()
         .sequence(UnsignedInteger.ONE)
         .fee(XrpCurrencyAmount.ofDrops(1))
         .account(Address.of("account"))
@@ -71,7 +65,9 @@ public class EscrowCreateTest {
         .destination(Address.of("destination"))
         .cancelAfter(UnsignedLong.ONE)
         .finishAfter(UnsignedLong.ONE)
-        .build();
+        .build(),
+      "The DepositPreAuth transaction must include either Authorize or Unauthorize, but not both."
+    );
   }
 
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/EscrowFinishTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/EscrowFinishTest.java
@@ -1,22 +1,18 @@
 package org.xrpl.xrpl4j.model.transactions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.primitives.UnsignedInteger;
 import com.ripple.cryptoconditions.Fulfillment;
 import com.ripple.cryptoconditions.PreimageSha256Fulfillment;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.transactions.ImmutableEscrowFinish.Builder;
 
 /**
  * Unit tests for {@link EscrowFinish}.
  */
 public class EscrowFinishTest {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testNormalizeWithNoFulfillmentNoCondition() {
@@ -39,40 +35,38 @@ public class EscrowFinishTest {
 
   @Test
   public void testNormalizeWithFulfillmentNoCondition() {
-    expectedException.expect(IllegalStateException.class);
-    expectedException
-        .expectMessage("If a fulfillment is specified, the corresponding condition must also be specified.");
-
     Fulfillment fulfillment = PreimageSha256Fulfillment.from("ssh".getBytes());
 
-    EscrowFinish.builder()
+    assertThrows(
+      IllegalStateException.class,
+      () -> EscrowFinish.builder()
         .fee(XrpCurrencyAmount.ofDrops(1))
         .account(Address.of("account"))
         .sequence(UnsignedInteger.ONE)
         .owner(Address.of("owner"))
         .offerSequence(UnsignedInteger.ZERO)
         .fulfillment(fulfillment)
-        .build();
-
+        .build(),
+      "If a fulfillment is specified, the corresponding condition must also be specified."
+    );
   }
 
   @Test
   public void testNormalizeWithNoFulfillmentAndCondition() {
-    expectedException.expect(IllegalStateException.class);
-    expectedException
-        .expectMessage("If a condition is specified, the corresponding fulfillment must also be specified.");
-
     Fulfillment fulfillment = PreimageSha256Fulfillment.from("ssh".getBytes());
 
-    EscrowFinish.builder()
+    assertThrows(
+      IllegalStateException.class,
+      () -> EscrowFinish.builder()
         .fee(XrpCurrencyAmount.ofDrops(1))
         .account(Address.of("account"))
         .sequence(UnsignedInteger.ONE)
         .owner(Address.of("owner"))
         .offerSequence(UnsignedInteger.ZERO)
         .condition(fulfillment.getDerivedCondition())
-        .build();
-
+        .build(),
+      "If a condition is specified, the corresponding fulfillment must also be specified."
+    );
   }
 
   @Test
@@ -104,11 +98,11 @@ public class EscrowFinishTest {
 
   @Test
   public void testNormalizeWithFeeTooLow() {
-    expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage("If a fulfillment is specified, the fee must be set to 330 or greater.");
-
     Fulfillment fulfillment = PreimageSha256Fulfillment.from("ssh".getBytes());
-    EscrowFinish.builder()
+
+    assertThrows(
+      IllegalStateException.class,
+      () -> EscrowFinish.builder()
         .fee(XrpCurrencyAmount.ofDrops(1))
         .account(Address.of("account"))
         .sequence(UnsignedInteger.ONE)
@@ -116,7 +110,9 @@ public class EscrowFinishTest {
         .offerSequence(UnsignedInteger.ZERO)
         .fulfillment(fulfillment)
         .condition(fulfillment.getDerivedCondition())
-        .build();
+        .build(),
+      "If a fulfillment is specified, the fee must be set to 330 or greater."
+    );
   }
 
   @Test

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/Hash256Test.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/Hash256Test.java
@@ -2,7 +2,7 @@ package org.xrpl.xrpl4j.model.transactions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link Hash256}.

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/PaymentChannelTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/PaymentChannelTests.java
@@ -4,14 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class PaymentChannelTests {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void createWithoutCancelAfterOrDestinationTag() {

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/PaymentTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/PaymentTest.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.transactions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.primitives.UnsignedInteger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link Payment}.

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/AccountDeleteJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/AccountDeleteJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.transactions.json;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.AccountDelete;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/AccountSetJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/AccountSetJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.transactions.json;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.AccountSet;
 import org.xrpl.xrpl4j.model.transactions.AccountSet.AccountSetFlag;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/CheckJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/CheckJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.transactions.json;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.CheckCancel;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/EscrowJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/EscrowJsonTests.java
@@ -1,5 +1,7 @@
 package org.xrpl.xrpl4j.model.transactions.json;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.UnsignedInteger;
@@ -8,9 +10,7 @@ import com.ripple.cryptoconditions.CryptoConditionReader;
 import com.ripple.cryptoconditions.PreimageSha256Fulfillment;
 import com.ripple.cryptoconditions.der.DerEncodingException;
 import org.json.JSONException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.EscrowCancel;
@@ -19,9 +19,6 @@ import org.xrpl.xrpl4j.model.transactions.EscrowFinish;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
 public class EscrowJsonTests extends AbstractJsonTest {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testEscrowCreateJson() throws JsonProcessingException, JSONException, DerEncodingException {
@@ -112,11 +109,9 @@ public class EscrowJsonTests extends AbstractJsonTest {
 
   @Test
   public void testEscrowFinishJsonWithFeeTooLow() {
-
-    expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage("If a fulfillment is specified, the fee must be set to 330 or greater.");
-
-    EscrowFinish.builder()
+    assertThrows(
+      IllegalStateException.class,
+      () -> EscrowFinish.builder()
         .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
         .fee(XrpCurrencyAmount.ofDrops(3))
         .sequence(UnsignedInteger.ONE)
@@ -124,6 +119,8 @@ public class EscrowJsonTests extends AbstractJsonTest {
         .offerSequence(UnsignedInteger.valueOf(7))
         .condition(PreimageSha256Fulfillment.from(new byte[48]).getDerivedCondition())
         .fulfillment(PreimageSha256Fulfillment.from(new byte[60]))
-        .build();
+        .build(),
+      "If a fulfillment is specified, the fee must be set to 330 or greater."
+    );
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/OfferJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/OfferJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.transactions.json;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.OfferCancel;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/PaymentChannelJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/PaymentChannelJsonTests.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.Flags;
 import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/PaymentFlagsJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/PaymentFlagsJsonTests.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.assertj.core.util.Lists;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.Flags.PaymentFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/SetRegularKeyJsonTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/SetRegularKeyJsonTest.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.transactions.json;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.SetRegularKey;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/SignerListSetJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/SignerListSetJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.transactions.json;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.ledger.SignerEntry;
 import org.xrpl.xrpl4j.model.ledger.SignerEntryWrapper;

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/TrustSetJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/TrustSetJsonTests.java
@@ -3,7 +3,7 @@ package org.xrpl.xrpl4j.model.transactions.json;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.Flags;
 import org.xrpl.xrpl4j.model.transactions.Address;


### PR DESCRIPTION
For some reason we have a mix of Junit4 and Junit5 Jupiter tests throughout the codebase. This removes the Junit4 dependency and migrates all Junit4 tests to Junit5.

This should supercede #124 