### PR TITLE
Make `AccountChannelsResult.ledgerHash` and `ledgerIndex` nullable (for now) and add `ledgerCurrentIndex`

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
@@ -127,8 +127,7 @@ public class AccountTransactionsIT {
 
     Hash256 validatedLedgerHash = ledger.ledgerHash()
       .orElseThrow(() -> new RuntimeException("ledgerHash not present."));
-    LedgerIndex validatedLedgerIndex = ledger.ledgerIndex()
-      .orElseThrow(() -> new RuntimeException("ledgerIndex not present."));
+    LedgerIndex validatedLedgerIndex = ledger.ledgerIndexSafe();
 
     AccountTransactionsResult resultByLedgerIndex = getAccountTransactions(
       AccountTransactionsRequestParams.builder()

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IssuedCurrencyIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IssuedCurrencyIT.java
@@ -6,8 +6,11 @@ import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
+import org.xrpl.xrpl4j.model.client.accounts.AccountCurrenciesRequestParams;
+import org.xrpl.xrpl4j.model.client.accounts.AccountCurrenciesResult;
 import org.xrpl.xrpl4j.model.client.accounts.AccountInfoResult;
 import org.xrpl.xrpl4j.model.client.accounts.TrustLine;
+import org.xrpl.xrpl4j.model.client.common.LedgerSpecifier;
 import org.xrpl.xrpl4j.model.client.fees.FeeResult;
 import org.xrpl.xrpl4j.model.client.transactions.SubmitResult;
 import org.xrpl.xrpl4j.model.transactions.AccountSet;
@@ -56,6 +59,20 @@ public class IssuedCurrencyIT extends AbstractIT {
       linesResult -> linesResult.lines().stream()
         .anyMatch(line -> line.balance().equals("-" + trustLine.limitPeer()))
     );
+
+    ///////////////////////////
+    // We can also retrieve the currencies that the counterparty can send/recieve using the accountCurrencies
+    // method.
+    AccountCurrenciesResult counterpartyCurrencies = xrplClient.accountCurrencies(
+      AccountCurrenciesRequestParams.builder()
+        .account(counterpartyWallet.classicAddress())
+        .ledgerSpecifier(LedgerSpecifier.CURRENT)
+        .build()
+    );
+
+    assertThat(counterpartyCurrencies.sendCurrencies()).asList().containsOnly(xrpl4jCoin);
+    assertThat(counterpartyCurrencies.ledgerCurrentIndex()).isNotEmpty().get()
+      .isEqualTo(counterpartyCurrencies.ledgerCurrentIndexSafe());
   }
 
   @Test

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/LedgerResultIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/LedgerResultIT.java
@@ -1,6 +1,7 @@
 package org.xrpl.xrpl4j.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
@@ -19,11 +20,15 @@ public class LedgerResultIT extends AbstractIT {
   void getValidatedLedgerResult() throws JsonRpcClientErrorException {
     final LedgerResult ledgerResult = xrplClient.ledger(LedgerRequestParams.builder()
       .ledgerSpecifier(LedgerSpecifier.VALIDATED)
-      .ledgerSpecifier(LedgerSpecifier.VALIDATED)
       .build());
-    assertThat(ledgerResult.ledgerIndex()).isNotEmpty();
-    assertThat(ledgerResult.ledgerHash()).isNotEmpty();
+
+    assertThat(ledgerResult.ledgerIndex()).isNotEmpty().get().isEqualTo(ledgerResult.ledgerIndexSafe());
+    assertThat(ledgerResult.ledgerHash()).isNotEmpty().get().isEqualTo(ledgerResult.ledgerHashSafe());
     assertThat(ledgerResult.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      ledgerResult::ledgerCurrentIndexSafe
+    );
     assertThat(ledgerResult.ledger().closeTimeHuman()).isNotEmpty();
     assertThat(ledgerResult.ledger().parentCloseTime()).isNotEmpty();
   }
@@ -33,9 +38,18 @@ public class LedgerResultIT extends AbstractIT {
     final LedgerResult ledgerResult = xrplClient.ledger(LedgerRequestParams.builder()
       .ledgerSpecifier(LedgerSpecifier.CURRENT)
       .build());
+
     assertThat(ledgerResult.ledgerIndex()).isEmpty();
     assertThat(ledgerResult.ledgerHash()).isEmpty();
-    assertThat(ledgerResult.ledgerCurrentIndex()).isNotEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      ledgerResult::ledgerHashSafe
+    );
+    assertThrows(
+      IllegalStateException.class,
+      ledgerResult::ledgerIndexSafe
+    );
+    assertThat(ledgerResult.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(ledgerResult.ledgerCurrentIndexSafe());
     assertThat(ledgerResult.ledger().closeTimeHuman()).isEmpty();
     assertThat(ledgerResult.ledger().parentCloseTime()).isEmpty();
   }
@@ -45,9 +59,14 @@ public class LedgerResultIT extends AbstractIT {
     final LedgerResult ledgerResult = xrplClient.ledger(LedgerRequestParams.builder()
       .ledgerSpecifier(LedgerSpecifier.CLOSED)
       .build());
-    assertThat(ledgerResult.ledgerIndex()).isNotEmpty();
-    assertThat(ledgerResult.ledgerHash()).isNotEmpty();
+
+    assertThat(ledgerResult.ledgerIndex()).isNotEmpty().get().isEqualTo(ledgerResult.ledgerIndexSafe());
+    assertThat(ledgerResult.ledgerHash()).isNotEmpty().get().isEqualTo(ledgerResult.ledgerHashSafe());
     assertThat(ledgerResult.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      ledgerResult::ledgerCurrentIndexSafe
+    );
     assertThat(ledgerResult.ledger().closeTimeHuman()).isNotEmpty();
     assertThat(ledgerResult.ledger().parentCloseTime()).isNotEmpty();
   }

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/PaymentChannelIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/PaymentChannelIT.java
@@ -109,11 +109,7 @@ public class PaymentChannelIT extends AbstractIT {
     // accounts XRP balance
     AccountInfoResult senderAccountInfoAfterCreate = this.scanForResult(
       () -> this.getValidatedAccountInfo(sourceWallet.classicAddress()),
-      accountInfo -> accountInfo.ledgerIndex()
-        .orElseThrow(() -> new RuntimeException("Ledger index was not present."))
-        .equals(senderAccountInfo.ledgerIndex()
-          .orElseThrow(() -> new RuntimeException("Ledger index was not present."))
-          .plus(UnsignedInteger.ONE))
+      accountInfo -> accountInfo.ledgerIndexSafe().equals(senderAccountInfo.ledgerIndexSafe().plus(UnsignedInteger.ONE))
     );
 
     assertThat(senderAccountInfoAfterCreate.accountData().balance())

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/PaymentChannelIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/PaymentChannelIT.java
@@ -426,5 +426,7 @@ public class PaymentChannelIT extends AbstractIT {
     );
 
     assertThat(accountChannelsResult.ledgerHash()).isNull();
+    assertThat(accountChannelsResult.ledgerIndex()).isNull();
+    assertThat(accountChannelsResult.ledgerCurrentIndex()).isNotEmpty();
   }
 }

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/PaymentChannelIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/PaymentChannelIT.java
@@ -11,10 +11,13 @@ import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
 import org.xrpl.xrpl4j.codec.binary.XrplBinaryCodec;
 import org.xrpl.xrpl4j.keypairs.DefaultKeyPairService;
 import org.xrpl.xrpl4j.keypairs.KeyPairService;
+import org.xrpl.xrpl4j.model.client.accounts.AccountChannelsRequestParams;
+import org.xrpl.xrpl4j.model.client.accounts.AccountChannelsResult;
 import org.xrpl.xrpl4j.model.client.accounts.AccountInfoResult;
 import org.xrpl.xrpl4j.model.client.accounts.PaymentChannelResultObject;
 import org.xrpl.xrpl4j.model.client.channels.ChannelVerifyResult;
 import org.xrpl.xrpl4j.model.client.channels.UnsignedClaim;
+import org.xrpl.xrpl4j.model.client.common.LedgerSpecifier;
 import org.xrpl.xrpl4j.model.client.fees.FeeResult;
 import org.xrpl.xrpl4j.model.client.transactions.SubmitResult;
 import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
@@ -365,5 +368,63 @@ public class PaymentChannelIT extends AbstractIT {
               channel.expiration().get().equals(newExpiry)
         )
     );
+  }
+
+  @Test
+  void testCurrentAccountChannels() throws JsonRpcClientErrorException {
+    //////////////////////////
+    // Create source and destination accounts on ledger
+    Wallet sourceWallet = createRandomAccount();
+    Wallet destinationWallet = createRandomAccount();
+
+    FeeResult feeResult = xrplClient.fee();
+    AccountInfoResult senderAccountInfo = this.scanForResult(
+      () -> this.getValidatedAccountInfo(sourceWallet.classicAddress())
+    );
+
+    //////////////////////////
+    // Submit a PaymentChannelCreate transaction to create a payment channel between
+    // the source and destination accounts
+    PaymentChannelCreate createPaymentChannel = PaymentChannelCreate.builder()
+      .account(sourceWallet.classicAddress())
+      .fee(feeResult.drops().openLedgerFee())
+      .sequence(senderAccountInfo.accountData().sequence())
+      .amount(XrpCurrencyAmount.ofDrops(10000))
+      .destination(destinationWallet.classicAddress())
+      .settleDelay(UnsignedInteger.ONE)
+      .publicKey(sourceWallet.publicKey())
+      .cancelAfter(UnsignedLong.valueOf(533171558))
+      .signingPublicKey(sourceWallet.publicKey())
+      .build();
+
+    //////////////////////////
+    // Validate that the transaction was submitted successfully
+    SubmitResult<PaymentChannelCreate> createResult = xrplClient.submit(sourceWallet, createPaymentChannel);
+    assertThat(createResult.result()).isEqualTo("tesSUCCESS");
+    assertThat(createResult.transactionResult().transaction().hash()).isNotEmpty().get()
+      .isEqualTo(createResult.transactionResult().hash());
+    logger.info("PaymentChannelCreate transaction successful. https://testnet.xrpl.org/transactions/{}",
+      createResult.transactionResult().hash()
+    );
+
+    //////////////////////////
+    // Wait for the payment channel to exist in a validated ledger
+    // and validate its fields
+    AccountChannelsResult accountChannelsResult = scanForResult(
+      () -> {
+        try {
+          return xrplClient.accountChannels(AccountChannelsRequestParams.builder()
+            .account(sourceWallet.classicAddress())
+            .ledgerSpecifier(LedgerSpecifier.CURRENT)
+            .build());
+        } catch (JsonRpcClientErrorException e) {
+          throw new RuntimeException(e);
+        }
+      },
+      channels -> channels.channels().stream()
+        .anyMatch(channel -> channel.destinationAccount().equals(destinationWallet.classicAddress()))
+    );
+
+    assertThat(accountChannelsResult.ledgerHash()).isNull();
   }
 }

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SubmitPaymentIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SubmitPaymentIT.java
@@ -100,7 +100,7 @@ public class SubmitPaymentIT extends AbstractIT {
     throws JsonRpcClientErrorException {
     LedgerResult ledger = xrplClient.ledger(
         LedgerRequestParams.builder()
-          .ledgerSpecifier(LedgerSpecifier.of(validatedPayment.ledgerIndex().get()))
+          .ledgerSpecifier(LedgerSpecifier.of(validatedPayment.ledgerIndexSafe()))
           .build()
     );
 

--- a/xrpl4j-model/pom.xml
+++ b/xrpl4j-model/pom.xml
@@ -85,6 +85,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.accounts;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -61,6 +62,19 @@ public interface AccountChannelsResult extends XrplResult {
   Hash256 ledgerHash();
 
   /**
+   * Get {@link #ledgerHash()}, or throw an {@link IllegalStateException} if {@link #ledgerHash()} is null.
+   *
+   * @return The value of {@link #ledgerHash()}.
+   * @throws IllegalStateException If {@link #ledgerHash()} is null.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return Optional.ofNullable(ledgerHash())
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
+
+  /**
    * The Ledger Index of the ledger version used to generate this response. Only present in responses to requests
    * with ledger_index = "validated" or "closed".
    *
@@ -75,6 +89,19 @@ public interface AccountChannelsResult extends XrplResult {
   LedgerIndex ledgerIndex();
 
   /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is null.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is null.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return Optional.ofNullable(ledgerIndex())
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
    * The ledger index of the current open ledger, which was used when retrieving this information. Only present
    * in responses to requests with ledger_index = "current".
    *
@@ -82,6 +109,21 @@ public interface AccountChannelsResult extends XrplResult {
    */
   @JsonProperty("ledger_current_index")
   Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
+
 
   /**
    * If true, the information in this response comes from a validated ledger version.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResult.java
@@ -13,6 +13,7 @@ import org.xrpl.xrpl4j.model.transactions.Marker;
 
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * The result of an account_channels rippled call.
@@ -50,17 +51,37 @@ public interface AccountChannelsResult extends XrplResult {
    * The identifying Hash of the ledger version used to generate this response.
    *
    * @return A {@link Hash256} containing the ledger hash.
+   * @deprecated When requesting Account Channels from a non-validated ledger, the result will not contain this field.
+   *   To prevent this class from throwing an error when requesting Account Channels from a non-validated ledger, this
+   *   field is currently marked as {@link Nullable}. However, this field will be {@link Optional} in a future release.
    */
   @JsonProperty("ledger_hash")
+  @Nullable
+  @Deprecated
   Hash256 ledgerHash();
 
   /**
-   * The Ledger Index of the ledger version used to generate this response.
+   * The Ledger Index of the ledger version used to generate this response. Only present in responses to requests
+   * with ledger_index = "validated" or "closed".
    *
    * @return A {@link LedgerIndex}.
+   * @deprecated When requesting Account Channels from a non-validated ledger, the result will not contain this field.
+   *   To prevent this class from throwing an error when requesting Account Channels from a non-validated ledger, this
+   *   field is currently marked as {@link Nullable}. However, this field will be {@link Optional} in a future release.
    */
   @JsonProperty("ledger_index")
+  @Nullable
+  @Deprecated
   LedgerIndex ledgerIndex();
+
+  /**
+   * The ledger index of the current open ledger, which was used when retrieving this information. Only present
+   * in responses to requests with ledger_index = "current".
+   *
+   * @return An optionally-present {@link LedgerIndex} representing the current ledger index.
+   */
+  @JsonProperty("ledger_current_index")
+  Optional<LedgerIndex> ledgerCurrentIndex();
 
   /**
    * If true, the information in this response comes from a validated ledger version.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountCurrenciesResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountCurrenciesResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.accounts;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -10,6 +11,7 @@ import org.xrpl.xrpl4j.model.transactions.Hash256;
 
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * The result of an account_currencies rippled call.
@@ -32,12 +34,66 @@ public interface AccountCurrenciesResult extends XrplResult {
   Optional<Hash256> ledgerHash();
 
   /**
+   * Get {@link #ledgerHash()}, or throw an {@link IllegalStateException} if {@link #ledgerHash()} is empty.
+   *
+   * @return The value of {@link #ledgerHash()}.
+   * @throws IllegalStateException If {@link #ledgerHash()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return ledgerHash()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
+
+  /**
    * The Ledger Index of the ledger version used to generate this response.
    *
    * @return A {@link LedgerIndex}.
+   * @deprecated When requesting Account Channels from a non-validated ledger, the result will not contain this field.
+   *   To prevent this class from throwing an error when requesting Account Currencies from a non-validated ledger, this
+   *   field is currently marked as {@link Nullable}. However, this field will be {@link Optional} in a future release.
    */
+  @Deprecated
+  @Nullable
   @JsonProperty("ledger_index")
   LedgerIndex ledgerIndex();
+
+  /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is null.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is null.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return Optional.ofNullable(ledgerIndex())
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
+   * The ledger index of the current open ledger, which was used when retrieving this information. Only present
+   * in responses to requests with ledger_index = "current".
+   *
+   * @return An optionally-present {@link LedgerIndex} representing the current ledger index.
+   */
+  @JsonProperty("ledger_current_index")
+  Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * If true, the information in this response comes from a validated ledger version.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.accounts;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -36,6 +37,28 @@ public interface AccountInfoResult extends XrplResult {
   AccountRootObject accountData();
 
   /**
+   * (Omitted if ledger_current_index is provided instead) The ledger index of the ledger version used when
+   * retrieving this information. The information does not contain any changes from ledger versions newer than this one.
+   *
+   * @return An optionally-present {@link LedgerIndex}.
+   */
+  @JsonProperty("ledger_index")
+  Optional<LedgerIndex> ledgerIndex();
+
+  /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
    * (Omitted if ledger_index is provided instead) The ledger index of the current in-progress ledger,
    * which was used when retrieving this information.
    *
@@ -45,13 +68,18 @@ public interface AccountInfoResult extends XrplResult {
   Optional<LedgerIndex> ledgerCurrentIndex();
 
   /**
-   * (Omitted if ledger_current_index is provided instead) The ledger index of the ledger version used when
-   * retrieving this information. The information does not contain any changes from ledger versions newer than this one.
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
    *
-   * @return An optionally-present {@link LedgerIndex}.
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
    */
-  @JsonProperty("ledger_index")
-  Optional<LedgerIndex> ledgerIndex();
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * (Omitted unless queue specified as true and querying the current open ledger.)

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.accounts;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -46,12 +47,25 @@ public interface AccountLinesResult extends XrplResult {
   List<TrustLine> lines();
 
   /**
-   * The ledger index of the current open ledger, which was used when retrieving this information.
+   * The identifying hash the ledger version that was used when retrieving this data.
    *
-   * @return An optionally-present {@link LedgerIndex} representing the current ledger index.
+   * @return An optionally-present {@link org.xrpl.xrpl4j.model.transactions.Hash256}.
    */
-  @JsonProperty("ledger_current_index")
-  Optional<LedgerIndex> ledgerCurrentIndex();
+  @JsonProperty("ledger_hash")
+  Optional<Hash256> ledgerHash();
+
+  /**
+   * Get {@link #ledgerHash()}, or throw an {@link IllegalStateException} if {@link #ledgerHash()} is empty.
+   *
+   * @return The value of {@link #ledgerHash()}.
+   * @throws IllegalStateException If {@link #ledgerHash()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return ledgerHash()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
 
   /**
    * The ledger index of the ledger version that was used when retrieving this data.
@@ -62,12 +76,39 @@ public interface AccountLinesResult extends XrplResult {
   Optional<LedgerIndex> ledgerIndex();
 
   /**
-   * The identifying hash the ledger version that was used when retrieving this data.
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
    *
-   * @return An optionally-present {@link org.xrpl.xrpl4j.model.transactions.Hash256}.
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
    */
-  @JsonProperty("ledger_hash")
-  Optional<Hash256> ledgerHash();
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
+   * The ledger index of the current open ledger, which was used when retrieving this information.
+   *
+   * @return An optionally-present {@link LedgerIndex} representing the current ledger index.
+   */
+  @JsonProperty("ledger_current_index")
+  Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * Server-defined value indicating the response is paginated. Pass this to the next call to resume where this

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.accounts;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -57,12 +58,38 @@ public interface AccountObjectsResult extends XrplResult {
   Optional<Hash256> ledgerHash();
 
   /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return ledgerHash()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
+
+  /**
    * The ledger index of the ledger version that was used to generate this {@link AccountObjectsResult}.
    *
    * @return An optionally-present {@link LedgerIndex}.
    */
   @JsonProperty("ledger_index")
   Optional<LedgerIndex> ledgerIndex();
+
+  /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
 
   /**
    * The ledger index of the current in-progress ledger version, which was used to generate this
@@ -72,6 +99,20 @@ public interface AccountObjectsResult extends XrplResult {
    */
   @JsonProperty("ledger_current_index")
   Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * The {@link AccountObjectsRequestParams#limit()} that was used in the corresponding request, if any.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountOffersResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountOffersResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.accounts;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -42,13 +43,25 @@ public interface AccountOffersResult extends XrplResult {
   List<OfferResultObject> offers();
 
   /**
-   * Omitted if ledger_hash or ledger_index provided. The ledger index
-   * of the current in-progress ledger version, which was used when retrieving this data.
+   * The identifying Hash of the ledger version used to generate this response.
    *
-   * @return A {@link LedgerIndex}.
+   * @return A {@link Hash256} containing the ledger hash.
    */
-  @JsonProperty("ledger_current_index")
-  Optional<LedgerIndex> ledgerCurrentIndex();
+  @JsonProperty("ledger_hash")
+  Optional<Hash256> ledgerHash();
+
+  /**
+   * Get {@link #ledgerHash()}, or throw an {@link IllegalStateException} if {@link #ledgerHash()} is empty.
+   *
+   * @return The value of {@link #ledgerHash()}.
+   * @throws IllegalStateException If {@link #ledgerHash()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return ledgerHash()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
 
   /**
    * The Ledger Index of the ledger version used to generate this response.
@@ -59,12 +72,40 @@ public interface AccountOffersResult extends XrplResult {
   Optional<LedgerIndex> ledgerIndex();
 
   /**
-   * The identifying Hash of the ledger version used to generate this response.
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
    *
-   * @return A {@link Hash256} containing the ledger hash.
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
    */
-  @JsonProperty("ledger_hash")
-  Optional<Hash256> ledgerHash();
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
+   * Omitted if ledger_hash or ledger_index provided. The ledger index
+   * of the current in-progress ledger version, which was used when retrieving this data.
+   *
+   * @return A {@link LedgerIndex}.
+   */
+  @JsonProperty("ledger_current_index")
+  Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * Server-defined value for pagination. Pass this to the next call to resume getting results where this

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/ledger/LedgerResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/ledger/LedgerResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.ledger;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -44,12 +45,38 @@ public interface LedgerResult extends XrplResult {
   Optional<Hash256> ledgerHash();
 
   /**
+   * Get {@link #ledgerHash()}, or throw an {@link IllegalStateException} if {@link #ledgerHash()} is empty.
+   *
+   * @return The value of {@link #ledgerHash()}.
+   * @throws IllegalStateException If {@link #ledgerHash()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return ledgerHash()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
+
+  /**
    * The {@link LedgerIndex} of this ledger.
    *
    * @return The {@link LedgerIndex} of this ledger.
    */
   @JsonProperty("ledger_index")
   Optional<LedgerIndex> ledgerIndex();
+
+  /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
 
   /**
    * The {@link LedgerIndex} of this ledger, if the ledger is the current ledger. Only present on a current ledger
@@ -59,6 +86,20 @@ public interface LedgerResult extends XrplResult {
    */
   @JsonProperty("ledger_current_index")
   Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * True if this data is from a validated ledger version; if false, this data is not final.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/path/DepositAuthorizedResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/path/DepositAuthorizedResult.java
@@ -1,5 +1,6 @@
 package org.xrpl.xrpl4j.model.client.path;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -65,6 +66,19 @@ public interface DepositAuthorizedResult extends XrplResult {
   Optional<Hash256> ledgerHash();
 
   /**
+   * Get {@link #ledgerHash()}, or throw an {@link IllegalStateException} if {@link #ledgerHash()} is empty.
+   *
+   * @return The value of {@link #ledgerHash()}.
+   * @throws IllegalStateException If {@link #ledgerHash()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default Hash256 ledgerHashSafe() {
+    return ledgerHash()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerHash."));
+  }
+
+  /**
    * (Omitted if ledger_current_index is provided instead) The ledger index of the ledger version used when retrieving
    * this information. The information does not contain any changes from ledger versions newer than this one.
    *
@@ -74,6 +88,19 @@ public interface DepositAuthorizedResult extends XrplResult {
   Optional<LedgerIndex> ledgerIndex();
 
   /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
    * (Omitted if ledger_index is provided instead) The ledger index of the current in-progress ledger, which was used
    * when retrieving this information.
    *
@@ -81,6 +108,20 @@ public interface DepositAuthorizedResult extends XrplResult {
    */
   @JsonProperty("ledger_current_index")
   Optional<LedgerIndex> ledgerCurrentIndex();
+
+  /**
+   * Get {@link #ledgerCurrentIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerCurrentIndex()} is
+   * empty.
+   *
+   * @return The value of {@link #ledgerCurrentIndex()}.
+   * @throws IllegalStateException If {@link #ledgerCurrentIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerCurrentIndexSafe() {
+    return ledgerCurrentIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerCurrentIndex."));
+  }
 
   /**
    * True if this data is from a validated ledger version; if false, this data is not final.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResult.java
@@ -63,6 +63,19 @@ public interface TransactionResult<TxnType extends Transaction> extends XrplResu
   Optional<LedgerIndex> ledgerIndex();
 
   /**
+   * Get {@link #ledgerIndex()}, or throw an {@link IllegalStateException} if {@link #ledgerIndex()} is empty.
+   *
+   * @return The value of {@link #ledgerIndex()}.
+   * @throws IllegalStateException If {@link #ledgerIndex()} is empty.
+   */
+  @JsonIgnore
+  @Value.Auxiliary
+  default LedgerIndex ledgerIndexSafe() {
+    return ledgerIndex()
+      .orElseThrow(() -> new IllegalStateException("Result did not contain a ledgerIndex."));
+  }
+
+  /**
    * The identifying hash of the {@link Transaction}.
    *
    * @return The {@link Hash256} of {@link #transaction()}.

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResultJsonTests.java
@@ -66,6 +66,55 @@ public class AccountChannelsResultJsonTests extends AbstractJsonTest {
   }
 
   @Test
+  public void testJsonWithoutLedgerHash() throws JsonProcessingException, JSONException {
+    AccountChannelsResult result = AccountChannelsResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addChannels(
+        PaymentChannelResultObject.builder()
+          .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+          .amount(XrpCurrencyAmount.ofDrops(100000000))
+          .balance(XrpCurrencyAmount.ofDrops(0))
+          .channelId(Hash256.of("5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3"))
+          .destinationAccount(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+          .destinationTag(UnsignedInteger.valueOf(20170428))
+          .publicKey("aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3")
+          .publicKeyHex("023693F15967AE357D0327974AD46FE3C127113B1110D6044FD41E723689F81CC6")
+          .expiration(UnsignedLong.valueOf(10000))
+          .cancelAfter(UnsignedLong.valueOf(10000))
+          .sourceTag(UnsignedInteger.valueOf(10000))
+          .settleDelay(UnsignedInteger.valueOf(86400))
+          .build()
+      )
+      .build();
+
+    String json = "{\n" +
+      "        \"account\": \"rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH\",\n" +
+      "        \"channels\": [{\n" +
+      "            \"account\": \"rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH\",\n" +
+      "            \"amount\": \"100000000\",\n" +
+      "            \"balance\": \"0\",\n" +
+      "            \"channel_id\": \"5DB01B7FFED6B67E6B0414DED11E051D2EE2B7619CE0EAA6286D67A3A4D5BDB3\",\n" +
+      "            \"destination_account\": \"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn\",\n" +
+      "            \"destination_tag\": 20170428,\n" +
+      "            \"public_key\": \"aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3\",\n" +
+      "            \"public_key_hex\": \"023693F15967AE357D0327974AD46FE3C127113B1110D6044FD41E723689F81CC6\",\n" +
+      "            \"expiration\": 10000,\n" +
+      "            \"cancel_after\": 10000,\n" +
+      "            \"source_tag\": 10000,\n" +
+      "            \"settle_delay\": 86400\n" +
+      "        }],\n" +
+      "        \"ledger_index\": 37230600,\n" +
+      "        \"status\": \"success\",\n" +
+      "        \"validated\": true\n" +
+      "    }";
+
+    assertCanSerializeAndDeserialize(result, json);
+  }
+
+  @Test
   public void testFullJson() throws JsonProcessingException, JSONException {
     AccountChannelsResult result = AccountChannelsResult.builder()
       .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountChannelsResultTest.java
@@ -1,0 +1,87 @@
+package org.xrpl.xrpl4j.model.client.accounts;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.primitives.UnsignedInteger;
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
+
+class AccountChannelsResultTest {
+
+  @Test
+  void testWithHash() {
+    AccountChannelsResult result = AccountChannelsResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addChannels(mock(PaymentChannelResultObject.class))
+      .build();
+
+    assertThat(result.ledgerHash()).isNotNull();
+    assertThat(result.ledgerHashSafe()).isEqualTo(result.ledgerHash());
+  }
+
+  @Test
+  void testWithoutHash() {
+    AccountChannelsResult result = AccountChannelsResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addChannels(mock(PaymentChannelResultObject.class))
+      .build();
+
+    assertThat(result.ledgerHash()).isNull();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerHashSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerIndex() {
+    AccountChannelsResult result = AccountChannelsResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addChannels(mock(PaymentChannelResultObject.class))
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotNull();
+    assertThat(result.ledgerIndexSafe()).isEqualTo(result.ledgerIndex());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    AccountChannelsResult result = AccountChannelsResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(false)
+      .addChannels(mock(PaymentChannelResultObject.class))
+      .build();
+
+    assertThat(result.ledgerIndex()).isNull();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountCurrenciesResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountCurrenciesResultJsonTests.java
@@ -3,6 +3,7 @@ package org.xrpl.xrpl4j.model.client.accounts;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
+import org.assertj.core.util.Lists;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
@@ -36,6 +37,35 @@ public class AccountCurrenciesResultJsonTests extends AbstractJsonTest {
       "        \"status\": \"success\",\n" +
       "        \"validated\": true\n" +
       "    }";
+
+    assertCanSerializeAndDeserialize(result, json);
+  }
+
+  @Test
+  void testCurrentJson() throws JSONException, JsonProcessingException {
+    AccountCurrenciesResult result = AccountCurrenciesResult.builder()
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(66467750)))
+      .status("success")
+      .validated(false)
+      .receiveCurrencies(Lists.newArrayList("BTC", "CNY", "015841551A748AD2C1F76FF6ECB0CCCD00000000"))
+      .sendCurrencies(Lists.newArrayList("ASP", "BTC", "USD"))
+      .build();
+
+    String json = "{\n" +
+      "        \"ledger_current_index\": 66467750,\n" +
+      "        \"receive_currencies\": [\n" +
+      "            \"BTC\",\n" +
+      "            \"CNY\",\n" +
+      "            \"015841551A748AD2C1F76FF6ECB0CCCD00000000\"\n" +
+      "        ],\n" +
+      "        \"send_currencies\": [\n" +
+      "            \"ASP\",\n" +
+      "            \"BTC\",\n" +
+      "            \"USD\"\n" +
+      "        ],\n" +
+      "        \"status\": \"success\",\n" +
+      "        \"validated\": false\n" +
+      "}";
 
     assertCanSerializeAndDeserialize(result, json);
   }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountCurrenciesResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountCurrenciesResultTest.java
@@ -1,0 +1,88 @@
+package org.xrpl.xrpl4j.model.client.accounts;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.primitives.UnsignedInteger;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+
+class AccountCurrenciesResultTest {
+
+  @Test
+  void testWithHash() {
+    AccountCurrenciesResult result = AccountCurrenciesResult.builder()
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addSendCurrencies("USD")
+      .addReceiveCurrencies("EUR")
+      .addReceiveCurrencies("USD")
+      .build();
+
+    assertThat(result.ledgerHash()).isNotEmpty().get().isEqualTo(result.ledgerHashSafe());
+  }
+
+  @Test
+  void testWithoutHash() {
+    AccountCurrenciesResult result = AccountCurrenciesResult.builder()
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addSendCurrencies("USD")
+      .addReceiveCurrencies("EUR")
+      .addReceiveCurrencies("USD")
+      .build();
+
+    assertThat(result.ledgerHash()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerHashSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerIndex() {
+    AccountCurrenciesResult result = AccountCurrenciesResult.builder()
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .validated(true)
+      .addSendCurrencies("USD")
+      .addReceiveCurrencies("EUR")
+      .addReceiveCurrencies("USD")
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotNull();
+    assertThat(result.ledgerIndexSafe()).isEqualTo(result.ledgerIndex());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    AccountCurrenciesResult result = AccountCurrenciesResult.builder()
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(66467750)))
+      .status("success")
+      .validated(false)
+      .receiveCurrencies(Lists.newArrayList("BTC", "CNY", "015841551A748AD2C1F76FF6ECB0CCCD00000000"))
+      .sendCurrencies(Lists.newArrayList("ASP", "BTC", "USD"))
+      .build();
+
+    assertThat(result.ledgerIndex()).isNull();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoResultTest.java
@@ -1,0 +1,50 @@
+package org.xrpl.xrpl4j.model.client.accounts;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.primitives.UnsignedInteger;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.ledger.AccountRootObject;
+
+class AccountInfoResultTest {
+
+  @Test
+  void testWithLedgerIndex() {
+    AccountInfoResult result = AccountInfoResult.builder()
+      .accountData(mock(AccountRootObject.class))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(4)))
+      .queueData(mock(QueueData.class))
+      .status("success")
+      .validated(true)
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotEmpty().get().isEqualTo(result.ledgerIndexSafe());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    AccountInfoResult result = AccountInfoResult.builder()
+      .accountData(mock(AccountRootObject.class))
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(4)))
+      .queueData(mock(QueueData.class))
+      .status("success")
+      .validated(true)
+      .build();
+
+    assertThat(result.ledgerIndex()).isEmpty();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResultJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResultJsonTests.java
@@ -5,6 +5,7 @@ import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.transactions.Address;
 
 public class AccountLinesResultJsonTests extends AbstractJsonTest {
@@ -14,6 +15,7 @@ public class AccountLinesResultJsonTests extends AbstractJsonTest {
     AccountLinesResult result = AccountLinesResult.builder()
       .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
       .status("success")
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.ONE))
       .addLines(
         TrustLine.builder()
           .account(Address.of("r3vi7mWxru9rJCxETCyA1CHvzL96eZWx5z"))
@@ -39,6 +41,7 @@ public class AccountLinesResultJsonTests extends AbstractJsonTest {
 
     String json = "{\n" +
       "        \"account\": \"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\n" +
+      "        \"ledger_index\": 1,\n" +
       "        \"lines\": [\n" +
       "            {\n" +
       "                \"account\": \"r3vi7mWxru9rJCxETCyA1CHvzL96eZWx5z\",\n" +

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountLinesResultTest.java
@@ -1,0 +1,73 @@
+package org.xrpl.xrpl4j.model.client.accounts;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.common.primitives.UnsignedInteger;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+
+class AccountLinesResultTest {
+
+  @Test
+  void testWithHash() {
+    AccountLinesResult result = AccountLinesResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .status("success")
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.ONE))
+      .build();
+
+    assertThat(result.ledgerHash()).isNotEmpty().get().isEqualTo(result.ledgerHashSafe());
+  }
+
+  @Test
+  void testWithoutHash() {
+    AccountLinesResult result = AccountLinesResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .status("success")
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.ONE))
+      .build();
+
+    assertThat(result.ledgerHash()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerHashSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerIndex() {
+    AccountLinesResult result = AccountLinesResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .status("success")
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.ONE))
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotEmpty().get().isEqualTo(result.ledgerIndexSafe());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    AccountLinesResult result = AccountLinesResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .status("success")
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.ONE))
+      .build();
+
+    assertThat(result.ledgerIndex()).isEmpty();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsResultTest.java
@@ -1,0 +1,77 @@
+package org.xrpl.xrpl4j.model.client.accounts;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.common.primitives.UnsignedInteger;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+
+class AccountObjectsResultTest {
+
+  @Test
+  void testWithHash() {
+    AccountObjectsResult result = AccountObjectsResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(14380380)))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .validated(true)
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerHash()).isNotEmpty().get().isEqualTo(result.ledgerHashSafe());
+  }
+
+  @Test
+  void testWithoutHash() {
+    AccountObjectsResult result = AccountObjectsResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(14380380)))
+      .validated(true)
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerHash()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerHashSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerIndex() {
+    AccountObjectsResult result = AccountObjectsResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(14380380)))
+      .validated(true)
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotEmpty().get().isEqualTo(result.ledgerIndexSafe());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    AccountObjectsResult result = AccountObjectsResult.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(14380380)))
+      .validated(true)
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerIndex()).isEmpty();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountOffersResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountOffersResultTest.java
@@ -1,0 +1,81 @@
+package org.xrpl.xrpl4j.model.client.accounts;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.common.primitives.UnsignedInteger;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.flags.Flags;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;
+import org.xrpl.xrpl4j.model.transactions.Marker;
+import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
+
+import java.math.BigDecimal;
+
+class AccountOffersResultTest {
+
+  @Test
+  void testWithHash() {
+    AccountOffersResult result = AccountOffersResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerHash()).isNotEmpty().get().isEqualTo(result.ledgerHashSafe());
+  }
+
+  @Test
+  void testWithoutHash() {
+    AccountOffersResult result = AccountOffersResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerHash()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerHashSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerIndex() {
+    AccountOffersResult result = AccountOffersResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotEmpty().get().isEqualTo(result.ledgerIndexSafe());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    AccountOffersResult result = AccountOffersResult.builder()
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+      .ledgerHash(Hash256.of("B9D3D80EDF4083A06B2D51202E0BFB63C46FC0985E015D06767C21A62853BF6D"))
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(37230600)))
+      .status("success")
+      .build();
+
+    assertThat(result.ledgerIndex()).isEmpty();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/ledger/LedgerResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/ledger/LedgerResultTest.java
@@ -1,0 +1,82 @@
+package org.xrpl.xrpl4j.model.client.ledger;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.primitives.UnsignedInteger;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.accounts.AccountLinesResult;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.ledger.LedgerHeader;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+
+class LedgerResultTest {
+
+  @Test
+  void testWithHash() {
+    LedgerResult result = LedgerResult.builder()
+      .status("success")
+      .ledgerHash(Hash256.of("3652D7FD0576BC452C0D2E9B747BDD733075971D1A9A1D98125055DEF428721A"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(54300940)))
+      .validated(true)
+      .ledger(mock(LedgerHeader.class))
+      .build();
+
+    assertThat(result.ledgerHash()).isNotEmpty().get().isEqualTo(result.ledgerHashSafe());
+  }
+
+  @Test
+  void testWithoutHash() {
+    LedgerResult result = LedgerResult.builder()
+      .status("success")
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(54300940)))
+      .validated(true)
+      .ledger(mock(LedgerHeader.class))
+      .build();
+
+    assertThat(result.ledgerHash()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerHashSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerIndex() {
+    LedgerResult result = LedgerResult.builder()
+      .status("success")
+      .ledgerHash(Hash256.of("3652D7FD0576BC452C0D2E9B747BDD733075971D1A9A1D98125055DEF428721A"))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.valueOf(54300940)))
+      .validated(true)
+      .ledger(mock(LedgerHeader.class))
+      .build();
+
+    assertThat(result.ledgerIndex()).isNotEmpty().get().isEqualTo(result.ledgerIndexSafe());
+    assertThat(result.ledgerCurrentIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerCurrentIndexSafe
+    );
+  }
+
+  @Test
+  void testWithLedgerCurrentIndex() {
+    LedgerResult result = LedgerResult.builder()
+      .status("success")
+      .ledgerHash(Hash256.of("3652D7FD0576BC452C0D2E9B747BDD733075971D1A9A1D98125055DEF428721A"))
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(54300940)))
+      .validated(true)
+      .ledger(mock(LedgerHeader.class))
+      .build();
+
+    assertThat(result.ledgerIndex()).isEmpty();
+    assertThat(result.ledgerCurrentIndex()).isNotEmpty().get().isEqualTo(result.ledgerCurrentIndexSafe());
+    assertThrows(
+      IllegalStateException.class,
+      result::ledgerIndexSafe
+    );
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/transactions/TransactionResultTest.java
@@ -1,0 +1,63 @@
+package org.xrpl.xrpl4j.model.client.transactions;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.primitives.UnsignedInteger;
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.Payment;
+import org.xrpl.xrpl4j.model.transactions.TransactionMetadata;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+class TransactionResultTest {
+
+  @Test
+  void testLedgerIndexSafeWithLedgerIndex() {
+    TransactionResult<Payment> paymentResult = TransactionResult.<Payment>builder()
+      .transaction(mock(Payment.class))
+      .hash(Hash256.of("E939C30F233E3E6B0A9F829BDDA258CB9DA38D11C0F66C7D60E38B9D9FA987B8"))
+      .closeDate(UnsignedLong.valueOf(666212460))
+      .metadata(mock(TransactionMetadata.class))
+      .ledgerIndex(LedgerIndex.of(UnsignedInteger.ONE))
+      .build();
+
+    assertThat(paymentResult.ledgerIndex()).isNotEmpty().get().isEqualTo(paymentResult.ledgerIndexSafe());
+  }
+
+  @Test
+  void testLedgerIndexSafeWithoutLedgerIndex() {
+    TransactionResult<Payment> paymentResult = TransactionResult.<Payment>builder()
+      .transaction(mock(Payment.class))
+      .hash(Hash256.of("E939C30F233E3E6B0A9F829BDDA258CB9DA38D11C0F66C7D60E38B9D9FA987B8"))
+      .closeDate(UnsignedLong.valueOf(666212460))
+      .metadata(mock(TransactionMetadata.class))
+      .build();
+
+    assertThat(paymentResult.ledgerIndex()).isEmpty();
+    assertThrows(
+      IllegalStateException.class,
+      paymentResult::ledgerIndexSafe
+    );
+  }
+
+  @Test
+  void testCloseTimeHuman() {
+    TransactionResult<Payment> paymentResult = TransactionResult.<Payment>builder()
+      .transaction(mock(Payment.class))
+      .hash(Hash256.of("E939C30F233E3E6B0A9F829BDDA258CB9DA38D11C0F66C7D60E38B9D9FA987B8"))
+      .closeDate(UnsignedLong.valueOf(666212460))
+      .metadata(mock(TransactionMetadata.class))
+      .build();
+
+    assertThat(paymentResult.closeDateHuman()).hasValue(
+      ZonedDateTime.of(LocalDateTime.of(2021, 2, 9, 19, 1, 0), ZoneId.of("UTC"))
+    );
+  }
+}


### PR DESCRIPTION
Fixes #135 

Also deprecates and makes `AccountChannelsResult.ledgerIndex` nullable, since the response to a request for the "current" channels has `ledger_current_index`, not `ledger_index`.