### PR TITLE
Provide non-optional `engine_result`, `engine_result_code`, and `engine_result_message` in `SubmitResult` and `SubmitMultisignedResult`

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountSetIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountSetIT.java
@@ -50,12 +50,12 @@ public class AccountSetIT extends AbstractIT {
       .build();
 
     SubmitResult<AccountSet> response = xrplClient.submit(wallet, accountSet);
+    assertThat(response.result()).isEqualTo("tesSUCCESS");
     assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(response.transactionResult().hash());
     logger.info(
       "AccountSet transaction successful: https://testnet.xrpl.org/transactions/" + response.transactionResult().hash()
     );
-    assertThat(response.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
 
     ///////////////////////
     // Set flags one-by-one
@@ -109,7 +109,7 @@ public class AccountSetIT extends AbstractIT {
       .build();
 
     SubmitResult<AccountSet> response = xrplClient.submit(wallet, accountSet);
-    assertThat(response.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(response.result()).isEqualTo("tesSUCCESS");
     assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(response.transactionResult().hash());
     logger.info(
@@ -145,7 +145,7 @@ public class AccountSetIT extends AbstractIT {
       .signingPublicKey(wallet.publicKey())
       .build();
     SubmitResult<AccountSet> response = xrplClient.submit(wallet, accountSet);
-    assertThat(response.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(response.result()).isEqualTo("tesSUCCESS");
     assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(response.transactionResult().hash());
     logger.info(

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
@@ -127,8 +127,7 @@ public class AccountTransactionsIT {
 
     Hash256 validatedLedgerHash = ledger.ledgerHash()
       .orElseThrow(() -> new RuntimeException("ledgerHash not present."));
-    LedgerIndex validatedLedgerIndex = ledger.ledgerIndex()
-      .orElseThrow(() -> new RuntimeException("ledgerIndex not present."));
+    LedgerIndex validatedLedgerIndex = ledger.ledgerIndexSafe();
 
     AccountTransactionsResult resultByLedgerIndex = getAccountTransactions(
       AccountTransactionsRequestParams.builder()

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/CheckIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/CheckIT.java
@@ -49,7 +49,7 @@ public class CheckIT extends AbstractIT {
       .build();
 
     SubmitResult<CheckCreate> response = xrplClient.submit(sourceWallet, checkCreate);
-    assertThat(response.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(response.result()).isEqualTo("tesSUCCESS");
     assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(response.transactionResult().hash());
     logger.info(
@@ -83,7 +83,7 @@ public class CheckIT extends AbstractIT {
       .signingPublicKey(destinationWallet.publicKey())
       .build();
     SubmitResult<CheckCash> cashResponse = xrplClient.submit(destinationWallet, checkCash);
-    assertThat(cashResponse.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(cashResponse.result()).isEqualTo("tesSUCCESS");
     assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(response.transactionResult().hash());
     logger.info(
@@ -138,7 +138,7 @@ public class CheckIT extends AbstractIT {
       .build();
 
     SubmitResult<CheckCreate> response = xrplClient.submit(sourceWallet, checkCreate);
-    assertThat(response.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(response.result()).isEqualTo("tesSUCCESS");
     assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(response.transactionResult().hash());
     logger.info(
@@ -169,7 +169,7 @@ public class CheckIT extends AbstractIT {
       .build();
 
     SubmitResult<CheckCancel> cancelResult = xrplClient.submit(sourceWallet, checkCancel);
-    assertThat(cancelResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(cancelResult.result()).isEqualTo("tesSUCCESS");
     assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(response.transactionResult().hash());
     logger.info(
@@ -215,7 +215,7 @@ public class CheckIT extends AbstractIT {
     // Poll the ledger for the source wallet's account objects, and validate that the created Check makes
     // it into the ledger
     SubmitResult<CheckCreate> response = xrplClient.submit(sourceWallet, checkCreate);
-    assertThat(response.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(response.result()).isEqualTo("tesSUCCESS");
     assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(response.transactionResult().hash());
     logger.info(
@@ -246,7 +246,7 @@ public class CheckIT extends AbstractIT {
       .build();
 
     SubmitResult<CheckCancel> cancelResult = xrplClient.submit(destinationWallet, checkCancel);
-    assertThat(cancelResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(cancelResult.result()).isEqualTo("tesSUCCESS");
     assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(response.transactionResult().hash());
     logger.info(

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/DepositPreAuthIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/DepositPreAuthIT.java
@@ -45,7 +45,7 @@ public class DepositPreAuthIT extends AbstractIT {
       .build();
 
     SubmitResult<DepositPreAuth> result = xrplClient.submit(receiverWallet, depositPreAuth);
-    assertThat(result.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(result.result()).isEqualTo("tesSUCCESS");
     assertThat(result.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(result.transactionResult().hash());
     logger.info("DepositPreauth transaction successful. https://testnet.xrpl.org/transactions/{}",
@@ -87,7 +87,7 @@ public class DepositPreAuthIT extends AbstractIT {
       .build();
 
     SubmitResult<Payment> paymentResult = xrplClient.submit(senderWallet, payment);
-    assertThat(result.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(result.result()).isEqualTo("tesSUCCESS");
     assertThat(result.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(result.transactionResult().hash());
     logger.info("Payment transaction successful. https://testnet.xrpl.org/transactions/{}",
@@ -153,7 +153,7 @@ public class DepositPreAuthIT extends AbstractIT {
     /////////////////////////
     // And validate that the transaction failed with a tecNO_PERMISSION error code
     SubmitResult<Payment> paymentResult = xrplClient.submit(senderWallet, payment);
-    assertThat(paymentResult.engineResult()).isNotEmpty().get().isEqualTo("tecNO_PERMISSION");
+    assertThat(paymentResult.result()).isEqualTo("tecNO_PERMISSION");
   }
 
   @Test
@@ -218,7 +218,7 @@ public class DepositPreAuthIT extends AbstractIT {
       .build();
 
     SubmitResult<AccountSet> accountSetResult = xrplClient.submit(wallet, accountSet);
-    assertThat(accountSetResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(accountSetResult.result()).isEqualTo("tesSUCCESS");
     assertThat(accountSetResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(accountSetResult.transactionResult().hash());
     logger.info("AccountSet to enable Deposit Preauth successful. https://testnet.xrpl.org/transactions/{}",

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/EscrowIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/EscrowIT.java
@@ -56,7 +56,7 @@ public class EscrowIT extends AbstractIT {
     //////////////////////
     // Submit the EscrowCreate transaction and validate that it was successful
     SubmitResult<EscrowCreate> createResult = xrplClient.submit(senderWallet, escrowCreate);
-    assertThat(createResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(createResult.result()).isEqualTo("tesSUCCESS");
     assertThat(createResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(createResult.transactionResult().hash());
     logger.info(
@@ -101,7 +101,7 @@ public class EscrowIT extends AbstractIT {
       .build();
 
     SubmitResult<EscrowFinish> finishResult = xrplClient.submit(receiverWallet, escrowFinish);
-    assertThat(finishResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(finishResult.result()).isEqualTo("tesSUCCESS");
     assertThat(finishResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(finishResult.transactionResult().hash());
     logger.info(
@@ -160,7 +160,7 @@ public class EscrowIT extends AbstractIT {
     //////////////////////
     // Submit the EscrowCreate transaction and validate that it was successful
     SubmitResult<EscrowCreate> createResult = xrplClient.submit(senderWallet, escrowCreate);
-    assertThat(createResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(createResult.result()).isEqualTo("tesSUCCESS");
     assertThat(createResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(createResult.transactionResult().hash());
     logger.info(
@@ -211,7 +211,7 @@ public class EscrowIT extends AbstractIT {
       .build();
 
     SubmitResult<EscrowCancel> cancelResult = xrplClient.submit(senderWallet, escrowCancel);
-    assertThat(cancelResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(cancelResult.result()).isEqualTo("tesSUCCESS");
     assertThat(cancelResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(cancelResult.transactionResult().hash());
     logger.info(
@@ -272,7 +272,7 @@ public class EscrowIT extends AbstractIT {
     //////////////////////
     // Submit the EscrowCreate transaction and validate that it was successful
     SubmitResult<EscrowCreate> createResult = xrplClient.submit(senderWallet, escrowCreate);
-    assertThat(createResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(createResult.result()).isEqualTo("tesSUCCESS");
     assertThat(createResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(createResult.transactionResult().hash());
     logger.info(
@@ -323,7 +323,7 @@ public class EscrowIT extends AbstractIT {
       .build();
 
     SubmitResult<EscrowFinish> finishResult = xrplClient.submit(receiverWallet, escrowFinish);
-    assertThat(finishResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(finishResult.result()).isEqualTo("tesSUCCESS");
     assertThat(finishResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(finishResult.transactionResult().hash());
     logger.info(
@@ -385,7 +385,7 @@ public class EscrowIT extends AbstractIT {
     //////////////////////
     // Submit the EscrowCreate transaction and validate that it was successful
     SubmitResult<EscrowCreate> createResult = xrplClient.submit(senderWallet, escrowCreate);
-    assertThat(createResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(createResult.result()).isEqualTo("tesSUCCESS");
     assertThat(createResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(createResult.transactionResult().hash());
     logger.info(
@@ -427,7 +427,7 @@ public class EscrowIT extends AbstractIT {
       .build();
 
     SubmitResult<EscrowCancel> cancelResult = xrplClient.submit(senderWallet, escrowCancel);
-    assertThat(cancelResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(cancelResult.result()).isEqualTo("tesSUCCESS");
     assertThat(cancelResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(cancelResult.transactionResult().hash());
     logger.info(

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IssuedCurrencyIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IssuedCurrencyIT.java
@@ -6,8 +6,11 @@ import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
+import org.xrpl.xrpl4j.model.client.accounts.AccountCurrenciesRequestParams;
+import org.xrpl.xrpl4j.model.client.accounts.AccountCurrenciesResult;
 import org.xrpl.xrpl4j.model.client.accounts.AccountInfoResult;
 import org.xrpl.xrpl4j.model.client.accounts.TrustLine;
+import org.xrpl.xrpl4j.model.client.common.LedgerSpecifier;
 import org.xrpl.xrpl4j.model.client.fees.FeeResult;
 import org.xrpl.xrpl4j.model.client.transactions.SubmitResult;
 import org.xrpl.xrpl4j.model.transactions.AccountSet;
@@ -56,6 +59,20 @@ public class IssuedCurrencyIT extends AbstractIT {
       linesResult -> linesResult.lines().stream()
         .anyMatch(line -> line.balance().equals("-" + trustLine.limitPeer()))
     );
+
+    ///////////////////////////
+    // We can also retrieve the currencies that the counterparty can send/recieve using the accountCurrencies
+    // method.
+    AccountCurrenciesResult counterpartyCurrencies = xrplClient.accountCurrencies(
+      AccountCurrenciesRequestParams.builder()
+        .account(counterpartyWallet.classicAddress())
+        .ledgerSpecifier(LedgerSpecifier.CURRENT)
+        .build()
+    );
+
+    assertThat(counterpartyCurrencies.sendCurrencies()).asList().containsOnly(xrpl4jCoin);
+    assertThat(counterpartyCurrencies.ledgerCurrentIndex()).isNotEmpty().get()
+      .isEqualTo(counterpartyCurrencies.ledgerCurrentIndexSafe());
   }
 
   @Test

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IssuedCurrencyIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IssuedCurrencyIT.java
@@ -133,7 +133,7 @@ public class IssuedCurrencyIT extends AbstractIT {
       .build();
 
     SubmitResult<Payment> paymentResult = xrplClient.submit(aliceWallet, aliceToBobPayment);
-    assertThat(paymentResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(paymentResult.result()).isEqualTo("tesSUCCESS");
     assertThat(paymentResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(paymentResult.transactionResult().hash());
     logger.info(
@@ -278,7 +278,7 @@ public class IssuedCurrencyIT extends AbstractIT {
       .build();
 
     SubmitResult<Payment> paymentResult = xrplClient.submit(charlieWallet, charlieToDanielPayment);
-    assertThat(paymentResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(paymentResult.result()).isEqualTo("tesSUCCESS");
     assertThat(paymentResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(paymentResult.transactionResult().hash());
     logger.info(
@@ -336,7 +336,7 @@ public class IssuedCurrencyIT extends AbstractIT {
       .build();
 
     SubmitResult<AccountSet> setResult = xrplClient.submit(issuerWallet, setDefaultRipple);
-    assertThat(setResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(setResult.result()).isEqualTo("tesSUCCESS");
     assertThat(setResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(setResult.transactionResult().hash());
     logger.info(
@@ -388,7 +388,7 @@ public class IssuedCurrencyIT extends AbstractIT {
       .build();
 
     SubmitResult<Payment> paymentResult = xrplClient.submit(issuerWallet, fundCounterparty);
-    assertThat(paymentResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(paymentResult.result()).isEqualTo("tesSUCCESS");
     assertThat(paymentResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(paymentResult.transactionResult().hash());
     logger.info(
@@ -441,7 +441,7 @@ public class IssuedCurrencyIT extends AbstractIT {
       .build();
 
     SubmitResult<TrustSet> trustSetSubmitResult = xrplClient.submit(counterpartyWallet, trustSet);
-    assertThat(trustSetSubmitResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(trustSetSubmitResult.result()).isEqualTo("tesSUCCESS");
     assertThat(trustSetSubmitResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(trustSetSubmitResult.transactionResult().hash());
     logger.info(

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/LedgerResultIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/LedgerResultIT.java
@@ -1,6 +1,7 @@
 package org.xrpl.xrpl4j.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
@@ -19,11 +20,15 @@ public class LedgerResultIT extends AbstractIT {
   void getValidatedLedgerResult() throws JsonRpcClientErrorException {
     final LedgerResult ledgerResult = xrplClient.ledger(LedgerRequestParams.builder()
       .ledgerSpecifier(LedgerSpecifier.VALIDATED)
-      .ledgerSpecifier(LedgerSpecifier.VALIDATED)
       .build());
-    assertThat(ledgerResult.ledgerIndex()).isNotEmpty();
-    assertThat(ledgerResult.ledgerHash()).isNotEmpty();
+
+    assertThat(ledgerResult.ledgerIndex()).isNotEmpty().get().isEqualTo(ledgerResult.ledgerIndexSafe());
+    assertThat(ledgerResult.ledgerHash()).isNotEmpty().get().isEqualTo(ledgerResult.ledgerHashSafe());
     assertThat(ledgerResult.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      ledgerResult::ledgerCurrentIndexSafe
+    );
     assertThat(ledgerResult.ledger().closeTimeHuman()).isNotEmpty();
     assertThat(ledgerResult.ledger().parentCloseTime()).isNotEmpty();
   }
@@ -33,9 +38,18 @@ public class LedgerResultIT extends AbstractIT {
     final LedgerResult ledgerResult = xrplClient.ledger(LedgerRequestParams.builder()
       .ledgerSpecifier(LedgerSpecifier.CURRENT)
       .build());
+
     assertThat(ledgerResult.ledgerIndex()).isEmpty();
     assertThat(ledgerResult.ledgerHash()).isEmpty();
-    assertThat(ledgerResult.ledgerCurrentIndex()).isNotEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      ledgerResult::ledgerHashSafe
+    );
+    assertThrows(
+      IllegalStateException.class,
+      ledgerResult::ledgerIndexSafe
+    );
+    assertThat(ledgerResult.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(ledgerResult.ledgerCurrentIndexSafe());
     assertThat(ledgerResult.ledger().closeTimeHuman()).isEmpty();
     assertThat(ledgerResult.ledger().parentCloseTime()).isEmpty();
   }
@@ -45,9 +59,14 @@ public class LedgerResultIT extends AbstractIT {
     final LedgerResult ledgerResult = xrplClient.ledger(LedgerRequestParams.builder()
       .ledgerSpecifier(LedgerSpecifier.CLOSED)
       .build());
-    assertThat(ledgerResult.ledgerIndex()).isNotEmpty();
-    assertThat(ledgerResult.ledgerHash()).isNotEmpty();
+
+    assertThat(ledgerResult.ledgerIndex()).isNotEmpty().get().isEqualTo(ledgerResult.ledgerIndexSafe());
+    assertThat(ledgerResult.ledgerHash()).isNotEmpty().get().isEqualTo(ledgerResult.ledgerHashSafe());
     assertThat(ledgerResult.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      ledgerResult::ledgerCurrentIndexSafe
+    );
     assertThat(ledgerResult.ledger().closeTimeHuman()).isNotEmpty();
     assertThat(ledgerResult.ledger().parentCloseTime()).isNotEmpty();
   }

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/OfferIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/OfferIT.java
@@ -76,7 +76,7 @@ public class OfferIT extends AbstractIT {
     assertThat(response.transactionResult().transaction().flags().tfFullyCanonicalSig()).isTrue();
     assertThat(response.transactionResult().transaction().flags().tfSell()).isTrue();
 
-    assertThat(response.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(response.result()).isEqualTo("tesSUCCESS");
     assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(response.transactionResult().hash());
     logger.info(
@@ -125,7 +125,7 @@ public class OfferIT extends AbstractIT {
     assertThat(response.transactionResult().transaction().flags().tfFullyCanonicalSig()).isTrue();
     assertThat(response.transactionResult().transaction().flags().tfSell()).isTrue();
 
-    assertThat(response.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(response.result()).isEqualTo("tesSUCCESS");
     assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(response.transactionResult().hash());
     logger.info(
@@ -167,7 +167,7 @@ public class OfferIT extends AbstractIT {
       .build();
 
     SubmitResult<OfferCancel> cancelResponse = xrplClient.submit(purchaser, offerCancel);
-    assertThat(cancelResponse.engineResult()).isNotEmpty().get().isEqualTo(expectedResult);
+    assertThat(cancelResponse.result()).isEqualTo(expectedResult);
 
     assertEmptyResults(() -> this.getValidatedAccountObjects(purchaser.classicAddress(), OfferObject.class));
     assertEmptyResults(() -> this.getValidatedAccountObjects(purchaser.classicAddress(), RippleStateObject.class));
@@ -209,7 +209,7 @@ public class OfferIT extends AbstractIT {
       .build();
 
     SubmitResult<OfferCreate> response = xrplClient.submit(purchaser, offerCreate);
-    assertThat(response.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(response.result()).isEqualTo("tesSUCCESS");
     logger.info(
       "OfferCreate transaction successful: https://testnet.xrpl.org/transactions/{}",
       response.transactionResult().hash()
@@ -265,7 +265,7 @@ public class OfferIT extends AbstractIT {
       .build();
 
     SubmitResult<OfferCreate> response = xrplClient.submit(purchaser, offerCreate);
-    assertThat(response.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(response.result()).isEqualTo("tesSUCCESS");
     assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(response.transactionResult().hash());
     logger.info(

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/PaymentChannelIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/PaymentChannelIT.java
@@ -64,7 +64,7 @@ public class PaymentChannelIT extends AbstractIT {
     //////////////////////////
     // Validate that the transaction was submitted successfully
     SubmitResult<PaymentChannelCreate> createResult = xrplClient.submit(sourceWallet, createPaymentChannel);
-    assertThat(createResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(createResult.result()).isEqualTo("tesSUCCESS");
     assertThat(createResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(createResult.transactionResult().hash());
     logger.info("PaymentChannelCreate transaction successful. https://testnet.xrpl.org/transactions/{}",
@@ -150,7 +150,7 @@ public class PaymentChannelIT extends AbstractIT {
     //////////////////////////
     // Validate that the transaction was submitted successfully
     SubmitResult<PaymentChannelCreate> createResult = xrplClient.submit(sourceWallet, createPaymentChannel);
-    assertThat(createResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(createResult.result()).isEqualTo("tesSUCCESS");
     assertThat(createResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(createResult.transactionResult().hash());
     logger.info("PaymentChannelCreate transaction successful. https://testnet.xrpl.org/transactions/{}",
@@ -221,7 +221,7 @@ public class PaymentChannelIT extends AbstractIT {
       .build();
 
     SubmitResult<PaymentChannelClaim> claimResult = xrplClient.submit(destinationWallet, signedClaim);
-    assertThat(claimResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(claimResult.result()).isEqualTo("tesSUCCESS");
     assertThat(claimResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(claimResult.transactionResult().hash());
     logger.info("PaymentChannelClaim transaction successful. https://testnet.xrpl.org/transactions/{}",
@@ -270,7 +270,7 @@ public class PaymentChannelIT extends AbstractIT {
     //////////////////////////
     // Validate that the transaction was submitted successfully
     SubmitResult<PaymentChannelCreate> createResult = xrplClient.submit(sourceWallet, createPaymentChannel);
-    assertThat(createResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(createResult.result()).isEqualTo("tesSUCCESS");
     assertThat(createResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(createResult.transactionResult().hash());
     logger.info("PaymentChannelCreate transaction successful. https://testnet.xrpl.org/transactions/{}",
@@ -307,7 +307,7 @@ public class PaymentChannelIT extends AbstractIT {
     //////////////////////////
     // Validate that the transaction was submitted successfully
     SubmitResult<PaymentChannelFund> fundResult = xrplClient.submit(sourceWallet, addFunds);
-    assertThat(fundResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(fundResult.result()).isEqualTo("tesSUCCESS");
     assertThat(fundResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(fundResult.transactionResult().hash());
     logger.info("PaymentChannelFund transaction successful. https://testnet.xrpl.org/transactions/{}",
@@ -346,7 +346,7 @@ public class PaymentChannelIT extends AbstractIT {
     //////////////////////////
     // Validate that the transaction was submitted successfully
     SubmitResult<PaymentChannelFund> expiryResult = xrplClient.submit(sourceWallet, setExpiry);
-    assertThat(expiryResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(expiryResult.result()).isEqualTo("tesSUCCESS");
     assertThat(expiryResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(expiryResult.transactionResult().hash());
     logger.info("PaymentChannelFund transaction successful. https://testnet.xrpl.org/transactions/{}",

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SetRegularKeyIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SetRegularKeyIT.java
@@ -41,7 +41,7 @@ public class SetRegularKeyIT extends AbstractIT {
       .build();
 
     SubmitResult<SetRegularKey> setResult = xrplClient.submit(wallet, setRegularKey);
-    assertThat(setResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(setResult.result()).isEqualTo("tesSUCCESS");
     assertThat(setResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(setResult.transactionResult().hash());
     logger.info("SetRegularKey transaction successful. https://testnet.xrpl.org/transactions/{}",
@@ -98,7 +98,7 @@ public class SetRegularKeyIT extends AbstractIT {
       .build();
 
     SubmitResult<SetRegularKey> setResult = xrplClient.submit(wallet, setRegularKey);
-    assertThat(setResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(setResult.result()).isEqualTo("tesSUCCESS");
     assertThat(setResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(setResult.transactionResult().hash());
     logger.info("SetRegularKey transaction successful. https://testnet.xrpl.org/transactions/{}",
@@ -135,7 +135,7 @@ public class SetRegularKeyIT extends AbstractIT {
       .build();
 
     SubmitResult<SetRegularKey> removeResult = xrplClient.submit(wallet, removeRegularKey);
-    assertThat(removeResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(removeResult.result()).isEqualTo("tesSUCCESS");
     assertThat(removeResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(removeResult.transactionResult().hash());
     logger.info("SetRegularKey transaction successful. https://testnet.xrpl.org/transactions/{}",

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SignerListSetIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SignerListSetIT.java
@@ -87,7 +87,7 @@ public class SignerListSetIT extends AbstractIT {
     /////////////////////////////
     // Validate that the transaction was submitted successfully
     SubmitResult<SignerListSet> signerListSetResult = xrplClient.submit(sourceWallet, signerListSet);
-    assertThat(signerListSetResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(signerListSetResult.result()).isEqualTo("tesSUCCESS");
     assertThat(signerListSetResult.transactionResult().transaction().hash()).isNotEmpty().get()
         .isEqualTo(signerListSetResult.transactionResult().hash());
     logger.info(
@@ -159,7 +159,7 @@ public class SignerListSetIT extends AbstractIT {
       .build();
 
     SubmitMultiSignedResult<Payment> paymentResult = xrplClient.submitMultisigned(multiSigPayment);
-    assertThat(paymentResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(paymentResult.result()).isEqualTo("tesSUCCESS");
     assertThat(signerListSetResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(signerListSetResult.transactionResult().hash());
     logger.info(
@@ -216,7 +216,7 @@ public class SignerListSetIT extends AbstractIT {
     ////////////////////////////
     // Validate that the transaction was submitted successfully
     SubmitResult<SignerListSet> signerListSetResult = xrplClient.submit(sourceWallet, signerListSet);
-    assertThat(signerListSetResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(signerListSetResult.result()).isEqualTo("tesSUCCESS");
     assertThat(signerListSetResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(signerListSetResult.transactionResult().hash());
     logger.info(
@@ -254,7 +254,7 @@ public class SignerListSetIT extends AbstractIT {
     /////////////////////////////
     // Submit it and validate that it was successful
     SubmitResult<SignerListSet> signerListDeleteResult = xrplClient.submit(sourceWallet, deleteSignerList);
-    assertThat(signerListDeleteResult.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(signerListDeleteResult.result()).isEqualTo("tesSUCCESS");
     assertThat(signerListSetResult.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(signerListSetResult.transactionResult().hash());
     logger.info(

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SubmitPaymentIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SubmitPaymentIT.java
@@ -100,7 +100,7 @@ public class SubmitPaymentIT extends AbstractIT {
     throws JsonRpcClientErrorException {
     LedgerResult ledger = xrplClient.ledger(
         LedgerRequestParams.builder()
-          .ledgerSpecifier(LedgerSpecifier.of(validatedPayment.ledgerIndex().get()))
+          .ledgerSpecifier(LedgerSpecifier.of(validatedPayment.ledgerIndexSafe()))
           .build()
     );
 

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SubmitPaymentIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SubmitPaymentIT.java
@@ -39,7 +39,7 @@ public class SubmitPaymentIT extends AbstractIT {
       .build();
 
     SubmitResult<Payment> result = xrplClient.submit(sourceWallet, payment);
-    assertThat(result.engineResult()).isNotEmpty().get().isEqualTo(SUCCESS_STATUS);
+    assertThat(result.result()).isEqualTo(SUCCESS_STATUS);
     assertThat(result.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(result.transactionResult().hash());
     logger.info("Payment successful: https://testnet.xrpl.org/transactions/" +
@@ -82,7 +82,7 @@ public class SubmitPaymentIT extends AbstractIT {
       .build();
 
     SubmitResult<Payment> result = xrplClient.submit(senderWallet, payment);
-    assertThat(result.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(result.result()).isEqualTo("tesSUCCESS");
     assertThat(result.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(result.transactionResult().hash());
     logger.info("Payment successful: https://testnet.xrpl.org/transactions/" +

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SubmitPaymentUsingSignatureService.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SubmitPaymentUsingSignatureService.java
@@ -78,7 +78,7 @@ public class SubmitPaymentUsingSignatureService extends AbstractIT {
 
     SignedTransaction<Payment> signedTransaction = signatureService.sign(sourceKeyMetadata, payment);
     SubmitResult<Payment> result = xrplClient.submit(signedTransaction);
-    assertThat(result.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(result.result()).isEqualTo("tesSUCCESS");
     assertThat(result.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(result.transactionResult().hash());
     logger.info(
@@ -111,7 +111,7 @@ public class SubmitPaymentUsingSignatureService extends AbstractIT {
 
     SignedTransaction<Payment> transactionWithSignature = signatureService.sign(sourceKeyMetadata, payment);
     SubmitResult<Payment> result = xrplClient.submit(transactionWithSignature);
-    assertThat(result.engineResult()).isNotEmpty().get().isEqualTo("tesSUCCESS");
+    assertThat(result.result()).isEqualTo("tesSUCCESS");
     assertThat(result.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(result.transactionResult().hash());
     logger.info(

--- a/xrpl4j-model/pom.xml
+++ b/xrpl4j-model/pom.xml
@@ -85,6 +85,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.accounts;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -13,6 +14,7 @@ import org.xrpl.xrpl4j.model.transactions.Marker;
 
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * The result of an account_channels rippled call.
@@ -50,17 +52,78 @@ public interface AccountChannelsResult extends XrplResult {
    * The identifying Hash of the ledger version used to generate this response.
    *
    * @return A {@link Hash256} containing the ledger hash.
+   * @deprecated When requesting Account Channels from a non-validated ledger, the result will not contain this field.
+   *   To prevent this class from throwing an error when requesting Account Channels from a non-validated ledger, this
+   *   field is currently marked as {@link Nullable}. However, this field will be {@link Optional} in a future release.
    */
   @JsonProperty("ledger_hash")
+  @Nullable
+  @Deprecated
   Hash256 ledgerHash();
 
   /**
-   * The Ledger Index of the ledger version used to generate this response.
+   * Get {@link #ledgerHash()}, or throw an {@link IllegalStateException} if {@link #ledgerHash()} is null.
+   *
+   * @return The value of {@link #ledgerHash()}.
+   * @throws IllegalStateException If {@link #ledgerHash()} is null.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return Optional.ofNullable(ledgerHash())
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
+
+  /**
+   * The Ledger Index of the ledger version used to generate this response. Only present in responses to requests
+   * with ledger_index = "validated" or "closed".
    *
    * @return A {@link LedgerIndex}.
+   * @deprecated When requesting Account Channels from a non-validated ledger, the result will not contain this field.
+   *   To prevent this class from throwing an error when requesting Account Channels from a non-validated ledger, this
+   *   field is currently marked as {@link Nullable}. However, this field will be {@link Optional} in a future release.
    */
   @JsonProperty("ledger_index")
+  @Nullable
+  @Deprecated
   LedgerIndex ledgerIndex();
+
+  /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is null.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is null.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return Optional.ofNullable(ledgerIndex())
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
+   * The ledger index of the current open ledger, which was used when retrieving this information. Only present
+   * in responses to requests with ledger_index = "current".
+   *
+   * @return An optionally-present {@link LedgerIndex} representing the current ledger index.
+   */
+  @JsonProperty("ledger_current_index")
+  Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
+
 
   /**
    * If true, the information in this response comes from a validated ledger version.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountCurrenciesResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountCurrenciesResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.accounts;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -10,6 +11,7 @@ import org.xrpl.xrpl4j.model.transactions.Hash256;
 
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * The result of an account_currencies rippled call.
@@ -32,12 +34,66 @@ public interface AccountCurrenciesResult extends XrplResult {
   Optional<Hash256> ledgerHash();
 
   /**
+   * Get {@link #ledgerHash()}, or throw an {@link IllegalStateException} if {@link #ledgerHash()} is empty.
+   *
+   * @return The value of {@link #ledgerHash()}.
+   * @throws IllegalStateException If {@link #ledgerHash()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return ledgerHash()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
+
+  /**
    * The Ledger Index of the ledger version used to generate this response.
    *
    * @return A {@link LedgerIndex}.
+   * @deprecated When requesting Account Channels from a non-validated ledger, the result will not contain this field.
+   *   To prevent this class from throwing an error when requesting Account Currencies from a non-validated ledger, this
+   *   field is currently marked as {@link Nullable}. However, this field will be {@link Optional} in a future release.
    */
+  @Deprecated
+  @Nullable
   @JsonProperty("ledger_index")
   LedgerIndex ledgerIndex();
+
+  /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is null.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is null.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return Optional.ofNullable(ledgerIndex())
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
+   * The ledger index of the current open ledger, which was used when retrieving this information. Only present
+   * in responses to requests with ledger_index = "current".
+   *
+   * @return An optionally-present {@link LedgerIndex} representing the current ledger index.
+   */
+  @JsonProperty("ledger_current_index")
+  Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * If true, the information in this response comes from a validated ledger version.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.accounts;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -36,6 +37,28 @@ public interface AccountInfoResult extends XrplResult {
   AccountRootObject accountData();
 
   /**
+   * (Omitted if ledger_current_index is provided instead) The ledger index of the ledger version used when
+   * retrieving this information. The information does not contain any changes from ledger versions newer than this one.
+   *
+   * @return An optionally-present {@link LedgerIndex}.
+   */
+  @JsonProperty("ledger_index")
+  Optional<LedgerIndex> ledgerIndex();
+
+  /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
    * (Omitted if ledger_index is provided instead) The ledger index of the current in-progress ledger,
    * which was used when retrieving this information.
    *
@@ -45,13 +68,18 @@ public interface AccountInfoResult extends XrplResult {
   Optional<LedgerIndex> ledgerCurrentIndex();
 
   /**
-   * (Omitted if ledger_current_index is provided instead) The ledger index of the ledger version used when
-   * retrieving this information. The information does not contain any changes from ledger versions newer than this one.
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
    *
-   * @return An optionally-present {@link LedgerIndex}.
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
    */
-  @JsonProperty("ledger_index")
-  Optional<LedgerIndex> ledgerIndex();
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * (Omitted unless queue specified as true and querying the current open ledger.)

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.accounts;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -46,12 +47,25 @@ public interface AccountLinesResult extends XrplResult {
   List<TrustLine> lines();
 
   /**
-   * The ledger index of the current open ledger, which was used when retrieving this information.
+   * The identifying hash the ledger version that was used when retrieving this data.
    *
-   * @return An optionally-present {@link LedgerIndex} representing the current ledger index.
+   * @return An optionally-present {@link org.xrpl.xrpl4j.model.transactions.Hash256}.
    */
-  @JsonProperty("ledger_current_index")
-  Optional<LedgerIndex> ledgerCurrentIndex();
+  @JsonProperty("ledger_hash")
+  Optional<Hash256> ledgerHash();
+
+  /**
+   * Get {@link #ledgerHash()}, or throw an {@link IllegalStateException} if {@link #ledgerHash()} is empty.
+   *
+   * @return The value of {@link #ledgerHash()}.
+   * @throws IllegalStateException If {@link #ledgerHash()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return ledgerHash()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
 
   /**
    * The ledger index of the ledger version that was used when retrieving this data.
@@ -62,12 +76,39 @@ public interface AccountLinesResult extends XrplResult {
   Optional<LedgerIndex> ledgerIndex();
 
   /**
-   * The identifying hash the ledger version that was used when retrieving this data.
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
    *
-   * @return An optionally-present {@link org.xrpl.xrpl4j.model.transactions.Hash256}.
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
    */
-  @JsonProperty("ledger_hash")
-  Optional<Hash256> ledgerHash();
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
+   * The ledger index of the current open ledger, which was used when retrieving this information.
+   *
+   * @return An optionally-present {@link LedgerIndex} representing the current ledger index.
+   */
+  @JsonProperty("ledger_current_index")
+  Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * Server-defined value indicating the response is paginated. Pass this to the next call to resume where this

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.accounts;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -57,12 +58,38 @@ public interface AccountObjectsResult extends XrplResult {
   Optional<Hash256> ledgerHash();
 
   /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return ledgerHash()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
+
+  /**
    * The ledger index of the ledger version that was used to generate this {@link AccountObjectsResult}.
    *
    * @return An optionally-present {@link LedgerIndex}.
    */
   @JsonProperty("ledger_index")
   Optional<LedgerIndex> ledgerIndex();
+
+  /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
 
   /**
    * The ledger index of the current in-progress ledger version, which was used to generate this
@@ -72,6 +99,20 @@ public interface AccountObjectsResult extends XrplResult {
    */
   @JsonProperty("ledger_current_index")
   Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * The {@link AccountObjectsRequestParams#limit()} that was used in the corresponding request, if any.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountOffersResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountOffersResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.accounts;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -42,13 +43,25 @@ public interface AccountOffersResult extends XrplResult {
   List<OfferResultObject> offers();
 
   /**
-   * Omitted if ledger_hash or ledger_index provided. The ledger index
-   * of the current in-progress ledger version, which was used when retrieving this data.
+   * The identifying Hash of the ledger version used to generate this response.
    *
-   * @return A {@link LedgerIndex}.
+   * @return A {@link Hash256} containing the ledger hash.
    */
-  @JsonProperty("ledger_current_index")
-  Optional<LedgerIndex> ledgerCurrentIndex();
+  @JsonProperty("ledger_hash")
+  Optional<Hash256> ledgerHash();
+
+  /**
+   * Get {@link #ledgerHash()}, or throw an {@link IllegalStateException} if {@link #ledgerHash()} is empty.
+   *
+   * @return The value of {@link #ledgerHash()}.
+   * @throws IllegalStateException If {@link #ledgerHash()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return ledgerHash()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
 
   /**
    * The Ledger Index of the ledger version used to generate this response.
@@ -59,12 +72,40 @@ public interface AccountOffersResult extends XrplResult {
   Optional<LedgerIndex> ledgerIndex();
 
   /**
-   * The identifying Hash of the ledger version used to generate this response.
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
    *
-   * @return A {@link Hash256} containing the ledger hash.
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
    */
-  @JsonProperty("ledger_hash")
-  Optional<Hash256> ledgerHash();
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
+   * Omitted if ledger_hash or ledger_index provided. The ledger index
+   * of the current in-progress ledger version, which was used when retrieving this data.
+   *
+   * @return A {@link LedgerIndex}.
+   */
+  @JsonProperty("ledger_current_index")
+  Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * Server-defined value for pagination. Pass this to the next call to resume getting results where this

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/ledger/LedgerResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/ledger/LedgerResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.ledger;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -44,12 +45,38 @@ public interface LedgerResult extends XrplResult {
   Optional<Hash256> ledgerHash();
 
   /**
+   * Get {@link #ledgerHash()}, or throw an {@link IllegalStateException} if {@link #ledgerHash()} is empty.
+   *
+   * @return The value of {@link #ledgerHash()}.
+   * @throws IllegalStateException If {@link #ledgerHash()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return ledgerHash()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
+
+  /**
    * The {@link LedgerIndex} of this ledger.
    *
    * @return The {@link LedgerIndex} of this ledger.
    */
   @JsonProperty("ledger_index")
   Optional<LedgerIndex> ledgerIndex();
+
+  /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
 
   /**
    * The {@link LedgerIndex} of this ledger, if the ledger is the current ledger. Only present on a current ledger
@@ -59,6 +86,20 @@ public interface LedgerResult extends XrplResult {
    */
   @JsonProperty("ledger_current_index")
   Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * True if this data is from a validated ledger version; if false, this data is not final.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/path/DepositAuthorizedResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/path/DepositAuthorizedResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.path;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -65,6 +66,19 @@ public interface DepositAuthorizedResult extends XrplResult {
   Optional<Hash256> ledgerHash();
 
   /**
+   * Get {@link #ledgerHash()}, or throw an {@link IllegalStateException} if {@link #ledgerHash()} is empty.
+   *
+   * @return The value of {@link #ledgerHash()}.
+   * @throws IllegalStateException If {@link #ledgerHash()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return ledgerHash()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
+
+  /**
    * (Omitted if ledger_current_index is provided instead) The ledger index of the ledger version used when retrieving
    * this information. The information does not contain any changes from ledger versions newer than this one.
    *
@@ -74,6 +88,19 @@ public interface DepositAuthorizedResult extends XrplResult {
   Optional<LedgerIndex> ledgerIndex();
 
   /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
    * (Omitted if ledger_index is provided instead) The ledger index of the current in-progress ledger, which was used
    * when retrieving this information.
    *
@@ -81,6 +108,20 @@ public interface DepositAuthorizedResult extends XrplResult {
    */
   @JsonProperty("ledger_current_index")
   Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * True if this data is from a validated ledger version; if false, this data is not final.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/SubmitMultiSignedResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/SubmitMultiSignedResult.java
@@ -34,25 +34,61 @@ public interface SubmitMultiSignedResult<TxnType extends Transaction> extends Xr
    * Text result code indicating the preliminary result of the transaction, for example "tesSUCCESS".
    *
    * @return An optionally-present {@link String} containing the result of the submission.
+   * @deprecated Use {@link #result()} instead.
+   */
+  @Deprecated
+  @Value.Auxiliary
+  default Optional<String> engineResult() {
+    return Optional.of(result());
+  }
+
+  /**
+   * Text result code indicating the preliminary result of the transaction, for example "tesSUCCESS".
+   *
+   * @return A {@link String} containing the result of the submission.
    */
   @JsonProperty("engine_result")
-  Optional<String> engineResult();
+  String result();
 
   /**
    * Numeric code indicating the preliminary result of the transaction, directly correlated to {@link #engineResult()}.
    *
    * @return An optionally-present {@link String} containing the result code of the submission.
+   * @deprecated Use {@link #resultCode()} instead.
+   */
+  @Deprecated
+  @Value.Auxiliary
+  default Optional<String> engineResultCode() {
+    return Optional.of(resultCode().toString());
+  }
+
+  /**
+   * Numeric code indicating the preliminary result of the transaction, directly correlated to {@link #engineResult()}.
+   *
+   * @return An {@link Integer} containing the result code of the submission.
    */
   @JsonProperty("engine_result_code")
-  Optional<String> engineResultCode();
+  Integer resultCode();
 
   /**
    * Human-readable explanation of the transaction's preliminary result.
    *
    * @return An optionally-present {@link String} containing the result message of the submission.
+   * @deprecated Use {@link #resultMessage()} instead.
+   */
+  @Deprecated
+  @Value.Auxiliary
+  default Optional<String> engineResultMessage() {
+    return Optional.of(resultMessage());
+  }
+
+  /**
+   * Human-readable explanation of the transaction's preliminary result.
+   *
+   * @return A {@link String} containing the result message of the submission.
    */
   @JsonProperty("engine_result_message")
-  Optional<String> engineResultMessage();
+  String resultMessage();
 
   /**
    * The complete transaction in hex {@link String} format.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResult.java
@@ -58,9 +58,21 @@ public interface SubmitResult<TxnType extends Transaction> extends XrplResult {
    * Human-readable explanation of the transaction's preliminary result.
    *
    * @return An optionally-present {@link String} containing the result message of the submission.
+   * @deprecated Use {@link #resultMessage()} instead.
+   */
+  @Deprecated
+  @Value.Auxiliary
+  default Optional<String> engineResultMessage() {
+    return Optional.of(resultMessage());
+  }
+
+  /**
+   * Human-readable explanation of the transaction's preliminary result.
+   *
+   * @return A {@link String} containing the result message of the submission.
    */
   @JsonProperty("engine_result_message")
-  Optional<String> engineResultMessage();
+  String resultMessage();
 
   /**
    * The complete transaction in hex {@link String} format.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResult.java
@@ -63,6 +63,19 @@ public interface TransactionResult<TxnType extends Transaction> extends XrplResu
   Optional<LedgerIndex> ledgerIndex();
 
   /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
    * The identifying hash of the {@link Transaction}.
    *
    * @return The {@link Hash256} of {@link #transaction()}.

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResultJsonTests.java
@@ -66,6 +66,55 @@ public class AccountChannelsResultJsonTests extends AbstractJsonTest {
   }
 
   @Test
+  public void testJsonWithoutLedgerHash() throws JsonProcessingException, JSONException {
+    AccountChannelsResult result = AccountChannelsResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addChannels(
+        PaymentChannelResultObject.builder()
+          .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+          .amount(XrpCurrencyAmount.ofDrops(100000000))
+          .balance(XrpCurrencyAmount.ofDrops(0))
+          .channelId(Hash256.of("5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3"))
+          .destinationAccount(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+          .destinationTag(UnsignedInteger.valueOf(20170428))
+          .publicKey("aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3")
+          .publicKeyHex("023693F15967AE357D0327974AD46FE3C127113B1110D6044FD41E723689F81CC6")
+          .expiration(UnsignedLong.valueOf(10000))
+          .cancelAfter(UnsignedLong.valueOf(10000))
+          .sourceTag(UnsignedInteger.valueOf(10000))
+          .settleDelay(UnsignedInteger.valueOf(86400))
+          .build()
+      )
+      .build();
+
+    String json = "{\n" +
+      "        \"account\": \"rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH\",\n" +
+      "        \"channels\": [{\n" +
+      "            \"account\": \"rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH\",\n" +
+      "            \"amount\": \"100000000\",\n" +
+      "            \"balance\": \"0\",\n" +
+      "            \"channel_id\": \"5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3\",\n" +
+      "            \"destination_account\": \"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn\",\n" +
+      "            \"destination_tag\": 20170428,\n" +
+      "            \"public_key\": \"aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3\",\n" +
+      "            \"public_key_hex\": \"023693F15967AE357D0327974AD46FE3C127113B1110D6044FD41E723689F81CC6\",\n" +
+      "            \"expiration\": 10000,\n" +
+      "            \"cancel_after\": 10000,\n" +
+      "            \"source_tag\": 10000,\n" +
+      "            \"settle_delay\": 86400\n" +
+      "        }],\n" +
+      "        \"ledger_index\": 37230600,\n" +
+      "        \"status\": \"success\",\n" +
+      "        \"validated\": true\n" +
+      "    }";
+
+    assertCanSerializeAndDeserialize(result, json);
+  }
+
+  @Test
   public void testFullJson() throws JsonProcessingException, JSONException {
     AccountChannelsResult result = AccountChannelsResult.builder()
       .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResultTest.java
@@ -1,0 +1,87 @@
+package org.xrpl.xrpl4j.model.client.accounts;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.primitives.UnsignedInteger;
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
+
+class AccountChannelsResultTest {
+
+  @Test
+  void testWithHash() {
+    AccountChannelsResult result = AccountChannelsResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addChannels(mock(PaymentChannelResultObject.class))
+      .build();
+
+    assertThat(result.ledgerHash()).isNotNull();
+    assertThat(result.ledgerHashSafe()).isEqualTo(result.ledgerHash());
+  }
+
+  @Test
+  void testWithoutHash() {
+    AccountChannelsResult result = AccountChannelsResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addChannels(mock(PaymentChannelResultObject.class))
+      .build();
+
+    assertThat(result.ledgerHash()).isNull();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerHashSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerIndex() {
+    AccountChannelsResult result = AccountChannelsResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addChannels(mock(PaymentChannelResultObject.class))
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotNull();
+    assertThat(result.ledgerIndexSafe()).isEqualTo(result.ledgerIndex());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    AccountChannelsResult result = AccountChannelsResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(false)
+      .addChannels(mock(PaymentChannelResultObject.class))
+      .build();
+
+    assertThat(result.ledgerIndex()).isNull();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountCurrenciesResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountCurrenciesResultJsonTests.java
@@ -3,6 +3,7 @@ package org.xrpl.xrpl4j.model.client.accounts;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
+import org.assertj.core.util.Lists;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
@@ -36,6 +37,35 @@ public class AccountCurrenciesResultJsonTests extends AbstractJsonTest {
       "        \"status\": \"success\",\n" +
       "        \"validated\": true\n" +
       "    }";
+
+    assertCanSerializeAndDeserialize(result, json);
+  }
+
+  @Test
+  void testCurrentJson() throws JSONException, JsonProcessingException {
+    AccountCurrenciesResult result = AccountCurrenciesResult.builder()
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(66467750)))
+      .status("success")
+      .validated(false)
+      .receiveCurrencies(Lists.newArrayList("BTC", "CNY", "015841551A748AD2C1F76FF6ECB0CCCD00000000"))
+      .sendCurrencies(Lists.newArrayList("ASP", "BTC", "USD"))
+      .build();
+
+    String json = "{\n" +
+      "        \"ledger_current_index\": 66467750,\n" +
+      "        \"receive_currencies\": [\n" +
+      "            \"BTC\",\n" +
+      "            \"CNY\",\n" +
+      "            \"015841551A748AD2C1F76FF6ECB0CCCD00000000\"\n" +
+      "        ],\n" +
+      "        \"send_currencies\": [\n" +
+      "            \"ASP\",\n" +
+      "            \"BTC\",\n" +
+      "            \"USD\"\n" +
+      "        ],\n" +
+      "        \"status\": \"success\",\n" +
+      "        \"validated\": false\n" +
+      "}";
 
     assertCanSerializeAndDeserialize(result, json);
   }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountCurrenciesResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountCurrenciesResultTest.java
@@ -1,0 +1,88 @@
+package org.xrpl.xrpl4j.model.client.accounts;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.primitives.UnsignedInteger;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+
+class AccountCurrenciesResultTest {
+
+  @Test
+  void testWithHash() {
+    AccountCurrenciesResult result = AccountCurrenciesResult.builder()
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addSendCurrencies("USD")
+      .addReceiveCurrencies("EUR")
+      .addReceiveCurrencies("USD")
+      .build();
+
+    assertThat(result.ledgerHash()).isNotEmpty().get().isEqualTo(result.ledgerHashSafe());
+  }
+
+  @Test
+  void testWithoutHash() {
+    AccountCurrenciesResult result = AccountCurrenciesResult.builder()
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addSendCurrencies("USD")
+      .addReceiveCurrencies("EUR")
+      .addReceiveCurrencies("USD")
+      .build();
+
+    assertThat(result.ledgerHash()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerHashSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerIndex() {
+    AccountCurrenciesResult result = AccountCurrenciesResult.builder()
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addSendCurrencies("USD")
+      .addReceiveCurrencies("EUR")
+      .addReceiveCurrencies("USD")
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotNull();
+    assertThat(result.ledgerIndexSafe()).isEqualTo(result.ledgerIndex());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    AccountCurrenciesResult result = AccountCurrenciesResult.builder()
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(66467750)))
+      .status("success")
+      .validated(false)
+      .receiveCurrencies(Lists.newArrayList("BTC", "CNY", "015841551A748AD2C1F76FF6ECB0CCCD00000000"))
+      .sendCurrencies(Lists.newArrayList("ASP", "BTC", "USD"))
+      .build();
+
+    assertThat(result.ledgerIndex()).isNull();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoResultTest.java
@@ -1,0 +1,50 @@
+package org.xrpl.xrpl4j.model.client.accounts;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.primitives.UnsignedInteger;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.ledger.AccountRootObject;
+
+class AccountInfoResultTest {
+
+  @Test
+  void testWithLedgerIndex() {
+    AccountInfoResult result = AccountInfoResult.builder()
+      .accountData(mock(AccountRootObject.class))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(4)))
+      .queueData(mock(QueueData.class))
+      .status("success")
+      .validated(true)
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotEmpty().get().isEqualTo(result.ledgerIndexSafe());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    AccountInfoResult result = AccountInfoResult.builder()
+      .accountData(mock(AccountRootObject.class))
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(4)))
+      .queueData(mock(QueueData.class))
+      .status("success")
+      .validated(true)
+      .build();
+
+    assertThat(result.ledgerIndex()).isEmpty();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResultJsonTests.java
@@ -5,6 +5,7 @@ import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.transactions.Address;
 
 public class AccountLinesResultJsonTests extends AbstractJsonTest {
@@ -14,6 +15,7 @@ public class AccountLinesResultJsonTests extends AbstractJsonTest {
     AccountLinesResult result = AccountLinesResult.builder()
       .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
       .status("success")
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.ONE))
       .addLines(
         TrustLine.builder()
           .account(Address.of("r3vi7mWxru9rJCxETCyA1CHvzL96eZWx5z"))
@@ -39,6 +41,7 @@ public class AccountLinesResultJsonTests extends AbstractJsonTest {
 
     String json = "{\n" +
       "        \"account\": \"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\n" +
+      "        \"ledger_index\": 1,\n" +
       "        \"lines\": [\n" +
       "            {\n" +
       "                \"account\": \"r3vi7mWxru9rJCxETCyA1CHvzL96eZWx5z\",\n" +

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResultTest.java
@@ -1,0 +1,73 @@
+package org.xrpl.xrpl4j.model.client.accounts;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.common.primitives.UnsignedInteger;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+
+class AccountLinesResultTest {
+
+  @Test
+  void testWithHash() {
+    AccountLinesResult result = AccountLinesResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .status("success")
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.ONE))
+      .build();
+
+    assertThat(result.ledgerHash()).isNotEmpty().get().isEqualTo(result.ledgerHashSafe());
+  }
+
+  @Test
+  void testWithoutHash() {
+    AccountLinesResult result = AccountLinesResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .status("success")
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.ONE))
+      .build();
+
+    assertThat(result.ledgerHash()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerHashSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerIndex() {
+    AccountLinesResult result = AccountLinesResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .status("success")
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.ONE))
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotEmpty().get().isEqualTo(result.ledgerIndexSafe());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    AccountLinesResult result = AccountLinesResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .status("success")
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.ONE))
+      .build();
+
+    assertThat(result.ledgerIndex()).isEmpty();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsResultTest.java
@@ -1,0 +1,77 @@
+package org.xrpl.xrpl4j.model.client.accounts;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.common.primitives.UnsignedInteger;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+
+class AccountObjectsResultTest {
+
+  @Test
+  void testWithHash() {
+    AccountObjectsResult result = AccountObjectsResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(14380380)))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .validated(true)
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerHash()).isNotEmpty().get().isEqualTo(result.ledgerHashSafe());
+  }
+
+  @Test
+  void testWithoutHash() {
+    AccountObjectsResult result = AccountObjectsResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(14380380)))
+      .validated(true)
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerHash()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerHashSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerIndex() {
+    AccountObjectsResult result = AccountObjectsResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(14380380)))
+      .validated(true)
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotEmpty().get().isEqualTo(result.ledgerIndexSafe());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    AccountObjectsResult result = AccountObjectsResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(14380380)))
+      .validated(true)
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerIndex()).isEmpty();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountOffersResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountOffersResultTest.java
@@ -1,0 +1,81 @@
+package org.xrpl.xrpl4j.model.client.accounts;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.common.primitives.UnsignedInteger;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.flags.Flags;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;
+import org.xrpl.xrpl4j.model.transactions.Marker;
+import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
+
+import java.math.BigDecimal;
+
+class AccountOffersResultTest {
+
+  @Test
+  void testWithHash() {
+    AccountOffersResult result = AccountOffersResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerHash()).isNotEmpty().get().isEqualTo(result.ledgerHashSafe());
+  }
+
+  @Test
+  void testWithoutHash() {
+    AccountOffersResult result = AccountOffersResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerHash()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerHashSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerIndex() {
+    AccountOffersResult result = AccountOffersResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotEmpty().get().isEqualTo(result.ledgerIndexSafe());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    AccountOffersResult result = AccountOffersResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerIndex()).isEmpty();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/ledger/LedgerResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/ledger/LedgerResultTest.java
@@ -1,0 +1,82 @@
+package org.xrpl.xrpl4j.model.client.ledger;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.primitives.UnsignedInteger;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.accounts.AccountLinesResult;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.ledger.LedgerHeader;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+
+class LedgerResultTest {
+
+  @Test
+  void testWithHash() {
+    LedgerResult result = LedgerResult.builder()
+      .status("success")
+      .ledgerHash(Hash256.of("3652D7FD0576BC452C0D2E9B747BDD733075971D1A9A1D98125055DEF428721A"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(54300940)))
+      .validated(true)
+      .ledger(mock(LedgerHeader.class))
+      .build();
+
+    assertThat(result.ledgerHash()).isNotEmpty().get().isEqualTo(result.ledgerHashSafe());
+  }
+
+  @Test
+  void testWithoutHash() {
+    LedgerResult result = LedgerResult.builder()
+      .status("success")
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(54300940)))
+      .validated(true)
+      .ledger(mock(LedgerHeader.class))
+      .build();
+
+    assertThat(result.ledgerHash()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerHashSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerIndex() {
+    LedgerResult result = LedgerResult.builder()
+      .status("success")
+      .ledgerHash(Hash256.of("3652D7FD0576BC452C0D2E9B747BDD733075971D1A9A1D98125055DEF428721A"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(54300940)))
+      .validated(true)
+      .ledger(mock(LedgerHeader.class))
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotEmpty().get().isEqualTo(result.ledgerIndexSafe());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    LedgerResult result = LedgerResult.builder()
+      .status("success")
+      .ledgerHash(Hash256.of("3652D7FD0576BC452C0D2E9B747BDD733075971D1A9A1D98125055DEF428721A"))
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(54300940)))
+      .validated(true)
+      .ledger(mock(LedgerHeader.class))
+      .build();
+
+    assertThat(result.ledgerIndex()).isEmpty();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitMultisignedResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitMultisignedResultJsonTests.java
@@ -1,5 +1,7 @@
 package org.xrpl.xrpl4j.model.client.transactions;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
@@ -69,6 +71,10 @@ public class SubmitMultisignedResultJsonTests extends AbstractJsonTest {
         .hash(Hash256.of("81A477E2A362D171BB16BE17B4120D9F809A327FA00242ABCA867283BEA2F4F8"))
         .build())
       .build();
+
+    assertThat(result.engineResult()).isNotEmpty().get().isEqualTo(result.result());
+    assertThat(result.engineResultCode()).isNotEmpty().get().isEqualTo(result.resultCode().toString());
+    assertThat(result.engineResultMessage()).isNotEmpty().get().isEqualTo(result.resultMessage());
 
     String json = "{\n" +
       "        \"engine_result\": \"tesSUCCESS\",\n" +

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitMultisignedResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitMultisignedResultJsonTests.java
@@ -19,8 +19,9 @@ public class SubmitMultisignedResultJsonTests extends AbstractJsonTest {
   @Test
   public void testJson() throws JsonProcessingException, JSONException {
     SubmitMultiSignedResult<TrustSet> result = SubmitMultiSignedResult.<TrustSet>builder()
-      .engineResult("tesSUCCESS")
-      .engineResultMessage("The transaction was applied. Only final in a validated ledger.")
+      .result("tesSUCCESS")
+      .resultCode(0)
+      .resultMessage("The transaction was applied. Only final in a validated ledger.")
       .status("success")
       .transactionBlob("120014220004000024000000046380000000000000000000000000000000000000005553440000000000B" +
         "5F762798A53D543A014CAF8B297CFF8F2F937E868400000000000753073008114A3780F5CB5A44D366520FC44055E8ED44" +
@@ -71,6 +72,7 @@ public class SubmitMultisignedResultJsonTests extends AbstractJsonTest {
 
     String json = "{\n" +
       "        \"engine_result\": \"tesSUCCESS\",\n" +
+      "        \"engine_result_code\": 0,\n" +
       "        \"engine_result_message\": \"The transaction was applied. Only final in a validated ledger.\",\n" +
       "        \"status\": \"success\",\n" +
       "        \"tx_blob\": \"12001422000400002400000004638000000000000000000000000000000000000000555344000000" +

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResultJsonTests.java
@@ -1,5 +1,7 @@
 package org.xrpl.xrpl4j.model.client.transactions;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
@@ -54,6 +56,9 @@ public class SubmitResultJsonTests extends AbstractJsonTest {
         .build())
       .validatedLedgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(21184416)))
       .build();
+
+    assertThat(paymentResult.engineResult()).isNotEmpty().get().isEqualTo(paymentResult.result());
+    assertThat(paymentResult.engineResultMessage()).isNotEmpty().get().isEqualTo(paymentResult.resultMessage());
 
     String json = "{\n" +
       "        \"accepted\" : true,\n" +

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResultJsonTests.java
@@ -24,7 +24,7 @@ public class SubmitResultJsonTests extends AbstractJsonTest {
       .applied(true)
       .broadcast(true)
       .result("tesSUCCESS")
-      .engineResultMessage("The transaction was applied. Only final in a validated ledger.")
+      .resultMessage("The transaction was applied. Only final in a validated ledger.")
       .status("success")
       .kept(true)
       .openLedgerCost(XrpCurrencyAmount.ofDrops(10))

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultTest.java
@@ -1,0 +1,63 @@
+package org.xrpl.xrpl4j.model.client.transactions;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.primitives.UnsignedInteger;
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.Payment;
+import org.xrpl.xrpl4j.model.transactions.TransactionMetadata;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+class TransactionResultTest {
+
+  @Test
+  void testLedgerIndexSafeWithLedgerIndex() {
+    TransactionResult<Payment> paymentResult = TransactionResult.<Payment>builder()
+      .transaction(mock(Payment.class))
+      .hash(Hash256.of("E939C30F233E3E6B0A9F829BDDA258CB9DA38D11C0F66C7D60E38B9D9FA987B8"))
+      .closeDate(UnsignedLong.valueOf(666212460))
+      .metadata(mock(TransactionMetadata.class))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.ONE))
+      .build();
+
+    assertThat(paymentResult.ledgerIndex()).isNotEmpty().get().isEqualTo(paymentResult.ledgerIndexSafe());
+  }
+
+  @Test
+  void testLedgerIndexSafeWithoutLedgerIndex() {
+    TransactionResult<Payment> paymentResult = TransactionResult.<Payment>builder()
+      .transaction(mock(Payment.class))
+      .hash(Hash256.of("E939C30F233E3E6B0A9F829BDDA258CB9DA38D11C0F66C7D60E38B9D9FA987B8"))
+      .closeDate(UnsignedLong.valueOf(666212460))
+      .metadata(mock(TransactionMetadata.class))
+      .build();
+
+    assertThat(paymentResult.ledgerIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      paymentResult::ledgerIndexSafe
+    );
+  }
+
+  @Test
+  void testCloseTimeHuman() {
+    TransactionResult<Payment> paymentResult = TransactionResult.<Payment>builder()
+      .transaction(mock(Payment.class))
+      .hash(Hash256.of("E939C30F233E3E6B0A9F829BDDA258CB9DA38D11C0F66C7D60E38B9D9FA987B8"))
+      .closeDate(UnsignedLong.valueOf(666212460))
+      .metadata(mock(TransactionMetadata.class))
+      .build();
+
+    assertThat(paymentResult.closeDateHuman()).hasValue(
+      ZonedDateTime.of(LocalDateTime.of(2021, 2, 9, 19, 1, 0), ZoneId.of("UTC"))
+    );
+  }
+}


### PR DESCRIPTION
Fixes #146 
Fixes #145 