### PR TITLE
Introduce DelegatedKeyPairService and split Abstract signature service classes

### DIFF
--- a/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/main/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/main/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureService.java
@@ -165,11 +165,6 @@ public class DerivedKeyDelegatedSignatureService implements DelegatedSignatureSe
   }
 
   @Override
-  public PublicKey createKeyPair(KeyMetadata keyMetadata) {
-    return getSignatureServiceSafe(keyMetadata).createKeyPair(keyMetadata);
-  }
-
-  @Override
   public PublicKey getPublicKey(final KeyMetadata keyMetadata) {
     Objects.requireNonNull(keyMetadata);
     return getSignatureServiceSafe(keyMetadata).getPublicKey(keyMetadata);
@@ -422,11 +417,6 @@ public class DerivedKeyDelegatedSignatureService implements DelegatedSignatureSe
         return Signature.builder()
           .value(sigBytes)
           .build();
-      }
-
-      @Override
-      public PublicKey createKeyPair(KeyMetadata keyMetadata) {
-        return getPublicKey(keyMetadata);
       }
 
       @Override

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/main/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/main/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureService.java
@@ -167,11 +167,6 @@ public class DerivedKeyDelegatedSignatureService implements DelegatedSignatureSe
   }
 
   @Override
-  public KeyStoreType keyStoreType() {
-    return DERIVED_SERVER_SECRET;
-  }
-
-  @Override
   public PublicKey getPublicKey(final KeyMetadata keyMetadata) {
     Objects.requireNonNull(keyMetadata);
     return getSignatureServiceSafe(keyMetadata).getPublicKey(keyMetadata);
@@ -320,8 +315,6 @@ public class DerivedKeyDelegatedSignatureService implements DelegatedSignatureSe
   private static class SingleKeySignatureService
     extends AbstractDelegatedSignatureService implements DelegatedSignatureService {
 
-    private static final KeyStoreType KEY_STORE_TYPE = KeyStoreType.fromKeystoreTypeId("in-memory-single-key");
-
     private final Ed25519Signer ed25519Signer;
     private final ECDSASigner ecdsaSigner;
     private final PrivateKey privateKey;
@@ -333,7 +326,6 @@ public class DerivedKeyDelegatedSignatureService implements DelegatedSignatureSe
      */
     private SingleKeySignatureService(final PrivateKey privateKey) {
       super(
-        KEY_STORE_TYPE,
         new SignatureUtils(ObjectMapperFactory.create(), new XrplBinaryCodec()),
         AddressUtils.getInstance()
       );

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/main/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/main/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureService.java
@@ -1,7 +1,5 @@
 package org.xrpl.xrpl4j.crypto.bc;
 
-import static org.xrpl.xrpl4j.crypto.core.KeyStoreType.DERIVED_SERVER_SECRET;
-
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -23,7 +21,6 @@ import org.xrpl.xrpl4j.codec.binary.XrplBinaryCodec;
 import org.xrpl.xrpl4j.crypto.core.AddressUtils;
 import org.xrpl.xrpl4j.crypto.core.HashingUtils;
 import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
-import org.xrpl.xrpl4j.crypto.core.KeyStoreType;
 import org.xrpl.xrpl4j.crypto.core.ServerSecret;
 import org.xrpl.xrpl4j.crypto.core.ServerSecretSupplier;
 import org.xrpl.xrpl4j.crypto.core.keys.Ed25519KeyPairService;
@@ -34,6 +31,8 @@ import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
 import org.xrpl.xrpl4j.crypto.core.keys.Secp256k1KeyPairService;
 import org.xrpl.xrpl4j.crypto.core.keys.Seed;
 import org.xrpl.xrpl4j.crypto.core.signing.AbstractDelegatedSignatureService;
+import org.xrpl.xrpl4j.crypto.core.signing.AbstractDelegatedTransactionSigner;
+import org.xrpl.xrpl4j.crypto.core.signing.AbstractDelegatedTransactionVerifier;
 import org.xrpl.xrpl4j.crypto.core.signing.DelegatedSignatureService;
 import org.xrpl.xrpl4j.crypto.core.signing.EcDsaSignature;
 import org.xrpl.xrpl4j.crypto.core.signing.Signature;
@@ -70,7 +69,7 @@ public class DerivedKeyDelegatedSignatureService implements DelegatedSignatureSe
   private final Ed25519KeyPairService ed25519KeyPairService;
   private final Secp256k1KeyPairService secp256k1KeyPairService;
 
-  private final LoadingCache<KeyMetadata, SingleKeySignatureService> keyMetadataLoadingCache;
+  private final LoadingCache<KeyMetadata, SingleKeyDelegatedSignatureService> keyMetadataLoadingCache;
 
   private final ServerSecretSupplier serverSecretSupplier;
 
@@ -218,7 +217,7 @@ public class DerivedKeyDelegatedSignatureService implements DelegatedSignatureSe
    * @return A {@link BouncyCastleSignatureService}.
    */
   @VisibleForTesting
-  protected SingleKeySignatureService constructSignatureService(final KeyMetadata privateKeyMetadata) {
+  protected SingleKeyDelegatedSignatureService constructSignatureService(final KeyMetadata privateKeyMetadata) {
     Objects.requireNonNull(privateKeyMetadata);
 
     final KeyPair keyPair;
@@ -233,7 +232,7 @@ public class DerivedKeyDelegatedSignatureService implements DelegatedSignatureSe
     }
 
     final PrivateKey privateKey = keyPair.privateKey();
-    return new SingleKeySignatureService(privateKey);
+    return new SingleKeyDelegatedSignatureService(privateKey);
   }
 
   /**
@@ -306,138 +305,201 @@ public class DerivedKeyDelegatedSignatureService implements DelegatedSignatureSe
   }
 
   /**
-   * <p>A {@link SignatureService} that holds a single private key, in-memory, using BouncyCastle as the underlying
-   * crypto implementation.</p>
+   * <p>A {@link DelegatedSignatureService} that holds a single private key, in-memory, using BouncyCastle as the
+   * underlying crypto implementation.</p>
    *
    * <p>WARNING: This implementation _might_ be appropriate for Android use, but should likely not be used in a
    * server-side context. In general, prefer an implementation that offers a higher level of security.</p>
    */
-  private static class SingleKeySignatureService
+  private static class SingleKeyDelegatedSignatureService
     extends AbstractDelegatedSignatureService implements DelegatedSignatureService {
 
-    private final Ed25519Signer ed25519Signer;
-    private final ECDSASigner ecdsaSigner;
-    private final PrivateKey privateKey;
+    private SingleKeyDelegatedSignatureService(
+      final PrivateKey privateKey,
+      final SignatureUtils signatureUtils,
+      final AddressUtils addressUtils
+    ) {
+      super(
+        new SingleKeyDelegatedTransactionSigner(
+          privateKey,
+          signatureUtils,
+          addressUtils
+        ),
+        new SingleKeyDelegatedTransactionVerifier(
+          privateKey,
+          signatureUtils,
+          addressUtils
+        )
+      );
+    }
 
     /**
      * Required-args Constructor for use in development mode.
      *
      * @param privateKey A {@link KeyStore} to load all private keys from.
      */
-    private SingleKeySignatureService(final PrivateKey privateKey) {
-      super(
+    private SingleKeyDelegatedSignatureService(final PrivateKey privateKey) {
+      this(
+        privateKey,
         new SignatureUtils(ObjectMapperFactory.create(), new XrplBinaryCodec()),
         AddressUtils.getInstance()
       );
-      this.ed25519Signer = new Ed25519Signer();
-      this.ecdsaSigner = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest()));
-      this.privateKey = Objects.requireNonNull(privateKey);
     }
 
-    @Override
-    public PublicKey getPublicKey(final KeyMetadata privateKeyMetadata) {
-      Objects.requireNonNull(privateKeyMetadata);
-      return BcKeyUtils.toPublicKey(this.privateKey);
-    }
+    /**
+     * <p>A {@link org.xrpl.xrpl4j.crypto.core.signing.DelegatedTransactionSigner} that holds a single private key,
+     * in-memory, using BouncyCastle as the underlying crypto implementation.</p>
+     */
+    private static class SingleKeyDelegatedTransactionSigner extends AbstractDelegatedTransactionSigner {
 
-    @Override
-    protected synchronized Signature edDsaSign(
-      final KeyMetadata privateKeyMetadata, final UnsignedByteArray signableTransactionBytes
-    ) {
-      Objects.requireNonNull(privateKeyMetadata);
-      Objects.requireNonNull(signableTransactionBytes);
+      private final Ed25519Signer ed25519Signer;
+      private final ECDSASigner ecdsaSigner;
+      private final PrivateKey privateKey;
 
-      Ed25519PrivateKeyParameters privateKeyParameters = BcKeyUtils.toEd25519PrivateKeyParams(privateKey);
-
-      ed25519Signer.reset();
-      ed25519Signer.init(true, privateKeyParameters);
-      ed25519Signer.update(
-        signableTransactionBytes.toByteArray(), 0, signableTransactionBytes.getUnsignedBytes().size()
-      );
-
-      final UnsignedByteArray sigBytes = UnsignedByteArray.of(ed25519Signer.generateSignature());
-      return Signature.builder()
-        .value(sigBytes)
-        .build();
-    }
-
-    @Override
-    protected synchronized boolean edDsaVerify(
-      final KeyMetadata keyMetadata,
-      final UnsignedByteArray signableTransactionBytes,
-      final Signature transactionSignature
-    ) {
-      Objects.requireNonNull(keyMetadata);
-      Objects.requireNonNull(signableTransactionBytes);
-      Objects.requireNonNull(transactionSignature);
-
-      final PublicKey publicKey = this.getPublicKey(keyMetadata);
-      final Ed25519PublicKeyParameters bcPublicKey = BcKeyUtils.toEd25519PublicKeyParameters(
-        publicKey);
-
-      ed25519Signer.reset();
-      ed25519Signer.init(false, bcPublicKey);
-      ed25519Signer.update(signableTransactionBytes.toByteArray(), 0,
-        signableTransactionBytes.getUnsignedBytes().size());
-
-      return ed25519Signer.verifySignature(
-        transactionSignature.value().toByteArray()
-      );
-    }
-
-    @SuppressWarnings("checkstyle:LocalVariableName")
-    @Override
-    protected synchronized Signature ecDsaSign(
-      final KeyMetadata keyMetadata, final UnsignedByteArray signableTransactionBytes
-    ) {
-      Objects.requireNonNull(keyMetadata);
-      Objects.requireNonNull(signableTransactionBytes);
-
-      final UnsignedByteArray messageHash = HashingUtils.sha512Half(signableTransactionBytes);
-
-      final ECPrivateKeyParameters parameters = BcKeyUtils.toEcPrivateKeyParams(privateKey);
-
-      ecdsaSigner.init(true, parameters);
-      final BigInteger[] signatures = ecdsaSigner.generateSignature(messageHash.toByteArray());
-      final BigInteger r = signatures[0];
-      BigInteger s = signatures[1];
-      final BigInteger otherS = Secp256k1.EC_DOMAIN_PARAMETERS.getN().subtract(s);
-      if (s.compareTo(otherS) > 0) {
-        s = otherS;
+      private SingleKeyDelegatedTransactionSigner(
+        PrivateKey privateKey,
+        SignatureUtils signatureUtils,
+        AddressUtils addressUtils
+      ) {
+        super(signatureUtils, addressUtils);
+        this.ed25519Signer = new Ed25519Signer();
+        this.ecdsaSigner = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest()));
+        this.privateKey = privateKey;
       }
 
-      final EcDsaSignature sig = EcDsaSignature.builder()
-        .r(r)
-        .s(s)
-        .build();
+      @Override
+      protected synchronized Signature edDsaSign(
+        final KeyMetadata privateKeyMetadata, final UnsignedByteArray signableTransactionBytes
+      ) {
+        Objects.requireNonNull(privateKeyMetadata);
+        Objects.requireNonNull(signableTransactionBytes);
 
-      UnsignedByteArray sigBytes = sig.der();
-      return Signature.builder()
-        .value(sigBytes)
-        .build();
-    }
+        Ed25519PrivateKeyParameters privateKeyParameters = BcKeyUtils.toEd25519PrivateKeyParams(privateKey);
 
-    @Override
-    protected synchronized boolean ecDsaVerify(
-      final KeyMetadata keyMetadata,
-      final UnsignedByteArray signableTransactionBytes,
-      final Signature transactionSignature
-    ) {
-      Objects.requireNonNull(keyMetadata);
-      Objects.requireNonNull(signableTransactionBytes);
-      Objects.requireNonNull(transactionSignature);
+        ed25519Signer.reset();
+        ed25519Signer.init(true, privateKeyParameters);
+        ed25519Signer.update(
+          signableTransactionBytes.toByteArray(), 0, signableTransactionBytes.getUnsignedBytes().size()
+        );
 
-      final PublicKey publicKey = this.getPublicKey(keyMetadata);
-      final ECPublicKeyParameters bcPublicKey = BcKeyUtils.toEcPublicKeyParameters(publicKey);
-
-      UnsignedByteArray messageHash = HashingUtils.sha512Half(signableTransactionBytes);
-      EcDsaSignature sig = EcDsaSignature.fromDer(transactionSignature.value().toByteArray());
-      if (sig == null) {
-        return false;
+        final UnsignedByteArray sigBytes = UnsignedByteArray.of(ed25519Signer.generateSignature());
+        return Signature.builder()
+          .value(sigBytes)
+          .build();
       }
 
-      ecdsaSigner.init(false, bcPublicKey);
-      return ecdsaSigner.verifySignature(messageHash.toByteArray(), sig.r(), sig.s());
+      @SuppressWarnings("checkstyle:LocalVariableName")
+      @Override
+      protected synchronized Signature ecDsaSign(
+        final KeyMetadata keyMetadata, final UnsignedByteArray signableTransactionBytes
+      ) {
+        Objects.requireNonNull(keyMetadata);
+        Objects.requireNonNull(signableTransactionBytes);
+
+        final UnsignedByteArray messageHash = HashingUtils.sha512Half(signableTransactionBytes);
+
+        final ECPrivateKeyParameters parameters = BcKeyUtils.toEcPrivateKeyParams(privateKey);
+
+        ecdsaSigner.init(true, parameters);
+        final BigInteger[] signatures = ecdsaSigner.generateSignature(messageHash.toByteArray());
+        final BigInteger r = signatures[0];
+        BigInteger s = signatures[1];
+        final BigInteger otherS = Secp256k1.EC_DOMAIN_PARAMETERS.getN().subtract(s);
+        if (s.compareTo(otherS) > 0) {
+          s = otherS;
+        }
+
+        final EcDsaSignature sig = EcDsaSignature.builder()
+          .r(r)
+          .s(s)
+          .build();
+
+        UnsignedByteArray sigBytes = sig.der();
+        return Signature.builder()
+          .value(sigBytes)
+          .build();
+      }
+
+      @Override
+      public PublicKey getPublicKey(KeyMetadata keyMetadata) {
+        Objects.requireNonNull(keyMetadata);
+        return BcKeyUtils.toPublicKey(this.privateKey);
+      }
+    }
+
+    /**
+     * <p>A {@link org.xrpl.xrpl4j.crypto.core.signing.TransactionVerifier} that holds a single private key, in-memory,
+     * using BouncyCastle as the underlying crypto implementation.</p>
+     */
+    private static class SingleKeyDelegatedTransactionVerifier extends AbstractDelegatedTransactionVerifier {
+
+      private final Ed25519Signer ed25519Signer;
+      private final ECDSASigner ecdsaSigner;
+      private final PrivateKey privateKey;
+
+      public SingleKeyDelegatedTransactionVerifier(
+        PrivateKey privateKey,
+        SignatureUtils signatureUtils,
+        AddressUtils addressUtils
+      ) {
+        super(signatureUtils, addressUtils);
+        this.ed25519Signer = new Ed25519Signer();
+        this.ecdsaSigner = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest()));
+        this.privateKey = privateKey;
+      }
+
+      @Override
+      protected synchronized boolean edDsaVerify(
+        final KeyMetadata keyMetadata,
+        final UnsignedByteArray signableTransactionBytes,
+        final Signature transactionSignature
+      ) {
+        Objects.requireNonNull(keyMetadata);
+        Objects.requireNonNull(signableTransactionBytes);
+        Objects.requireNonNull(transactionSignature);
+
+        final PublicKey publicKey = this.getPublicKey(keyMetadata);
+        final Ed25519PublicKeyParameters bcPublicKey = BcKeyUtils.toEd25519PublicKeyParameters(
+          publicKey);
+
+        ed25519Signer.reset();
+        ed25519Signer.init(false, bcPublicKey);
+        ed25519Signer.update(signableTransactionBytes.toByteArray(), 0,
+          signableTransactionBytes.getUnsignedBytes().size());
+
+        return ed25519Signer.verifySignature(
+          transactionSignature.value().toByteArray()
+        );
+      }
+
+      @Override
+      protected synchronized boolean ecDsaVerify(
+        final KeyMetadata keyMetadata,
+        final UnsignedByteArray signableTransactionBytes,
+        final Signature transactionSignature
+      ) {
+        Objects.requireNonNull(keyMetadata);
+        Objects.requireNonNull(signableTransactionBytes);
+        Objects.requireNonNull(transactionSignature);
+
+        final PublicKey publicKey = this.getPublicKey(keyMetadata);
+        final ECPublicKeyParameters bcPublicKey = BcKeyUtils.toEcPublicKeyParameters(publicKey);
+
+        UnsignedByteArray messageHash = HashingUtils.sha512Half(signableTransactionBytes);
+        EcDsaSignature sig = EcDsaSignature.fromDer(transactionSignature.value().toByteArray());
+        if (sig == null) {
+          return false;
+        }
+
+        ecdsaSigner.init(false, bcPublicKey);
+        return ecdsaSigner.verifySignature(messageHash.toByteArray(), sig.r(), sig.s());
+      }
+
+      @Override
+      public PublicKey getPublicKey(KeyMetadata keyMetadata) {
+        Objects.requireNonNull(keyMetadata);
+        return BcKeyUtils.toPublicKey(this.privateKey);
+      }
     }
   }
 

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/main/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/main/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureService.java
@@ -36,7 +36,6 @@ import org.xrpl.xrpl4j.crypto.core.signing.AbstractDelegatedTransactionVerifier;
 import org.xrpl.xrpl4j.crypto.core.signing.DelegatedSignatureService;
 import org.xrpl.xrpl4j.crypto.core.signing.EcDsaSignature;
 import org.xrpl.xrpl4j.crypto.core.signing.Signature;
-import org.xrpl.xrpl4j.crypto.core.signing.SignatureService;
 import org.xrpl.xrpl4j.crypto.core.signing.SignatureUtils;
 import org.xrpl.xrpl4j.crypto.core.signing.SignatureWithKeyMetadata;
 import org.xrpl.xrpl4j.crypto.core.signing.SingleSingedTransaction;
@@ -163,6 +162,11 @@ public class DerivedKeyDelegatedSignatureService implements DelegatedSignatureSe
     Objects.requireNonNull(keyMetadata);
     Objects.requireNonNull(transaction);
     return getSignatureServiceSafe(keyMetadata).multiSign(keyMetadata, transaction);
+  }
+
+  @Override
+  public PublicKey createKeyPair(KeyMetadata keyMetadata) {
+    return getSignatureServiceSafe(keyMetadata).createKeyPair(keyMetadata);
   }
 
   @Override
@@ -418,6 +422,11 @@ public class DerivedKeyDelegatedSignatureService implements DelegatedSignatureSe
         return Signature.builder()
           .value(sigBytes)
           .build();
+      }
+
+      @Override
+      public PublicKey createKeyPair(KeyMetadata keyMetadata) {
+        return getPublicKey(keyMetadata);
       }
 
       @Override

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/test/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureServiceTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/test/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureServiceTest.java
@@ -368,6 +368,14 @@ class DerivedKeyDelegatedSignatureServiceTest {
   }
 
   @Test
+  void createKeyPair() {
+    KeyMetadata keyMetadata = keyMetadata("ed_key");
+    PublicKey publicKey = this.edSignatureService.getPublicKey(keyMetadata);
+    PublicKey created = this.edSignatureService.createKeyPair(keyMetadata);
+    assertThat(created).isEqualTo(publicKey);
+  }
+
+  @Test
   void getPublicKeyEd() {
     PublicKey actualEcPublicKey = this.edSignatureService.getPublicKey(keyMetadata("ec_key"));
     assertThat(actualEcPublicKey.base16Value())

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/test/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureServiceTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/test/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureServiceTest.java
@@ -368,14 +368,6 @@ class DerivedKeyDelegatedSignatureServiceTest {
   }
 
   @Test
-  void createKeyPair() {
-    KeyMetadata keyMetadata = keyMetadata("ed_key");
-    PublicKey publicKey = this.edSignatureService.getPublicKey(keyMetadata);
-    PublicKey created = this.edSignatureService.createKeyPair(keyMetadata);
-    assertThat(created).isEqualTo(publicKey);
-  }
-
-  @Test
   void getPublicKeyEd() {
     PublicKey actualEcPublicKey = this.edSignatureService.getPublicKey(keyMetadata("ec_key"));
     assertThat(actualEcPublicKey.base16Value())

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/test/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureServiceTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/test/java/org/xrpl/xrpl4j/crypto/bc/DerivedKeyDelegatedSignatureServiceTest.java
@@ -151,12 +151,6 @@ class DerivedKeyDelegatedSignatureServiceTest {
     );
   }
 
-  @Test
-  void keyStoreType() {
-    assertThat(edSignatureService.keyStoreType()).isEqualTo(KeyStoreType.DERIVED_SERVER_SECRET);
-    assertThat(ecSignatureService.keyStoreType()).isEqualTo(KeyStoreType.DERIVED_SERVER_SECRET);
-  }
-
   /**
    * Note: this test runs in a loop solely to exercise concurrent correctness.
    */

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/keys/DelegatedKeyPairService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/keys/DelegatedKeyPairService.java
@@ -1,0 +1,21 @@
+package org.xrpl.xrpl4j.crypto.core.keys;
+
+import org.xrpl.xrpl4j.codec.addresses.VersionType;
+import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
+
+public interface DelegatedKeyPairService {
+
+  PublicKey createKeyPair(KeyMetadata keyMetadata, VersionType versionType);
+
+  /**
+   * Accessor for the public-key corresponding to the supplied key meta-data. This method exists to support
+   * implementations that hold private-key material internally, yet need a way for external callers to determine the
+   * actual public key for signature verification or other purposes.
+   *
+   * @param keyMetadata A {@link KeyMetadata} for a key-pair.
+   *
+   * @return A {@link PublicKey}.
+   */
+  PublicKey getPublicKey(KeyMetadata keyMetadata);
+
+}

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/keys/DelegatedKeyPairService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/keys/DelegatedKeyPairService.java
@@ -1,12 +1,13 @@
 package org.xrpl.xrpl4j.crypto.core.keys;
 
 import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
+import org.xrpl.xrpl4j.crypto.core.signing.DelegatedPublicKeyProvider;
 
 /**
  * Defines how to create XRPL public/private key pairs in a delegated manner, meaning private-key material is never
  * accessible via the runtime operating this service.
  */
-public interface DelegatedKeyPairService {
+public interface DelegatedKeyPairService extends DelegatedPublicKeyProvider {
 
   /**
    * Create a new delegated key pair. Because private keys managed by a {@link DelegatedKeyPairService} are
@@ -17,16 +18,5 @@ public interface DelegatedKeyPairService {
    * @return The {@link PublicKey} of the newly created key pair.
    */
   PublicKey createKeyPair(KeyMetadata keyMetadata);
-
-  /**
-   * Accessor for the public-key corresponding to the supplied key meta-data. This method exists to support
-   * implementations that hold private-key material internally, yet need a way for external callers to determine the
-   * actual public key for signature verification or other purposes.
-   *
-   * @param keyMetadata A {@link KeyMetadata} for a key-pair.
-   *
-   * @return A {@link PublicKey}.
-   */
-  PublicKey getPublicKey(KeyMetadata keyMetadata);
 
 }

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/keys/DelegatedKeyPairService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/keys/DelegatedKeyPairService.java
@@ -1,11 +1,10 @@
 package org.xrpl.xrpl4j.crypto.core.keys;
 
-import org.xrpl.xrpl4j.codec.addresses.VersionType;
 import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
 
 public interface DelegatedKeyPairService {
 
-  PublicKey createKeyPair(KeyMetadata keyMetadata, VersionType versionType);
+  PublicKey createKeyPair(KeyMetadata keyMetadata);
 
   /**
    * Accessor for the public-key corresponding to the supplied key meta-data. This method exists to support

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/keys/DelegatedKeyPairService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/keys/DelegatedKeyPairService.java
@@ -2,8 +2,20 @@ package org.xrpl.xrpl4j.crypto.core.keys;
 
 import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
 
+/**
+ * Defines how to create XRPL public/private key pairs in a delegated manner, meaning private-key material is never
+ * accessible via the runtime operating this service.
+ */
 public interface DelegatedKeyPairService {
 
+  /**
+   * Create a new delegated key pair. Because private keys managed by a {@link DelegatedKeyPairService} are
+   * assumed to be inaccessible to this runtime, this method simply returns the public key of the key pair.
+   *
+   * @param keyMetadata The {@link KeyMetadata} identifying the key pair to create.
+   *
+   * @return The {@link PublicKey} of the newly created key pair.
+   */
   PublicKey createKeyPair(KeyMetadata keyMetadata);
 
   /**

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureService.java
@@ -23,98 +23,37 @@ public abstract class AbstractDelegatedSignatureService implements DelegatedSign
 
   protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-  private final KeyStoreType keyStoreType;
+  private SignatureUtils signatureUtils = null;
 
-  private final SignatureUtils signatureUtils;
+  private AddressUtils addressService = null;
 
-  private final AddressUtils addressService;
+  private final DelegatedTransactionSigner delegatedTransactionSigner;
+  private final DelegatedTransactionVerifier delegatedTransactionVerifier;
 
-  /**
-   * Required-args Constructor.
-   *
-   * @param keyStoreType   The {@link KeyStoreType} for this service.
-   * @param signatureUtils An {@link SignatureUtils} for help with signing.
-   * @param addressService A {@link AddressUtils}.
-   */
-  public AbstractDelegatedSignatureService(
-    final KeyStoreType keyStoreType,
-    final SignatureUtils signatureUtils,
-    final AddressUtils addressService
-  ) {
-    this.keyStoreType = Objects.requireNonNull(keyStoreType);
-    this.signatureUtils = Objects.requireNonNull(signatureUtils);
-    this.addressService = Objects.requireNonNull(addressService);
+  public AbstractDelegatedSignatureService(DelegatedTransactionSigner delegatedTransactionSigner, DelegatedTransactionVerifier delegatedTransactionVerifier) {
+    this.delegatedTransactionSigner = delegatedTransactionSigner;
+    this.delegatedTransactionVerifier = delegatedTransactionVerifier;
   }
 
+
   @Override
-  public final KeyStoreType keyStoreType() {
-    return this.keyStoreType;
+  public PublicKey getPublicKey(KeyMetadata keyMetadata) {
+    return null;
   }
 
   @Override
   public <T extends Transaction> SingleSingedTransaction<T> sign(KeyMetadata keyMetadata, T transaction) {
-    Objects.requireNonNull(keyMetadata);
-    Objects.requireNonNull(transaction);
-
-    final UnsignedByteArray signableTransactionBytes = this.signatureUtils.toSignableBytes(transaction);
-    final Signature signature = this.signingHelper(keyMetadata, signableTransactionBytes).transactionSignature();
-    return this.signatureUtils.addSignatureToTransaction(transaction, signature);
+    return delegatedTransactionSigner.sign(keyMetadata, transaction);
   }
 
   @Override
-  public Signature sign(final KeyMetadata keyMetadata, final UnsignedClaim unsignedClaim) {
-    Objects.requireNonNull(keyMetadata);
-    Objects.requireNonNull(unsignedClaim);
-
-    final UnsignedByteArray signableBytes = signatureUtils.toSignableBytes(unsignedClaim);
-    return this.signingHelper(keyMetadata, signableBytes).transactionSignature();
+  public Signature sign(KeyMetadata keyMetadata, UnsignedClaim unsignedClaim) {
+    return null;
   }
 
   @Override
   public <T extends Transaction> SignatureWithKeyMetadata multiSign(KeyMetadata keyMetadata, T transaction) {
-    Objects.requireNonNull(keyMetadata);
-    Objects.requireNonNull(transaction);
-
-    final Address address = addressService.deriveAddress(this.getPublicKey(keyMetadata));
-    final UnsignedByteArray signableTransactionBytes = this.signatureUtils.toMultiSignableBytes(transaction, address);
-
-    return this.signingHelper(keyMetadata, signableTransactionBytes);
-  }
-
-  /**
-   * Helper to generate a signature based upon an {@link UnsignedByteArray} of transaction bytes.
-   *
-   * @param keyMetadata              A {@link KeyMetadata} for the signing key.
-   * @param signableTransactionBytes A {@link UnsignedByteArray} of transaction bytes.
-   *
-   * @return A {@link SignatureWithPublicKey}.
-   */
-  private SignatureWithKeyMetadata signingHelper(
-    final KeyMetadata keyMetadata, final UnsignedByteArray signableTransactionBytes
-  ) {
-    Objects.requireNonNull(keyMetadata);
-    Objects.requireNonNull(signableTransactionBytes);
-
-    final PublicKey publicKey = this.getPublicKey(keyMetadata);
-    final Signature signature;
-    switch (publicKey.versionType()) {
-      case ED25519: {
-        signature = this.edDsaSign(keyMetadata, signableTransactionBytes);
-        break;
-      }
-      case SECP256K1: {
-        signature = this.ecDsaSign(keyMetadata, signableTransactionBytes);
-        break;
-      }
-      default: {
-        throw new IllegalArgumentException("Unhandled PrivateKey VersionType: {}" + keyMetadata);
-      }
-    }
-
-    return SignatureWithKeyMetadata.builder()
-      .signingKeyMetadata(keyMetadata)
-      .transactionSignature(signature)
-      .build();
+    return null;
   }
 
   @Override
@@ -240,12 +179,14 @@ public abstract class AbstractDelegatedSignatureService implements DelegatedSign
    * @param signableTransactionBytes A {@link UnsignedByteArray} to sign.
    *
    * @return A {@link Signature} with data that can be used to submit a transaction to the XRP Ledger.
-   */
-  protected abstract Signature edDsaSign(
+   *//*
+  protected Signature edDsaSign(
     KeyMetadata privateKeyMetadata, UnsignedByteArray signableTransactionBytes
-  );
+  ) {
+    return delegatedTransactionSigner.
+  }
 
-  /**
+  *//**
    * Does the actual work of computing a signature using a secp256k1 private-key, as locatable using {@code
    * privateKeyMetadata}.
    *
@@ -253,10 +194,10 @@ public abstract class AbstractDelegatedSignatureService implements DelegatedSign
    * @param signableTransactionBytes A {@link UnsignedByteArray} to sign.
    *
    * @return A {@link Signature} with data that can be used to submit a transaction to the XRP Ledger.
-   */
+   *//*
   protected abstract Signature ecDsaSign(
     KeyMetadata privateKeyMetadata, UnsignedByteArray signableTransactionBytes
-  );
+  );*/
 
   /**
    * Verify a signature.

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureService.java
@@ -35,12 +35,6 @@ public abstract class AbstractDelegatedSignatureService implements DelegatedSign
     this.delegatedTransactionVerifier = Objects.requireNonNull(delegatedTransactionVerifier);
   }
 
-
-  @Override
-  public PublicKey createKeyPair(KeyMetadata keyMetadata) {
-    return delegatedTransactionSigner.createKeyPair(keyMetadata);
-  }
-
   @Override
   public PublicKey getPublicKey(KeyMetadata keyMetadata) {
     return delegatedTransactionSigner.getPublicKey(keyMetadata);

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureService.java
@@ -1,15 +1,10 @@
 package org.xrpl.xrpl4j.crypto.core.signing;
 
-import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
-import org.xrpl.xrpl4j.crypto.core.AddressUtils;
 import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
-import org.xrpl.xrpl4j.crypto.core.KeyStoreType;
 import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
 import org.xrpl.xrpl4j.model.client.channels.UnsignedClaim;
-import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Transaction;
 
 import java.util.Objects;
@@ -23,22 +18,27 @@ public abstract class AbstractDelegatedSignatureService implements DelegatedSign
 
   protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-  private SignatureUtils signatureUtils = null;
-
-  private AddressUtils addressService = null;
-
   private final DelegatedTransactionSigner delegatedTransactionSigner;
   private final DelegatedTransactionVerifier delegatedTransactionVerifier;
 
-  public AbstractDelegatedSignatureService(DelegatedTransactionSigner delegatedTransactionSigner, DelegatedTransactionVerifier delegatedTransactionVerifier) {
-    this.delegatedTransactionSigner = delegatedTransactionSigner;
-    this.delegatedTransactionVerifier = delegatedTransactionVerifier;
+  /**
+   * Required-args constructor.
+   *
+   * @param delegatedTransactionSigner   A {@link DelegatedTransactionSigner} to sign transactions.
+   * @param delegatedTransactionVerifier A {@link DelegatedTransactionVerifier} to verify signatures.
+   */
+  public AbstractDelegatedSignatureService(
+    final DelegatedTransactionSigner delegatedTransactionSigner,
+    final DelegatedTransactionVerifier delegatedTransactionVerifier
+  ) {
+    this.delegatedTransactionSigner = Objects.requireNonNull(delegatedTransactionSigner);
+    this.delegatedTransactionVerifier = Objects.requireNonNull(delegatedTransactionVerifier);
   }
 
 
   @Override
   public PublicKey getPublicKey(KeyMetadata keyMetadata) {
-    return null;
+    return delegatedTransactionSigner.getPublicKey(keyMetadata);
   }
 
   @Override
@@ -48,185 +48,31 @@ public abstract class AbstractDelegatedSignatureService implements DelegatedSign
 
   @Override
   public Signature sign(KeyMetadata keyMetadata, UnsignedClaim unsignedClaim) {
-    return null;
+    return delegatedTransactionSigner.sign(keyMetadata, unsignedClaim);
   }
 
   @Override
   public <T extends Transaction> SignatureWithKeyMetadata multiSign(KeyMetadata keyMetadata, T transaction) {
-    return null;
+    return delegatedTransactionSigner.multiSign(keyMetadata, transaction);
   }
 
   @Override
   public <T extends Transaction> boolean verifySingleSigned(
     final SignatureWithKeyMetadata signatureWithKeyMetadata, final T unsignedTransaction
   ) {
-    Objects.requireNonNull(signatureWithKeyMetadata);
-    Objects.requireNonNull(unsignedTransaction);
-
-    final byte[] signableTransactionBytes = signatureUtils.toSignableBytes(unsignedTransaction).toByteArray();
-
-    final PublicKey publicKey = this.getPublicKey(signatureWithKeyMetadata.signingKeyMetadata());
-    final KeyMetadata keyMetadata = signatureWithKeyMetadata.signingKeyMetadata();
-    final Signature signature = signatureWithKeyMetadata.transactionSignature();
-    final UnsignedByteArray signableTransactionUba = UnsignedByteArray.of(signableTransactionBytes);
-    switch (publicKey.versionType()) {
-      case ED25519: {
-        return edDsaVerify(keyMetadata, signableTransactionUba, signature);
-      }
-      case SECP256K1: {
-        return ecDsaVerify(keyMetadata, signableTransactionUba, signature);
-      }
-      default: {
-        throw new IllegalArgumentException("Unhandled KeyMetadata: %s" + keyMetadata);
-      }
-    }
+    return delegatedTransactionVerifier.verifySingleSigned(signatureWithKeyMetadata, unsignedTransaction);
   }
 
-  /**
-   * Verify that all signers have properly signed the {@code unsignedTransaction}.
-   *
-   * @param signatureWithKeyMetadataSet A {@link Set} of {@link SignatureWithKeyMetadata} used for verification.
-   * @param unsignedTransaction         The {@link Transaction} of type {@link T} that was signed.
-   * @param <T>                         The actual type of {@link Transaction}.
-   *
-   * @return {@code true} if a minimum number of signatures are valid for the supplied transaction; {@code false}
-   *   otherwise.
-   */
   public <T extends Transaction> boolean verifyMultiSigned(
     final Set<SignatureWithKeyMetadata> signatureWithKeyMetadataSet, final T unsignedTransaction
   ) {
-    Objects.requireNonNull(signatureWithKeyMetadataSet);
-    Objects.requireNonNull(unsignedTransaction);
-    return verifyMultiSigned(signatureWithKeyMetadataSet, unsignedTransaction, signatureWithKeyMetadataSet.size());
+    return delegatedTransactionVerifier.verifyMultiSigned(signatureWithKeyMetadataSet, unsignedTransaction);
   }
 
-  /**
-   * Verify that {@code minSigners} from the collection of public keys have supplied signatures for the given the {@code
-   * unsignedTransaction}.
-   *
-   * @param signatureWithKeyMetadataSet A {@link Set} of {@link SignatureWithKeyMetadata} used for verification.
-   * @param unsignedTransaction         The transaction of type {@link T} that was signed.
-   * @param minSigners                  The minimum number of signatures required to form a quorum.
-   * @param <T>                         The actual type of {@link Transaction}.
-   *
-   * @return {@code true} if a minimum number of signatures are valid for the supplied transaction; {@code false}
-   *   otherwise.
-   */
   public <T extends Transaction> boolean verifyMultiSigned(
     final Set<SignatureWithKeyMetadata> signatureWithKeyMetadataSet, T unsignedTransaction, int minSigners
   ) {
-    Objects.requireNonNull(signatureWithKeyMetadataSet);
-    Objects.requireNonNull(unsignedTransaction);
-    Preconditions.checkArgument(minSigners > 0);
-
-    final long numValidSignatures = signatureWithKeyMetadataSet.stream()
-      .map(signatureWithKeyMetadata -> {
-        // Check signature against all public keys, hoping for a valid verification against one.
-        final UnsignedByteArray unsignedTransactionBytes =
-          signatureUtils.toMultiSignableBytes(
-            unsignedTransaction,
-            addressService.deriveAddress(getPublicKey(signatureWithKeyMetadata.signingKeyMetadata()))
-          );
-        final boolean oneValidSignature = verifyHelper(
-          signatureWithKeyMetadata.signingKeyMetadata(),
-          unsignedTransactionBytes,
-          signatureWithKeyMetadata.transactionSignature()
-        );
-        return oneValidSignature;
-      })
-      .filter($ -> $) // Only count it if it's 'true'
-      .count();
-
-    return numValidSignatures >= minSigners;
+    return delegatedTransactionVerifier.verifyMultiSigned(signatureWithKeyMetadataSet, unsignedTransaction, minSigners);
   }
-
-  /**
-   * Helper to verify a signed transaction.
-   *
-   * @param keyMetadata              A {@link KeyMetadata} used to lookup a {@link PublicKey} to verify a signature.
-   * @param unsignedTransactionBytes The actual binary bytes of the transaction that was signed.
-   * @param signature                The {@link Signature} to verify.
-   *
-   * @return {@code true} if the signature was created by the private key corresponding to {@code publicKey}; otherwise
-   *   {@code false}.
-   */
-  private boolean verifyHelper(
-    final KeyMetadata keyMetadata, final UnsignedByteArray unsignedTransactionBytes, final Signature signature
-  ) {
-    Objects.requireNonNull(keyMetadata);
-    Objects.requireNonNull(signature);
-    Objects.requireNonNull(unsignedTransactionBytes);
-
-    final PublicKey publicKey = getPublicKey(keyMetadata);
-    switch (publicKey.versionType()) {
-      case ED25519: {
-        return edDsaVerify(keyMetadata, unsignedTransactionBytes, signature);
-      }
-      case SECP256K1: {
-        return ecDsaVerify(keyMetadata, unsignedTransactionBytes, signature);
-      }
-      default: {
-        throw new IllegalArgumentException("Unhandled PublicKey VersionType: {}" + publicKey.versionType());
-      }
-    }
-  }
-
-  /**
-   * Does the actual work of computing a signature using a ed25519 private-key, as locatable using {@code
-   * privateKeyMetadata}.
-   *
-   * @param privateKeyMetadata       A {@link KeyMetadata} to describe the private-key to use for signing.
-   * @param signableTransactionBytes A {@link UnsignedByteArray} to sign.
-   *
-   * @return A {@link Signature} with data that can be used to submit a transaction to the XRP Ledger.
-   *//*
-  protected Signature edDsaSign(
-    KeyMetadata privateKeyMetadata, UnsignedByteArray signableTransactionBytes
-  ) {
-    return delegatedTransactionSigner.
-  }
-
-  *//**
-   * Does the actual work of computing a signature using a secp256k1 private-key, as locatable using {@code
-   * privateKeyMetadata}.
-   *
-   * @param privateKeyMetadata       A {@link KeyMetadata} to describe the private-key to use for signing.
-   * @param signableTransactionBytes A {@link UnsignedByteArray} to sign.
-   *
-   * @return A {@link Signature} with data that can be used to submit a transaction to the XRP Ledger.
-   *//*
-  protected abstract Signature ecDsaSign(
-    KeyMetadata privateKeyMetadata, UnsignedByteArray signableTransactionBytes
-  );*/
-
-  /**
-   * Verify a signature.
-   *
-   * @param keyMetadata              A {@link KeyMetadata}.
-   * @param signableTransactionBytes A {@link UnsignedByteArray}.
-   * @param transactionSignature     A {@link Signature}.
-   *
-   * @return {@code true} if the signature is valid; {@code false} otherwise.
-   */
-  protected abstract boolean edDsaVerify(
-    KeyMetadata keyMetadata,
-    UnsignedByteArray signableTransactionBytes,
-    Signature transactionSignature
-  );
-
-  /**
-   * Verify a signature.
-   *
-   * @param keyMetadata              A {@link KeyMetadata}.
-   * @param signableTransactionBytes A {@link UnsignedByteArray}.
-   * @param transactionSignature     A {@link Signature}.
-   *
-   * @return {@code true} if the signature is valid; {@code false} otherwise.
-   */
-  protected abstract boolean ecDsaVerify(
-    KeyMetadata keyMetadata,
-    UnsignedByteArray signableTransactionBytes,
-    Signature transactionSignature
-  );
 
 }

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureService.java
@@ -37,6 +37,11 @@ public abstract class AbstractDelegatedSignatureService implements DelegatedSign
 
 
   @Override
+  public PublicKey createKeyPair(KeyMetadata keyMetadata) {
+    return delegatedTransactionSigner.createKeyPair(keyMetadata);
+  }
+
+  @Override
   public PublicKey getPublicKey(KeyMetadata keyMetadata) {
     return delegatedTransactionSigner.getPublicKey(keyMetadata);
   }

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionSigner.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionSigner.java
@@ -1,0 +1,123 @@
+package org.xrpl.xrpl4j.crypto.core.signing;
+
+import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
+import org.xrpl.xrpl4j.crypto.core.AddressUtils;
+import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
+import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
+import org.xrpl.xrpl4j.model.client.channels.UnsignedClaim;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Transaction;
+
+import java.util.Objects;
+
+public abstract class AbstractDelegatedTransactionSigner implements DelegatedTransactionSigner {
+
+  private final SignatureUtils signatureUtils;
+  private final AddressUtils addressService;
+
+  /**
+   * Required-args Constructor.
+   *
+   * @param signatureUtils An {@link SignatureUtils} for help with signing.
+   * @param addressService A {@link AddressUtils}.
+   */
+  public AbstractDelegatedTransactionSigner(
+    final SignatureUtils signatureUtils,
+    final AddressUtils addressService
+  ) {
+    this.signatureUtils = Objects.requireNonNull(signatureUtils);
+    this.addressService = Objects.requireNonNull(addressService);
+  }
+
+  @Override
+  public <T extends Transaction> SingleSingedTransaction<T> sign(KeyMetadata keyMetadata, T transaction) {
+    Objects.requireNonNull(keyMetadata);
+    Objects.requireNonNull(transaction);
+
+    final UnsignedByteArray signableTransactionBytes = this.signatureUtils.toSignableBytes(transaction);
+    final Signature signature = this.signingHelper(keyMetadata, signableTransactionBytes).transactionSignature();
+    return this.signatureUtils.addSignatureToTransaction(transaction, signature);
+  }
+
+  @Override
+  public Signature sign(final KeyMetadata keyMetadata, final UnsignedClaim unsignedClaim) {
+    Objects.requireNonNull(keyMetadata);
+    Objects.requireNonNull(unsignedClaim);
+
+    final UnsignedByteArray signableBytes = signatureUtils.toSignableBytes(unsignedClaim);
+    return this.signingHelper(keyMetadata, signableBytes).transactionSignature();
+  }
+
+  @Override
+  public <T extends Transaction> SignatureWithKeyMetadata multiSign(KeyMetadata keyMetadata, T transaction) {
+    Objects.requireNonNull(keyMetadata);
+    Objects.requireNonNull(transaction);
+
+    final Address address = addressService.deriveAddress(this.getPublicKey(keyMetadata));
+    final UnsignedByteArray signableTransactionBytes = this.signatureUtils.toMultiSignableBytes(transaction, address);
+
+    return this.signingHelper(keyMetadata, signableTransactionBytes);
+  }
+
+  /**
+   * Helper to generate a signature based upon an {@link UnsignedByteArray} of transaction bytes.
+   *
+   * @param keyMetadata              A {@link KeyMetadata} for the signing key.
+   * @param signableTransactionBytes A {@link UnsignedByteArray} of transaction bytes.
+   *
+   * @return A {@link SignatureWithPublicKey}.
+   */
+  private SignatureWithKeyMetadata signingHelper(
+    final KeyMetadata keyMetadata, final UnsignedByteArray signableTransactionBytes
+  ) {
+    Objects.requireNonNull(keyMetadata);
+    Objects.requireNonNull(signableTransactionBytes);
+
+    final PublicKey publicKey = this.getPublicKey(keyMetadata);
+    final Signature signature;
+    switch (publicKey.versionType()) {
+      case ED25519: {
+        signature = this.edDsaSign(keyMetadata, signableTransactionBytes);
+        break;
+      }
+      case SECP256K1: {
+        signature = this.ecDsaSign(keyMetadata, signableTransactionBytes);
+        break;
+      }
+      default: {
+        throw new IllegalArgumentException("Unhandled PrivateKey VersionType: {}" + keyMetadata);
+      }
+    }
+
+    return SignatureWithKeyMetadata.builder()
+      .signingKeyMetadata(keyMetadata)
+      .transactionSignature(signature)
+      .build();
+  }
+
+  /**
+   * Does the actual work of computing a signature using a ed25519 private-key, as locatable using {@code
+   * privateKeyMetadata}.
+   *
+   * @param privateKeyMetadata       A {@link KeyMetadata} to describe the private-key to use for signing.
+   * @param signableTransactionBytes A {@link UnsignedByteArray} to sign.
+   *
+   * @return A {@link Signature} with data that can be used to submit a transaction to the XRP Ledger.
+   */
+  protected abstract Signature edDsaSign(
+    KeyMetadata privateKeyMetadata, UnsignedByteArray signableTransactionBytes
+  );
+
+  /**
+   * Does the actual work of computing a signature using a secp256k1 private-key, as locatable using {@code
+   * privateKeyMetadata}.
+   *
+   * @param privateKeyMetadata       A {@link KeyMetadata} to describe the private-key to use for signing.
+   * @param signableTransactionBytes A {@link UnsignedByteArray} to sign.
+   *
+   * @return A {@link Signature} with data that can be used to submit a transaction to the XRP Ledger.
+   */
+  protected abstract Signature ecDsaSign(
+    KeyMetadata privateKeyMetadata, UnsignedByteArray signableTransactionBytes
+  );
+}

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionSigner.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionSigner.java
@@ -10,6 +10,10 @@ import org.xrpl.xrpl4j.model.transactions.Transaction;
 
 import java.util.Objects;
 
+/**
+ * An abstract implementation of {@link DelegatedTransactionSigner} with common functionality that sub-classes can
+ * utilize.
+ */
 public abstract class AbstractDelegatedTransactionSigner implements DelegatedTransactionSigner {
 
   private final SignatureUtils signatureUtils;
@@ -19,7 +23,7 @@ public abstract class AbstractDelegatedTransactionSigner implements DelegatedTra
    * Required-args Constructor.
    *
    * @param signatureUtils An {@link SignatureUtils} for help with signing.
-   * @param addressService A {@link AddressUtils}.
+   * @param addressService An {@link AddressUtils}.
    */
   public AbstractDelegatedTransactionSigner(
     final SignatureUtils signatureUtils,

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionVerifier.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionVerifier.java
@@ -1,0 +1,4 @@
+package org.xrpl.xrpl4j.crypto.core.signing;
+
+public abstract class AbstractDelegatedTransactionVerifier implements DelegatedTransactionVerifier {
+}

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionVerifier.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionVerifier.java
@@ -1,4 +1,161 @@
 package org.xrpl.xrpl4j.crypto.core.signing;
 
+import com.google.common.base.Preconditions;
+import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
+import org.xrpl.xrpl4j.crypto.core.AddressUtils;
+import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
+import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
+import org.xrpl.xrpl4j.model.transactions.Transaction;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * An abstract implementation of {@link DelegatedTransactionVerifier} with common functionality that sub-classes can
+ * utilize.
+ */
 public abstract class AbstractDelegatedTransactionVerifier implements DelegatedTransactionVerifier {
+
+  private final SignatureUtils signatureUtils;
+  private final AddressUtils addressService;
+
+  /**
+   * Required-args Constructor.
+   *
+   * @param signatureUtils An {@link SignatureUtils} for help with signing.
+   * @param addressService An {@link AddressUtils}.
+   */
+  protected AbstractDelegatedTransactionVerifier(
+    final SignatureUtils signatureUtils,
+    final AddressUtils addressService
+  ) {
+    this.signatureUtils = Objects.requireNonNull(signatureUtils);
+    this.addressService = Objects.requireNonNull(addressService);
+  }
+
+  @Override
+  public <T extends Transaction> boolean verifySingleSigned(
+    final SignatureWithKeyMetadata signatureWithKeyMetadata, final T unsignedTransaction
+  ) {
+    Objects.requireNonNull(signatureWithKeyMetadata);
+    Objects.requireNonNull(unsignedTransaction);
+
+    final byte[] signableTransactionBytes = signatureUtils.toSignableBytes(unsignedTransaction).toByteArray();
+
+    final PublicKey publicKey = this.getPublicKey(signatureWithKeyMetadata.signingKeyMetadata());
+    final KeyMetadata keyMetadata = signatureWithKeyMetadata.signingKeyMetadata();
+    final Signature signature = signatureWithKeyMetadata.transactionSignature();
+    final UnsignedByteArray signableTransactionUba = UnsignedByteArray.of(signableTransactionBytes);
+    switch (publicKey.versionType()) {
+      case ED25519: {
+        return edDsaVerify(keyMetadata, signableTransactionUba, signature);
+      }
+      case SECP256K1: {
+        return ecDsaVerify(keyMetadata, signableTransactionUba, signature);
+      }
+      default: {
+        throw new IllegalArgumentException("Unhandled KeyMetadata: %s" + keyMetadata);
+      }
+    }
+  }
+
+  @Override
+  public <T extends Transaction> boolean verifyMultiSigned(
+    final Set<SignatureWithKeyMetadata> signatureWithKeyMetadataSet, final T unsignedTransaction
+  ) {
+    Objects.requireNonNull(signatureWithKeyMetadataSet);
+    Objects.requireNonNull(unsignedTransaction);
+    return verifyMultiSigned(signatureWithKeyMetadataSet, unsignedTransaction, signatureWithKeyMetadataSet.size());
+  }
+
+  @Override
+  public <T extends Transaction> boolean verifyMultiSigned(
+    final Set<SignatureWithKeyMetadata> signatureWithKeyMetadataSet, T unsignedTransaction, int minSigners
+  ) {
+    Objects.requireNonNull(signatureWithKeyMetadataSet);
+    Objects.requireNonNull(unsignedTransaction);
+    Preconditions.checkArgument(minSigners > 0);
+
+    final long numValidSignatures = signatureWithKeyMetadataSet.stream()
+      .map(signatureWithKeyMetadata -> {
+        // Check signature against all public keys, hoping for a valid verification against one.
+        final UnsignedByteArray unsignedTransactionBytes =
+          signatureUtils.toMultiSignableBytes(
+            unsignedTransaction,
+            addressService.deriveAddress(getPublicKey(signatureWithKeyMetadata.signingKeyMetadata()))
+          );
+        final boolean oneValidSignature = verifyHelper(
+          signatureWithKeyMetadata.signingKeyMetadata(),
+          unsignedTransactionBytes,
+          signatureWithKeyMetadata.transactionSignature()
+        );
+        return oneValidSignature;
+      })
+      .filter($ -> $) // Only count it if it's 'true'
+      .count();
+
+    return numValidSignatures >= minSigners;
+  }
+
+  /**
+   * Helper to verify a signed transaction.
+   *
+   * @param keyMetadata              A {@link KeyMetadata} used to lookup a {@link PublicKey} to verify a signature.
+   * @param unsignedTransactionBytes The actual binary bytes of the transaction that was signed.
+   * @param signature                The {@link Signature} to verify.
+   *
+   * @return {@code true} if the signature was created by the private key corresponding to {@code publicKey}; otherwise
+   *   {@code false}.
+   */
+  private boolean verifyHelper(
+    final KeyMetadata keyMetadata, final UnsignedByteArray unsignedTransactionBytes, final Signature signature
+  ) {
+    Objects.requireNonNull(keyMetadata);
+    Objects.requireNonNull(signature);
+    Objects.requireNonNull(unsignedTransactionBytes);
+
+    final PublicKey publicKey = getPublicKey(keyMetadata);
+    switch (publicKey.versionType()) {
+      case ED25519: {
+        return edDsaVerify(keyMetadata, unsignedTransactionBytes, signature);
+      }
+      case SECP256K1: {
+        return ecDsaVerify(keyMetadata, unsignedTransactionBytes, signature);
+      }
+      default: {
+        throw new IllegalArgumentException("Unhandled PublicKey VersionType: {}" + publicKey.versionType());
+      }
+    }
+  }
+
+  /**
+   * Verify a signature.
+   *
+   * @param keyMetadata              A {@link KeyMetadata}.
+   * @param signableTransactionBytes A {@link UnsignedByteArray}.
+   * @param transactionSignature     A {@link Signature}.
+   *
+   * @return {@code true} if the signature is valid; {@code false} otherwise.
+   */
+  protected abstract boolean edDsaVerify(
+    KeyMetadata keyMetadata,
+    UnsignedByteArray signableTransactionBytes,
+    Signature transactionSignature
+  );
+
+  /**
+   * Verify a signature.
+   *
+   * @param keyMetadata              A {@link KeyMetadata}.
+   * @param signableTransactionBytes A {@link UnsignedByteArray}.
+   * @param transactionSignature     A {@link Signature}.
+   *
+   * @return {@code true} if the signature is valid; {@code false} otherwise.
+   */
+  protected abstract boolean ecDsaVerify(
+    KeyMetadata keyMetadata,
+    UnsignedByteArray signableTransactionBytes,
+    Signature transactionSignature
+  );
+
 }

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedPublicKeyProvider.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedPublicKeyProvider.java
@@ -1,0 +1,22 @@
+package org.xrpl.xrpl4j.crypto.core.signing;
+
+import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
+import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
+
+/**
+ * Defines how to retrieve a {@link PublicKey} in a delegated manner.
+ */
+public interface DelegatedPublicKeyProvider {
+
+  /**
+   * Accessor for the public-key corresponding to the supplied key meta-data. This method exists to support
+   * implementations that hold private-key material internally, yet need a way for external callers to determine the
+   * actual public key for signature verification or other purposes.
+   *
+   * @param keyMetadata A {@link KeyMetadata} for a key-pair.
+   *
+   * @return A {@link PublicKey}.
+   */
+  PublicKey getPublicKey(KeyMetadata keyMetadata);
+
+}

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedSignatureService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedSignatureService.java
@@ -1,30 +1,9 @@
 package org.xrpl.xrpl4j.crypto.core.signing;
 
-import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
-import org.xrpl.xrpl4j.crypto.core.KeyStoreType;
-import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
-
 /**
  * Defines how to sign and verify an XRPL transaction in a delegated manner, meaning private-key material used for
  * signing is never accessible via the runtime operating this signing service.
  */
 public interface DelegatedSignatureService extends DelegatedTransactionSigner, DelegatedTransactionVerifier {
 
-  /**
-   * Accessor for the public-key corresponding to the supplied key meta-data. This method exists to support
-   * implementations that hold private-key material internally, yet need a way for external callers to determine the
-   * actual public key for signature verification or other purposes.
-   *
-   * @param keyMetadata A {@link KeyMetadata} for a key-pair.
-   *
-   * @return A {@link PublicKey}.
-   */
-  PublicKey getPublicKey(KeyMetadata keyMetadata);
-
-  /**
-   * The type of org.xrpl4j.crypto.keystore this signer can be used with.
-   *
-   * @return A {@link KeyStoreType}.
-   */
-  KeyStoreType keyStoreType();
 }

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionSigner.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionSigner.java
@@ -12,18 +12,7 @@ import org.xrpl.xrpl4j.model.transactions.Transaction;
  * private-key material. Alternatively, an implementation may use key meta-data to lookup key material in some custom
  * manner (e.g., by deriving it from a secret value).
  */
-public interface DelegatedTransactionSigner {
-
-  /**
-   * Accessor for the public-key corresponding to the supplied key meta-data. This method exists to support
-   * implementations that hold private-key material internally, yet need a way for external callers to determine the
-   * actual public key for signature verification or other purposes.
-   *
-   * @param keyMetadata A {@link KeyMetadata} for a key-pair.
-   *
-   * @return A {@link PublicKey}.
-   */
-  PublicKey getPublicKey(KeyMetadata keyMetadata);
+public interface DelegatedTransactionSigner extends DelegatedPublicKeyProvider {
 
   /**
    * Obtain a signature for the supplied transaction using the private-key that corresponds to {@code keyMetadata}.

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionSigner.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionSigner.java
@@ -1,6 +1,7 @@
 package org.xrpl.xrpl4j.crypto.core.signing;
 
 import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
+import org.xrpl.xrpl4j.crypto.core.keys.DelegatedKeyPairService;
 import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
 import org.xrpl.xrpl4j.model.client.channels.UnsignedClaim;
 import org.xrpl.xrpl4j.model.transactions.Transaction;
@@ -11,7 +12,7 @@ import org.xrpl.xrpl4j.model.transactions.Transaction;
  * private-key material. Alternatively, an implementation may use key meta-data to lookup key material in some custom
  * manner (e.g., by deriving it from a secret value).
  */
-public interface DelegatedTransactionSigner {
+public interface DelegatedTransactionSigner extends DelegatedKeyPairService {
 
   /**
    * Accessor for the public-key corresponding to the supplied key meta-data. This method exists to support

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionSigner.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionSigner.java
@@ -1,6 +1,7 @@
 package org.xrpl.xrpl4j.crypto.core.signing;
 
 import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
+import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
 import org.xrpl.xrpl4j.model.client.channels.UnsignedClaim;
 import org.xrpl.xrpl4j.model.transactions.Transaction;
 
@@ -11,6 +12,17 @@ import org.xrpl.xrpl4j.model.transactions.Transaction;
  * manner (e.g., by deriving it from a secret value).
  */
 public interface DelegatedTransactionSigner {
+
+  /**
+   * Accessor for the public-key corresponding to the supplied key meta-data. This method exists to support
+   * implementations that hold private-key material internally, yet need a way for external callers to determine the
+   * actual public key for signature verification or other purposes.
+   *
+   * @param keyMetadata A {@link KeyMetadata} for a key-pair.
+   *
+   * @return A {@link PublicKey}.
+   */
+  PublicKey getPublicKey(KeyMetadata keyMetadata);
 
   /**
    * Obtain a signature for the supplied transaction using the private-key that corresponds to {@code keyMetadata}.

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionSigner.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionSigner.java
@@ -12,7 +12,7 @@ import org.xrpl.xrpl4j.model.transactions.Transaction;
  * private-key material. Alternatively, an implementation may use key meta-data to lookup key material in some custom
  * manner (e.g., by deriving it from a secret value).
  */
-public interface DelegatedTransactionSigner extends DelegatedKeyPairService {
+public interface DelegatedTransactionSigner {
 
   /**
    * Accessor for the public-key corresponding to the supplied key meta-data. This method exists to support

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionVerifier.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionVerifier.java
@@ -1,5 +1,7 @@
 package org.xrpl.xrpl4j.crypto.core.signing;
 
+import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
+import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
 import org.xrpl.xrpl4j.model.transactions.Transaction;
 
 import java.util.Set;
@@ -11,6 +13,17 @@ import java.util.Set;
  * by deriving it from a secret value).
  */
 public interface DelegatedTransactionVerifier {
+
+  /**
+   * Accessor for the public-key corresponding to the supplied key meta-data. This method exists to support
+   * implementations that hold private-key material internally, yet need a way for external callers to determine the
+   * actual public key for signature verification or other purposes.
+   *
+   * @param keyMetadata A {@link KeyMetadata} for a key-pair.
+   *
+   * @return A {@link PublicKey}.
+   */
+  PublicKey getPublicKey(KeyMetadata keyMetadata);
 
   /**
    * TransactionVerifier the supplied digital-signature to ensure that it was constructed using the private-key

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionVerifier.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionVerifier.java
@@ -12,18 +12,7 @@ import java.util.Set;
  * Alternatively, an implementation may use supplied key meta-data to lookup key material in some custom manner (e.g.,
  * by deriving it from a secret value).
  */
-public interface DelegatedTransactionVerifier {
-
-  /**
-   * Accessor for the public-key corresponding to the supplied key meta-data. This method exists to support
-   * implementations that hold private-key material internally, yet need a way for external callers to determine the
-   * actual public key for signature verification or other purposes.
-   *
-   * @param keyMetadata A {@link KeyMetadata} for a key-pair.
-   *
-   * @return A {@link PublicKey}.
-   */
-  PublicKey getPublicKey(KeyMetadata keyMetadata);
+public interface DelegatedTransactionVerifier extends DelegatedPublicKeyProvider {
 
   /**
    * TransactionVerifier the supplied digital-signature to ensure that it was constructed using the private-key

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureServiceTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureServiceTest.java
@@ -2,36 +2,22 @@ package org.xrpl.xrpl4j.crypto.core.signing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
-import org.assertj.core.util.Sets;
-import org.junit.jupiter.api.Assertions;
+import com.google.common.collect.Sets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
-import org.xrpl.xrpl4j.codec.addresses.VersionType;
-import org.xrpl.xrpl4j.crypto.core.AddressUtils;
 import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
-import org.xrpl.xrpl4j.crypto.core.KeyStoreType;
-import org.xrpl.xrpl4j.crypto.core.keys.Ed25519KeyPairService;
-import org.xrpl.xrpl4j.crypto.core.keys.KeyPair;
-import org.xrpl.xrpl4j.crypto.core.keys.Passphrase;
 import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
-import org.xrpl.xrpl4j.crypto.core.keys.Secp256k1KeyPairService;
-import org.xrpl.xrpl4j.crypto.core.keys.Seed;
 import org.xrpl.xrpl4j.model.client.channels.UnsignedClaim;
-import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Transaction;
 
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.HashSet;
 
 /**
  * Unit tests for {@link AbstractDelegatedSignatureService}.
@@ -39,389 +25,93 @@ import java.util.concurrent.atomic.AtomicBoolean;
 class AbstractDelegatedSignatureServiceTest {
 
   @Mock
-  private SignatureUtils signatureUtilsMock;
+  DelegatedTransactionSigner delegatedTransactionSignerMock;
+
   @Mock
-  private Signature ed25519SignatureMock;
+  DelegatedTransactionVerifier delegatedTransactionVerifierMock;
+
   @Mock
-  private Signature secp256k1SignatureMock;
+  KeyMetadata keyMetadataMock;
+
   @Mock
-  private KeyMetadata keyMetadataMock;
-  @Mock
-  private Transaction transactionMock;
-  @Mock
-  private AddressUtils addressServiceMock;
+  PublicKey publicKeyMock;
+
   @Mock
   private SignatureWithKeyMetadata signatureWithKeyMetaMock;
 
-  private KeyPair ed25519KeyPair;
-  private Address ed25519SignerAddress;
+  @Mock
+  private Signature signatureMock;
 
-  private KeyPair secp256k1KeyPair;
-  private Address secp256k1SignerAddress;
+  @Mock
+  private Transaction transactionMock;
 
-  private AtomicBoolean ed25519VerifyCalled;
-  private AtomicBoolean secp256k1VerifyCalled;
-  private VersionType keyType;
+  @Mock
+  private SingleSingedTransaction<Transaction> singleSignedTransactionMock;
 
-  private AbstractDelegatedSignatureService signatureService;
+  private AbstractDelegatedSignatureService delegatedSignatureService;
 
   @BeforeEach
   void setUp() {
-    MockitoAnnotations.openMocks(this);
-    ed25519VerifyCalled = new AtomicBoolean(false);
-    secp256k1VerifyCalled = new AtomicBoolean(false);
+    openMocks(this);
 
-    AddressUtils addressService = AddressUtils.getInstance();
-    Ed25519KeyPairService ed25519KeyPairService = Ed25519KeyPairService.getInstance();
-    this.ed25519KeyPair = ed25519KeyPairService.deriveKeyPair(
-      Seed.ed25519SeedFromPassphrase(Passphrase.of("hello"))
-    );
-    this.ed25519SignerAddress = addressService.deriveAddress(ed25519KeyPair.publicKey());
+    when(delegatedTransactionSignerMock.getPublicKey(keyMetadataMock)).thenReturn(publicKeyMock);
+    when(delegatedTransactionSignerMock.sign(keyMetadataMock, transactionMock)).thenReturn(singleSignedTransactionMock);
+    when(delegatedTransactionSignerMock.sign(eq(keyMetadataMock), any(UnsignedClaim.class))).thenReturn(signatureMock);
+    when(delegatedTransactionSignerMock.multiSign(keyMetadataMock, transactionMock))
+      .thenReturn(signatureWithKeyMetaMock);
 
-    Secp256k1KeyPairService secp256k1KeyPairService = Secp256k1KeyPairService.getInstance();
-    this.secp256k1KeyPair = secp256k1KeyPairService.deriveKeyPair(
-      Seed.secp256k1SeedFromPassphrase(Passphrase.of("hello"))
-    );
-    this.secp256k1SignerAddress = addressService.deriveAddress(secp256k1KeyPair.publicKey());
-
-    when(addressServiceMock.deriveAddress(any())).thenReturn(ed25519SignerAddress);
-
-    when(signatureUtilsMock.toSignableBytes(Mockito.<Transaction>any())).thenReturn(UnsignedByteArray.empty());
-    when(signatureUtilsMock.toMultiSignableBytes(any(), any())).thenReturn(UnsignedByteArray.empty());
-
-    when(signatureWithKeyMetaMock.signingKeyMetadata()).thenReturn(keyMetadataMock);
-    when(signatureWithKeyMetaMock.transactionSignature()).thenReturn(ed25519SignatureMock);
-
-    this.signatureService = new AbstractDelegatedSignatureService(
-      signatureUtilsMock,
-      addressServiceMock
-    ) {
-      @Override
-      public PublicKey getPublicKey(KeyMetadata keyMetadata) {
-        return keyType == VersionType.ED25519 ? ed25519KeyPair.publicKey() : secp256k1KeyPair.publicKey();
-      }
-
-      @Override
-      protected Signature edDsaSign(KeyMetadata privateKeyMetadata, UnsignedByteArray signableTransactionBytes) {
-        return ed25519SignatureMock;
-      }
-
-      @Override
-      protected Signature ecDsaSign(KeyMetadata privateKeyMetadata, UnsignedByteArray signableTransactionBytes) {
-        return secp256k1SignatureMock;
-      }
-
-      @Override
-      protected boolean edDsaVerify(
-        KeyMetadata keyMetadata, UnsignedByteArray signableTransactionBytes, Signature transactionSignature
-      ) {
-        ed25519VerifyCalled.set(true);
-        return ed25519VerifyCalled.get();
-      }
-
-      @Override
-      protected boolean ecDsaVerify(KeyMetadata keyMetadata, UnsignedByteArray signableTransactionBytes,
-        Signature transactionSignature) {
-        secp256k1VerifyCalled.set(true);
-        return secp256k1VerifyCalled.get();
-      }
-    };
-  }
-
-  ///////////////////
-  // Sign (Transaction)
-  ///////////////////
-
-  @Test
-  void signWithNullMetadata() {
-    Assertions.assertThrows(NullPointerException.class, () -> signatureService.sign(null, transactionMock));
+    this.delegatedSignatureService = new AbstractDelegatedSignatureService(
+      delegatedTransactionSignerMock,
+      delegatedTransactionVerifierMock
+    ) { };
   }
 
   @Test
-  void signWithNullTransaction() {
-    Assertions.assertThrows(NullPointerException.class,
-      () -> signatureService.sign(keyMetadataMock, (Transaction) null));
+  void getPublicKey() {
+    PublicKey actual = delegatedSignatureService.getPublicKey(keyMetadataMock);
+    assertThat(actual).isEqualTo(publicKeyMock);
   }
 
   @Test
-  void signEd25519() {
-    keyType = VersionType.ED25519;
-    signatureService.sign(keyMetadataMock, transactionMock);
-
-    verify(signatureUtilsMock).toSignableBytes(transactionMock);
-    verify(signatureUtilsMock).addSignatureToTransaction(transactionMock, ed25519SignatureMock);
-    verifyNoMoreInteractions(signatureUtilsMock);
+  void signTransaction() {
+    SingleSingedTransaction<Transaction> actual = delegatedSignatureService.sign(keyMetadataMock, transactionMock);
+    assertThat(actual).isEqualTo(singleSignedTransactionMock);
+    verify(delegatedTransactionSignerMock).sign(keyMetadataMock, transactionMock);
   }
 
   @Test
-  void signSecp256k1() {
-    keyType = VersionType.SECP256K1;
-
-    signatureService.sign(keyMetadataMock, transactionMock);
-
-    verify(signatureUtilsMock).toSignableBytes(transactionMock);
-    verify(signatureUtilsMock).addSignatureToTransaction(transactionMock, secp256k1SignatureMock);
-    verifyNoMoreInteractions(signatureUtilsMock);
-  }
-
-  ///////////////////
-  // Sign (UnsignedClaim)
-  ///////////////////
-
-  @Test
-  void signUnsignedClaimWithNullMetadata() {
-    UnsignedClaim unsignedClaimMock = mock(UnsignedClaim.class);
-    Assertions.assertThrows(NullPointerException.class, () -> signatureService.sign(null, unsignedClaimMock));
+  void signClaim() {
+    UnsignedClaim mockUnsignedClaim = mock(UnsignedClaim.class);
+    Signature actual = delegatedSignatureService.sign(keyMetadataMock, mockUnsignedClaim);
+    assertThat(actual).isEqualTo(signatureMock);
+    verify(delegatedTransactionSignerMock).sign(keyMetadataMock, mockUnsignedClaim);
   }
 
   @Test
-  void signUnsignedClaimWithNullTransaction() {
-    Assertions.assertThrows(NullPointerException.class,
-      () -> signatureService.sign(keyMetadataMock, (UnsignedClaim) null));
+  void multiSignTransaction() {
+    SignatureWithKeyMetadata actual = delegatedSignatureService.multiSign(keyMetadataMock, transactionMock);
+    assertThat(actual).isEqualTo(signatureWithKeyMetaMock);
+    verify(delegatedTransactionSignerMock).multiSign(keyMetadataMock, transactionMock);
   }
 
   @Test
-  void signUnsignedClaimEd25519() {
-    keyType = VersionType.ED25519;
-    UnsignedClaim unsignedClaimMock = mock(UnsignedClaim.class);
-    when(signatureUtilsMock.toSignableBytes(unsignedClaimMock)).thenReturn(UnsignedByteArray.empty());
-
-    Signature actual = signatureService.sign(keyMetadataMock, unsignedClaimMock);
-
-    verify(signatureUtilsMock).toSignableBytes(unsignedClaimMock);
-    verifyNoMoreInteractions(signatureUtilsMock);
-    assertThat(actual).isEqualTo(ed25519SignatureMock);
+  void verifySingleSigned() {
+    delegatedSignatureService.verifySingleSigned(signatureWithKeyMetaMock, transactionMock);
+    verify(delegatedTransactionVerifierMock).verifySingleSigned(signatureWithKeyMetaMock, transactionMock);
   }
 
   @Test
-  void signUnsignedClaimSecp256k1() {
-    keyType = VersionType.SECP256K1;
-    UnsignedClaim unsignedClaimMock = mock(UnsignedClaim.class);
-    when(signatureUtilsMock.toSignableBytes(unsignedClaimMock)).thenReturn(UnsignedByteArray.empty());
-
-    Signature actual = signatureService.sign(keyMetadataMock, unsignedClaimMock);
-
-    verify(signatureUtilsMock).toSignableBytes(unsignedClaimMock);
-    verifyNoMoreInteractions(signatureUtilsMock);
-    assertThat(actual).isEqualTo(secp256k1SignatureMock);
-  }
-
-  ///////////////////
-  // MultiSign
-  ///////////////////
-
-  @Test
-  void multiSignWithNullMetadata() {
-    Assertions.assertThrows(NullPointerException.class, () -> signatureService.multiSign(null, transactionMock));
+  void verifyMultiSignedWithoutMinSigners() {
+    HashSet<SignatureWithKeyMetadata> signatureSet = Sets.newHashSet(signatureWithKeyMetaMock);
+    delegatedSignatureService.verifyMultiSigned(signatureSet, transactionMock);
+    verify(delegatedTransactionVerifierMock).verifyMultiSigned(signatureSet, transactionMock);
   }
 
   @Test
-  void multiSignWithNullTransaction() {
-    Assertions.assertThrows(NullPointerException.class, () -> signatureService.multiSign(keyMetadataMock, null));
-  }
-
-  @Test
-  void multiSignEd25519() {
-    keyType = VersionType.ED25519;
-    when(addressServiceMock.deriveAddress(any())).thenReturn(ed25519SignerAddress);
-
-    SignatureWithKeyMetadata signatureWithKeyMetadata = signatureService.multiSign(
-      keyMetadataMock,
-      transactionMock
-    );
-    assertThat(signatureWithKeyMetadata.transactionSignature()).isEqualTo(ed25519SignatureMock);
-    assertThat(signatureWithKeyMetadata.signingKeyMetadata()).isEqualTo(keyMetadataMock);
-
-    verify(addressServiceMock).deriveAddress(any());
-    verifyNoMoreInteractions(addressServiceMock);
-    verify(signatureUtilsMock).toMultiSignableBytes(transactionMock, ed25519SignerAddress);
-    verify(signatureUtilsMock, times(0)).toSignableBytes(transactionMock);
-    verifyNoMoreInteractions(signatureUtilsMock);
-  }
-
-  @Test
-  void multiSignSecp256k1() {
-    keyType = VersionType.SECP256K1;
-    when(addressServiceMock.deriveAddress(any())).thenReturn(secp256k1SignerAddress);
-
-    SignatureWithKeyMetadata signatureWithKeyMetadata = signatureService.multiSign(
-      keyMetadataMock,
-      transactionMock
-    );
-
-    assertThat(signatureWithKeyMetadata.transactionSignature()).isEqualTo(secp256k1SignatureMock);
-    assertThat(signatureWithKeyMetadata.signingKeyMetadata()).isEqualTo(keyMetadataMock);
-
-    verify(addressServiceMock).deriveAddress(any());
-    verifyNoMoreInteractions(addressServiceMock);
-    verify(signatureUtilsMock).toMultiSignableBytes(transactionMock, secp256k1SignerAddress);
-    verify(signatureUtilsMock, times(0)).toSignableBytes(transactionMock);
-    verifyNoMoreInteractions(signatureUtilsMock);
-  }
-
-  ///////////////////
-  // verify (signatureWithKeyMetadata, transaction)
-  ///////////////////
-
-  @Test
-  void verifyWithNullMetadata() {
-    Assertions.assertThrows(NullPointerException.class,
-      () -> signatureService.verifySingleSigned(null, transactionMock));
-  }
-
-  @Test
-  void verifyWithNullTransaction() {
-    Assertions.assertThrows(NullPointerException.class,
-      () -> signatureService.verifySingleSigned(signatureWithKeyMetaMock, null));
-  }
-
-  @Test
-  void verifyEd25519() {
-    keyType = VersionType.ED25519;
-    boolean actual = signatureService.verifySingleSigned(signatureWithKeyMetaMock, transactionMock);
-
-    assertThat(actual).isTrue();
-    assertThat(ed25519VerifyCalled.get()).isTrue();
-    assertThat(secp256k1VerifyCalled.get()).isFalse();
-    verify(signatureUtilsMock).toSignableBytes(transactionMock);
-    verifyNoMoreInteractions(signatureUtilsMock);
-  }
-
-  @Test
-  void verifySecp256k1() {
-    keyType = VersionType.SECP256K1;
-    boolean actual = signatureService.verifySingleSigned(signatureWithKeyMetaMock, transactionMock);
-
-    assertThat(actual).isTrue();
-    assertThat(secp256k1VerifyCalled.get()).isTrue();
-    assertThat(ed25519VerifyCalled.get()).isFalse();
-    verify(signatureUtilsMock).toSignableBytes(transactionMock);
-    verifyNoMoreInteractions(signatureUtilsMock);
-  }
-
-  ///////////////////
-  // verify (signatureWithKeyMetadata, transaction)
-  ///////////////////
-
-  @Test
-  void verifyMultiWithNullSet() {
-    Assertions.assertThrows(NullPointerException.class,
-      () -> signatureService.verifyMultiSigned(null, transactionMock));
-  }
-
-  @Test
-  void verifyMultiWithNullTransaction() {
-    Assertions.assertThrows(NullPointerException.class,
-      () -> signatureService.verifyMultiSigned(Sets.newHashSet(), null));
-  }
-
-  @Test
-  void verifyMultiWithEmptySet() {
-    Assertions.assertThrows(IllegalArgumentException.class,
-      () -> signatureService.verifyMultiSigned(Sets.newHashSet(), transactionMock));
-  }
-
-  @Test
-  void verifyMultiEd25519() {
-    keyType = VersionType.ED25519;
-    when(signatureWithKeyMetaMock.transactionSignature()).thenReturn(ed25519SignatureMock);
-
-    final Set<SignatureWithKeyMetadata> signatureWithKeyMetadataSet = Sets.newLinkedHashSet(signatureWithKeyMetaMock);
-    boolean actual = signatureService.verifyMultiSigned(signatureWithKeyMetadataSet, transactionMock, 1);
-
-    assertThat(actual).isTrue();
-    assertThat(ed25519VerifyCalled.get()).isTrue();
-    assertThat(secp256k1VerifyCalled.get()).isFalse();
-    verify(addressServiceMock).deriveAddress(ed25519KeyPair.publicKey());
-    verifyNoMoreInteractions(addressServiceMock);
-    verify(signatureUtilsMock).toMultiSignableBytes(any(), any());
-    verifyNoMoreInteractions(signatureUtilsMock);
-  }
-
-  @Test
-  void verifyMultiSecp256k1() {
-    keyType = VersionType.SECP256K1;
-    when(signatureWithKeyMetaMock.transactionSignature()).thenReturn(secp256k1SignatureMock);
-
-    final Set<SignatureWithKeyMetadata> signatureWithKeyMetadataSet = Sets.newLinkedHashSet(signatureWithKeyMetaMock);
-    boolean actual = signatureService.verifyMultiSigned(signatureWithKeyMetadataSet, transactionMock, 1);
-
-    assertThat(actual).isTrue();
-    assertThat(secp256k1VerifyCalled.get()).isTrue();
-    assertThat(ed25519VerifyCalled.get()).isFalse();
-    verify(addressServiceMock).deriveAddress(secp256k1KeyPair.publicKey());
-    verifyNoMoreInteractions(addressServiceMock);
-    verify(signatureUtilsMock).toMultiSignableBytes(any(), any());
-    verifyNoMoreInteractions(signatureUtilsMock);
-  }
-
-  ///////////////////
-  // EdDsaSign
-  ///////////////////
-
-  @Test
-  void edDsaSign() {
-    this.keyType = VersionType.ED25519;
-
-    Signature actual = signatureService.edDsaSign(keyMetadataMock,
-      UnsignedByteArray.empty());
-
-    assertThat(actual).isEqualTo(ed25519SignatureMock);
-    assertThat(ed25519VerifyCalled.get()).isFalse();
-    assertThat(secp256k1VerifyCalled.get()).isFalse();
-    verifyNoMoreInteractions(signatureUtilsMock);
-  }
-
-  ///////////////////
-  // EcDsaSign
-  ///////////////////
-
-  @Test
-  void ecDsaSign() {
-    this.keyType = VersionType.SECP256K1;
-
-    Signature actual = signatureService.ecDsaSign(keyMetadataMock, UnsignedByteArray.empty());
-
-    assertThat(actual).isEqualTo(secp256k1SignatureMock);
-
-    assertThat(secp256k1VerifyCalled.get()).isFalse();
-    assertThat(ed25519VerifyCalled.get()).isFalse();
-    verifyNoMoreInteractions(signatureUtilsMock);
-  }
-
-  ///////////////////
-  // edDsaVerify
-  ///////////////////
-
-  @Test
-  void edDsaVerify() {
-    this.keyType = VersionType.ED25519;
-
-    boolean actual = signatureService.edDsaVerify(
-      keyMetadataMock, UnsignedByteArray.empty(), ed25519SignatureMock
-    );
-
-    assertThat(actual).isTrue();
-    assertThat(ed25519VerifyCalled.get()).isTrue();
-    assertThat(secp256k1VerifyCalled.get()).isFalse();
-    verifyNoMoreInteractions(signatureUtilsMock);
-  }
-
-  ///////////////////
-  // ecDsaVerify
-  ///////////////////
-
-  @Test
-  void ecDsaVerify() {
-    this.keyType = VersionType.SECP256K1;
-
-    boolean actual = signatureService.ecDsaVerify(
-      keyMetadataMock, UnsignedByteArray.empty(), secp256k1SignatureMock
-    );
-
-    assertThat(actual).isTrue();
-    assertThat(secp256k1VerifyCalled.get()).isTrue();
-    assertThat(ed25519VerifyCalled.get()).isFalse();
-    verifyNoMoreInteractions(signatureUtilsMock);
+  void verifyMultiSignedWithMinSigners() {
+    HashSet<SignatureWithKeyMetadata> signatureSet = Sets.newHashSet(signatureWithKeyMetaMock);
+    int minSigners = 1;
+    delegatedSignatureService.verifyMultiSigned(signatureSet, transactionMock, minSigners);
+    verify(delegatedTransactionVerifierMock).verifyMultiSigned(signatureSet, transactionMock, minSigners);
   }
 }

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureServiceTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureServiceTest.java
@@ -64,17 +64,7 @@ class AbstractDelegatedSignatureServiceTest {
       delegatedTransactionSignerMock,
       delegatedTransactionVerifierMock
     ) {
-      @Override
-      public PublicKey createKeyPair(KeyMetadata keyMetadata) {
-        return getPublicKey(keyMetadata);
-      }
     };
-  }
-
-  @Test
-  void createKeyPair() {
-    PublicKey actual = delegatedSignatureService.createKeyPair(keyMetadataMock);
-    assertThat(actual).isEqualTo(publicKeyMock);
   }
 
   @Test

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureServiceTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureServiceTest.java
@@ -93,7 +93,6 @@ class AbstractDelegatedSignatureServiceTest {
     when(signatureWithKeyMetaMock.transactionSignature()).thenReturn(ed25519SignatureMock);
 
     this.signatureService = new AbstractDelegatedSignatureService(
-      KeyStoreType.DERIVED_SERVER_SECRET,
       signatureUtilsMock,
       addressServiceMock
     ) {
@@ -127,15 +126,6 @@ class AbstractDelegatedSignatureServiceTest {
         return secp256k1VerifyCalled.get();
       }
     };
-  }
-
-  ///////////////////
-  // KeyStoreType
-  ///////////////////
-
-  @Test
-  void keyStoreType() {
-    assertThat(signatureService.keyStoreType()).isEqualTo(KeyStoreType.DERIVED_SERVER_SECRET);
   }
 
   ///////////////////

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureServiceTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureServiceTest.java
@@ -63,7 +63,18 @@ class AbstractDelegatedSignatureServiceTest {
     this.delegatedSignatureService = new AbstractDelegatedSignatureService(
       delegatedTransactionSignerMock,
       delegatedTransactionVerifierMock
-    ) { };
+    ) {
+      @Override
+      public PublicKey createKeyPair(KeyMetadata keyMetadata) {
+        return getPublicKey(keyMetadata);
+      }
+    };
+  }
+
+  @Test
+  void createKeyPair() {
+    PublicKey actual = delegatedSignatureService.createKeyPair(keyMetadataMock);
+    assertThat(actual).isEqualTo(publicKeyMock);
   }
 
   @Test

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionSignerTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionSignerTest.java
@@ -1,0 +1,277 @@
+package org.xrpl.xrpl4j.crypto.core.signing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
+import org.xrpl.xrpl4j.codec.addresses.VersionType;
+import org.xrpl.xrpl4j.crypto.core.AddressUtils;
+import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
+import org.xrpl.xrpl4j.crypto.core.keys.Ed25519KeyPairService;
+import org.xrpl.xrpl4j.crypto.core.keys.KeyPair;
+import org.xrpl.xrpl4j.crypto.core.keys.Passphrase;
+import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
+import org.xrpl.xrpl4j.crypto.core.keys.Secp256k1KeyPairService;
+import org.xrpl.xrpl4j.crypto.core.keys.Seed;
+import org.xrpl.xrpl4j.model.client.channels.UnsignedClaim;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Transaction;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class AbstractDelegatedTransactionSignerTest {
+
+  @Mock
+  private SignatureUtils signatureUtilsMock;
+  @Mock
+  private Signature ed25519SignatureMock;
+  @Mock
+  private Signature secp256k1SignatureMock;
+  @Mock
+  private KeyMetadata keyMetadataMock;
+  @Mock
+  private Transaction transactionMock;
+  @Mock
+  private AddressUtils addressServiceMock;
+  @Mock
+  private SignatureWithKeyMetadata signatureWithKeyMetaMock;
+
+  private KeyPair ed25519KeyPair;
+  private Address ed25519SignerAddress;
+
+  private KeyPair secp256k1KeyPair;
+  private Address secp256k1SignerAddress;
+
+  private AtomicBoolean ed25519VerifyCalled;
+  private AtomicBoolean secp256k1VerifyCalled;
+
+  private VersionType keyType;
+
+  private AbstractDelegatedTransactionSigner transactionSigner;
+
+  @BeforeEach
+  void setUp() {
+    openMocks(this);
+
+    ed25519VerifyCalled = new AtomicBoolean(false);
+    secp256k1VerifyCalled = new AtomicBoolean(false);
+
+    AddressUtils addressService = AddressUtils.getInstance();
+    Ed25519KeyPairService ed25519KeyPairService = Ed25519KeyPairService.getInstance();
+    this.ed25519KeyPair = ed25519KeyPairService.deriveKeyPair(
+      Seed.ed25519SeedFromPassphrase(Passphrase.of("hello"))
+    );
+    this.ed25519SignerAddress = addressService.deriveAddress(ed25519KeyPair.publicKey());
+
+    Secp256k1KeyPairService secp256k1KeyPairService = Secp256k1KeyPairService.getInstance();
+    this.secp256k1KeyPair = secp256k1KeyPairService.deriveKeyPair(
+      Seed.secp256k1SeedFromPassphrase(Passphrase.of("hello"))
+    );
+    this.secp256k1SignerAddress = addressService.deriveAddress(secp256k1KeyPair.publicKey());
+
+    when(addressServiceMock.deriveAddress(any())).thenReturn(ed25519SignerAddress);
+
+    when(signatureUtilsMock.toSignableBytes(Mockito.<Transaction>any())).thenReturn(UnsignedByteArray.empty());
+    when(signatureUtilsMock.toMultiSignableBytes(any(), any())).thenReturn(UnsignedByteArray.empty());
+
+    when(signatureWithKeyMetaMock.signingKeyMetadata()).thenReturn(keyMetadataMock);
+    when(signatureWithKeyMetaMock.transactionSignature()).thenReturn(ed25519SignatureMock);
+
+    this.transactionSigner = new AbstractDelegatedTransactionSigner(
+      signatureUtilsMock,
+      addressServiceMock
+    ) {
+      @Override
+      protected Signature edDsaSign(KeyMetadata privateKeyMetadata, UnsignedByteArray signableTransactionBytes) {
+        return ed25519SignatureMock;
+      }
+
+      @Override
+      protected Signature ecDsaSign(KeyMetadata privateKeyMetadata, UnsignedByteArray signableTransactionBytes) {
+        return secp256k1SignatureMock;
+      }
+
+      @Override
+      public PublicKey getPublicKey(KeyMetadata keyMetadata) {
+        return keyType == VersionType.ED25519 ? ed25519KeyPair.publicKey() : secp256k1KeyPair.publicKey();
+      }
+    };
+  }
+
+  ///////////////////
+  // Sign (Transaction)
+  ///////////////////
+
+  @Test
+  void signWithNullMetadata() {
+    Assertions.assertThrows(NullPointerException.class, () -> transactionSigner.sign(null, transactionMock));
+  }
+
+  @Test
+  void signWithNullTransaction() {
+    Assertions.assertThrows(NullPointerException.class,
+      () -> transactionSigner.sign(keyMetadataMock, (Transaction) null));
+  }
+
+  @Test
+  void signEd25519() {
+    keyType = VersionType.ED25519;
+    transactionSigner.sign(keyMetadataMock, transactionMock);
+
+    verify(signatureUtilsMock).toSignableBytes(transactionMock);
+    verify(signatureUtilsMock).addSignatureToTransaction(transactionMock, ed25519SignatureMock);
+    verifyNoMoreInteractions(signatureUtilsMock);
+  }
+
+  @Test
+  void signSecp256k1() {
+    keyType = VersionType.SECP256K1;
+
+    transactionSigner.sign(keyMetadataMock, transactionMock);
+
+    verify(signatureUtilsMock).toSignableBytes(transactionMock);
+    verify(signatureUtilsMock).addSignatureToTransaction(transactionMock, secp256k1SignatureMock);
+    verifyNoMoreInteractions(signatureUtilsMock);
+  }
+
+  ///////////////////
+  // Sign (UnsignedClaim)
+  ///////////////////
+
+  @Test
+  void signUnsignedClaimWithNullMetadata() {
+    UnsignedClaim unsignedClaimMock = mock(UnsignedClaim.class);
+    Assertions.assertThrows(NullPointerException.class, () -> transactionSigner.sign(null, unsignedClaimMock));
+  }
+
+  @Test
+  void signUnsignedClaimWithNullTransaction() {
+    Assertions.assertThrows(NullPointerException.class,
+      () -> transactionSigner.sign(keyMetadataMock, (UnsignedClaim) null));
+  }
+
+  @Test
+  void signUnsignedClaimEd25519() {
+    keyType = VersionType.ED25519;
+    UnsignedClaim unsignedClaimMock = mock(UnsignedClaim.class);
+    when(signatureUtilsMock.toSignableBytes(unsignedClaimMock)).thenReturn(UnsignedByteArray.empty());
+
+    Signature actual = transactionSigner.sign(keyMetadataMock, unsignedClaimMock);
+
+    verify(signatureUtilsMock).toSignableBytes(unsignedClaimMock);
+    verifyNoMoreInteractions(signatureUtilsMock);
+    assertThat(actual).isEqualTo(ed25519SignatureMock);
+  }
+
+  @Test
+  void signUnsignedClaimSecp256k1() {
+    keyType = VersionType.SECP256K1;
+    UnsignedClaim unsignedClaimMock = mock(UnsignedClaim.class);
+    when(signatureUtilsMock.toSignableBytes(unsignedClaimMock)).thenReturn(UnsignedByteArray.empty());
+
+    Signature actual = transactionSigner.sign(keyMetadataMock, unsignedClaimMock);
+
+    verify(signatureUtilsMock).toSignableBytes(unsignedClaimMock);
+    verifyNoMoreInteractions(signatureUtilsMock);
+    assertThat(actual).isEqualTo(secp256k1SignatureMock);
+  }
+
+  ///////////////////
+  // MultiSign
+  ///////////////////
+
+  @Test
+  void multiSignWithNullMetadata() {
+    Assertions.assertThrows(NullPointerException.class, () -> transactionSigner.multiSign(null, transactionMock));
+  }
+
+  @Test
+  void multiSignWithNullTransaction() {
+    Assertions.assertThrows(NullPointerException.class, () -> transactionSigner.multiSign(keyMetadataMock, null));
+  }
+
+  @Test
+  void multiSignEd25519() {
+    keyType = VersionType.ED25519;
+    when(addressServiceMock.deriveAddress(any())).thenReturn(ed25519SignerAddress);
+
+    SignatureWithKeyMetadata signatureWithKeyMetadata = transactionSigner.multiSign(
+      keyMetadataMock,
+      transactionMock
+    );
+    assertThat(signatureWithKeyMetadata.transactionSignature()).isEqualTo(ed25519SignatureMock);
+    assertThat(signatureWithKeyMetadata.signingKeyMetadata()).isEqualTo(keyMetadataMock);
+
+    verify(addressServiceMock).deriveAddress(any());
+    verifyNoMoreInteractions(addressServiceMock);
+    verify(signatureUtilsMock).toMultiSignableBytes(transactionMock, ed25519SignerAddress);
+    verify(signatureUtilsMock, times(0)).toSignableBytes(transactionMock);
+    verifyNoMoreInteractions(signatureUtilsMock);
+  }
+
+  @Test
+  void multiSignSecp256k1() {
+    keyType = VersionType.SECP256K1;
+    when(addressServiceMock.deriveAddress(any())).thenReturn(secp256k1SignerAddress);
+
+    SignatureWithKeyMetadata signatureWithKeyMetadata = transactionSigner.multiSign(
+      keyMetadataMock,
+      transactionMock
+    );
+
+    assertThat(signatureWithKeyMetadata.transactionSignature()).isEqualTo(secp256k1SignatureMock);
+    assertThat(signatureWithKeyMetadata.signingKeyMetadata()).isEqualTo(keyMetadataMock);
+
+    verify(addressServiceMock).deriveAddress(any());
+    verifyNoMoreInteractions(addressServiceMock);
+    verify(signatureUtilsMock).toMultiSignableBytes(transactionMock, secp256k1SignerAddress);
+    verify(signatureUtilsMock, times(0)).toSignableBytes(transactionMock);
+    verifyNoMoreInteractions(signatureUtilsMock);
+  }
+
+  ///////////////////
+  // EdDsaSign
+  ///////////////////
+
+  @Test
+  void edDsaSign() {
+    this.keyType = VersionType.ED25519;
+
+    Signature actual = transactionSigner.edDsaSign(keyMetadataMock,
+      UnsignedByteArray.empty());
+
+    assertThat(actual).isEqualTo(ed25519SignatureMock);
+    assertThat(ed25519VerifyCalled.get()).isFalse();
+    assertThat(secp256k1VerifyCalled.get()).isFalse();
+    verifyNoMoreInteractions(signatureUtilsMock);
+  }
+
+  ///////////////////
+  // EcDsaSign
+  ///////////////////
+
+  @Test
+  void ecDsaSign() {
+    this.keyType = VersionType.SECP256K1;
+
+    Signature actual = transactionSigner.ecDsaSign(keyMetadataMock, UnsignedByteArray.empty());
+
+    assertThat(actual).isEqualTo(secp256k1SignatureMock);
+
+    assertThat(secp256k1VerifyCalled.get()).isFalse();
+    assertThat(ed25519VerifyCalled.get()).isFalse();
+    verifyNoMoreInteractions(signatureUtilsMock);
+  }
+
+}

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionSignerTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionSignerTest.java
@@ -103,11 +103,6 @@ public class AbstractDelegatedTransactionSignerTest {
       }
 
       @Override
-      public PublicKey createKeyPair(KeyMetadata keyMetadata) {
-        return this.getPublicKey(keyMetadata);
-      }
-
-      @Override
       public PublicKey getPublicKey(KeyMetadata keyMetadata) {
         return keyType == VersionType.ED25519 ? ed25519KeyPair.publicKey() : secp256k1KeyPair.publicKey();
       }

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionSignerTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionSignerTest.java
@@ -103,6 +103,11 @@ public class AbstractDelegatedTransactionSignerTest {
       }
 
       @Override
+      public PublicKey createKeyPair(KeyMetadata keyMetadata) {
+        return this.getPublicKey(keyMetadata);
+      }
+
+      @Override
       public PublicKey getPublicKey(KeyMetadata keyMetadata) {
         return keyType == VersionType.ED25519 ? ed25519KeyPair.publicKey() : secp256k1KeyPair.publicKey();
       }

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionVerifierTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionVerifierTest.java
@@ -1,0 +1,248 @@
+package org.xrpl.xrpl4j.crypto.core.signing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import org.assertj.core.util.Sets;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
+import org.xrpl.xrpl4j.codec.addresses.VersionType;
+import org.xrpl.xrpl4j.crypto.core.AddressUtils;
+import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
+import org.xrpl.xrpl4j.crypto.core.keys.Ed25519KeyPairService;
+import org.xrpl.xrpl4j.crypto.core.keys.KeyPair;
+import org.xrpl.xrpl4j.crypto.core.keys.Passphrase;
+import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
+import org.xrpl.xrpl4j.crypto.core.keys.Secp256k1KeyPairService;
+import org.xrpl.xrpl4j.crypto.core.keys.Seed;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Transaction;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class AbstractDelegatedTransactionVerifierTest {
+
+  @Mock
+  private SignatureUtils signatureUtilsMock;
+  @Mock
+  private Signature ed25519SignatureMock;
+  @Mock
+  private Signature secp256k1SignatureMock;
+  @Mock
+  private KeyMetadata keyMetadataMock;
+  @Mock
+  private Transaction transactionMock;
+  @Mock
+  private AddressUtils addressServiceMock;
+  @Mock
+  private SignatureWithKeyMetadata signatureWithKeyMetaMock;
+
+  private KeyPair ed25519KeyPair;
+
+  private KeyPair secp256k1KeyPair;
+
+  private AtomicBoolean ed25519VerifyCalled;
+  private AtomicBoolean secp256k1VerifyCalled;
+  private VersionType keyType;
+
+  private AbstractDelegatedTransactionVerifier transactionVerifier;
+
+  @BeforeEach
+  void setUp() {
+    openMocks(this);
+
+    ed25519VerifyCalled = new AtomicBoolean(false);
+    secp256k1VerifyCalled = new AtomicBoolean(false);
+
+    AddressUtils addressService = AddressUtils.getInstance();
+    Ed25519KeyPairService ed25519KeyPairService = Ed25519KeyPairService.getInstance();
+    this.ed25519KeyPair = ed25519KeyPairService.deriveKeyPair(
+      Seed.ed25519SeedFromPassphrase(Passphrase.of("hello"))
+    );
+    Address ed25519SignerAddress = addressService.deriveAddress(ed25519KeyPair.publicKey());
+
+    Secp256k1KeyPairService secp256k1KeyPairService = Secp256k1KeyPairService.getInstance();
+    this.secp256k1KeyPair = secp256k1KeyPairService.deriveKeyPair(
+      Seed.secp256k1SeedFromPassphrase(Passphrase.of("hello"))
+    );
+
+    when(addressServiceMock.deriveAddress(any())).thenReturn(ed25519SignerAddress);
+
+    when(signatureUtilsMock.toSignableBytes(Mockito.<Transaction>any())).thenReturn(UnsignedByteArray.empty());
+    when(signatureUtilsMock.toMultiSignableBytes(any(), any())).thenReturn(UnsignedByteArray.empty());
+
+    when(signatureWithKeyMetaMock.signingKeyMetadata()).thenReturn(keyMetadataMock);
+    when(signatureWithKeyMetaMock.transactionSignature()).thenReturn(ed25519SignatureMock);
+
+    this.transactionVerifier = new AbstractDelegatedTransactionVerifier(
+      signatureUtilsMock,
+      addressServiceMock
+    ) {
+      @Override
+      protected boolean edDsaVerify(
+        KeyMetadata keyMetadata,
+        UnsignedByteArray signableTransactionBytes,
+        Signature transactionSignature
+      ) {
+        ed25519VerifyCalled.set(true);
+        return ed25519VerifyCalled.get();
+      }
+
+      @Override
+      protected boolean ecDsaVerify(
+        KeyMetadata keyMetadata,
+        UnsignedByteArray signableTransactionBytes,
+        Signature transactionSignature
+      ) {
+        secp256k1VerifyCalled.set(true);
+        return secp256k1VerifyCalled.get();
+      }
+
+      @Override
+      public PublicKey getPublicKey(KeyMetadata keyMetadata) {
+        return keyType == VersionType.ED25519 ? ed25519KeyPair.publicKey() : secp256k1KeyPair.publicKey();
+      }
+    };
+  }
+
+  ///////////////////
+  // verify (signatureWithKeyMetadata, transaction)
+  ///////////////////
+
+  @Test
+  void verifyWithNullMetadata() {
+    Assertions.assertThrows(NullPointerException.class,
+      () -> transactionVerifier.verifySingleSigned(null, transactionMock));
+  }
+
+  @Test
+  void verifyWithNullTransaction() {
+    Assertions.assertThrows(NullPointerException.class,
+      () -> transactionVerifier.verifySingleSigned(signatureWithKeyMetaMock, null));
+  }
+
+  @Test
+  void verifyEd25519() {
+    keyType = VersionType.ED25519;
+    boolean actual = transactionVerifier.verifySingleSigned(signatureWithKeyMetaMock, transactionMock);
+
+    assertThat(actual).isTrue();
+    assertThat(ed25519VerifyCalled.get()).isTrue();
+    assertThat(secp256k1VerifyCalled.get()).isFalse();
+    verify(signatureUtilsMock).toSignableBytes(transactionMock);
+    verifyNoMoreInteractions(signatureUtilsMock);
+  }
+
+  @Test
+  void verifySecp256k1() {
+    keyType = VersionType.SECP256K1;
+    boolean actual = transactionVerifier.verifySingleSigned(signatureWithKeyMetaMock, transactionMock);
+
+    assertThat(actual).isTrue();
+    assertThat(secp256k1VerifyCalled.get()).isTrue();
+    assertThat(ed25519VerifyCalled.get()).isFalse();
+    verify(signatureUtilsMock).toSignableBytes(transactionMock);
+    verifyNoMoreInteractions(signatureUtilsMock);
+  }
+
+  ///////////////////
+  // verify (signatureWithKeyMetadata, transaction)
+  ///////////////////
+
+  @Test
+  void verifyMultiWithNullSet() {
+    Assertions.assertThrows(NullPointerException.class,
+      () -> transactionVerifier.verifyMultiSigned(null, transactionMock));
+  }
+
+  @Test
+  void verifyMultiWithNullTransaction() {
+    Assertions.assertThrows(NullPointerException.class,
+      () -> transactionVerifier.verifyMultiSigned(Sets.newHashSet(), null));
+  }
+
+  @Test
+  void verifyMultiWithEmptySet() {
+    Assertions.assertThrows(IllegalArgumentException.class,
+      () -> transactionVerifier.verifyMultiSigned(Sets.newHashSet(), transactionMock));
+  }
+
+  @Test
+  void verifyMultiEd25519() {
+    keyType = VersionType.ED25519;
+    when(signatureWithKeyMetaMock.transactionSignature()).thenReturn(ed25519SignatureMock);
+
+    final Set<SignatureWithKeyMetadata> signatureWithKeyMetadataSet = Sets.newLinkedHashSet(signatureWithKeyMetaMock);
+    boolean actual = transactionVerifier.verifyMultiSigned(signatureWithKeyMetadataSet, transactionMock, 1);
+
+    assertThat(actual).isTrue();
+    assertThat(ed25519VerifyCalled.get()).isTrue();
+    assertThat(secp256k1VerifyCalled.get()).isFalse();
+    verify(addressServiceMock).deriveAddress(ed25519KeyPair.publicKey());
+    verifyNoMoreInteractions(addressServiceMock);
+    verify(signatureUtilsMock).toMultiSignableBytes(any(), any());
+    verifyNoMoreInteractions(signatureUtilsMock);
+  }
+
+  @Test
+  void verifyMultiSecp256k1() {
+    keyType = VersionType.SECP256K1;
+    when(signatureWithKeyMetaMock.transactionSignature()).thenReturn(secp256k1SignatureMock);
+
+    final Set<SignatureWithKeyMetadata> signatureWithKeyMetadataSet = Sets.newLinkedHashSet(signatureWithKeyMetaMock);
+    boolean actual = transactionVerifier.verifyMultiSigned(signatureWithKeyMetadataSet, transactionMock, 1);
+
+    assertThat(actual).isTrue();
+    assertThat(secp256k1VerifyCalled.get()).isTrue();
+    assertThat(ed25519VerifyCalled.get()).isFalse();
+    verify(addressServiceMock).deriveAddress(secp256k1KeyPair.publicKey());
+    verifyNoMoreInteractions(addressServiceMock);
+    verify(signatureUtilsMock).toMultiSignableBytes(any(), any());
+    verifyNoMoreInteractions(signatureUtilsMock);
+  }
+
+  ///////////////////
+  // edDsaVerify
+  ///////////////////
+
+  @Test
+  void edDsaVerify() {
+    this.keyType = VersionType.ED25519;
+
+    boolean actual = transactionVerifier.edDsaVerify(
+      keyMetadataMock, UnsignedByteArray.empty(), ed25519SignatureMock
+    );
+
+    assertThat(actual).isTrue();
+    assertThat(ed25519VerifyCalled.get()).isTrue();
+    assertThat(secp256k1VerifyCalled.get()).isFalse();
+    verifyNoMoreInteractions(signatureUtilsMock);
+  }
+
+  ///////////////////
+  // ecDsaVerify
+  ///////////////////
+
+  @Test
+  void ecDsaVerify() {
+    this.keyType = VersionType.SECP256K1;
+
+    boolean actual = transactionVerifier.ecDsaVerify(
+      keyMetadataMock, UnsignedByteArray.empty(), secp256k1SignatureMock
+    );
+
+    assertThat(actual).isTrue();
+    assertThat(secp256k1VerifyCalled.get()).isTrue();
+    assertThat(ed25519VerifyCalled.get()).isFalse();
+    verifyNoMoreInteractions(signatureUtilsMock);
+  }
+}


### PR DESCRIPTION
This PR aims to improve interface definitions and abstract implementations of `DelegatedSignatureService`, `DelegatedTransactionSigner`, and `DelegatedTransactionVerifier` based on my experience implementing `DelegatedSignatureService` for GCP KMS.

The changes are as follows:
* `AbstractDelegatedSignatureService` is now a composition of `AbstractDelegatedTransactionSigner` and `AbstractDelegatedTransactionVerifier`
* Introduced an interface called `DelegatedKeyPairService`
* `DelegatedTransactionSigner` now extends `DelegatedKeyPairService`