### PR TITLE
feat: add static constructors for builders with ledger input(account_tx req)

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
@@ -47,10 +47,8 @@ public class AccountTransactionsIT {
     LedgerIndexBound minLedger = LedgerIndexBound.of(61400000);
     LedgerIndexBound maxLedger = LedgerIndexBound.of(61487000);
     AccountTransactionsResult results = mainnetClient.accountTransactions(
-      AccountTransactionsRequestParams.builder()
+      AccountTransactionsRequestParams.builder(minLedger, maxLedger)
         .account(MAINNET_ADDRESS)
-        .ledgerIndexMinimum(minLedger)
-        .ledgerIndexMaximum(maxLedger)
         .build()
     );
     assertThat(results.transactions()).isNotEmpty();
@@ -59,10 +57,9 @@ public class AccountTransactionsIT {
     int transactionsFound = results.transactions().size();
     int pages = 1;
     while (results.marker().isPresent()) {
-      results = mainnetClient.accountTransactions(AccountTransactionsRequestParams.builder()
+      results = mainnetClient.accountTransactions(AccountTransactionsRequestParams
+          .builder(minLedger, maxLedger)
         .account(MAINNET_ADDRESS)
-        .ledgerIndexMinimum(minLedger)
-        .ledgerIndexMaximum(maxLedger)
         .marker(results.marker().get())
         .build());
       assertThat(results.transactions()).isNotEmpty();
@@ -83,10 +80,8 @@ public class AccountTransactionsIT {
     // Sometimes we will get a "server busy" error back in this test, so if we do get that, we should just wait
     // a few seconds until asking again.
     AccountTransactionsResult results = getAccountTransactions(
-      AccountTransactionsRequestParams.builder()
+      AccountTransactionsRequestParams.builder(minLedger, maxLedger)
         .account(MAINNET_ADDRESS)
-        .ledgerIndexMinimum(minLedger)
-        .ledgerIndexMaximum(maxLedger)
         .build()
     );
 
@@ -108,9 +103,8 @@ public class AccountTransactionsIT {
   @Test
   void listTransactionsWithLedgerSpecifiers() throws JsonRpcClientErrorException {
     AccountTransactionsResult resultByShortcut = getAccountTransactions(
-      AccountTransactionsRequestParams.builder()
+      AccountTransactionsRequestParams.builder(LedgerSpecifier.VALIDATED)
         .account(MAINNET_ADDRESS)
-        .ledgerSpecifier(Optional.of(LedgerSpecifier.VALIDATED))
         .build()
     );
 
@@ -130,18 +124,14 @@ public class AccountTransactionsIT {
     LedgerIndex validatedLedgerIndex = ledger.ledgerIndexSafe();
 
     AccountTransactionsResult resultByLedgerIndex = getAccountTransactions(
-      AccountTransactionsRequestParams.builder()
+      AccountTransactionsRequestParams.builder(LedgerSpecifier.of(validatedLedgerIndex))
         .account(MAINNET_ADDRESS)
-        .ledgerSpecifier(
-          Optional.of(LedgerSpecifier.of(validatedLedgerIndex))
-        )
         .build()
     );
 
     AccountTransactionsResult resultByLedgerHash = getAccountTransactions(
-      AccountTransactionsRequestParams.builder()
+      AccountTransactionsRequestParams.builder(LedgerSpecifier.of(validatedLedgerHash))
         .account(MAINNET_ADDRESS)
-        .ledgerSpecifier(Optional.of(LedgerSpecifier.of(validatedLedgerHash)))
         .build()
     );
 

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoRequestParams.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoRequestParams.java
@@ -43,8 +43,8 @@ public interface AccountInfoRequestParams extends XrplRequestParams {
    */
   static AccountInfoRequestParams of(Address account) {
     return builder()
-        .account(account)
-        .build();
+      .account(account)
+      .build();
   }
 
   /**
@@ -94,7 +94,7 @@ public interface AccountInfoRequestParams extends XrplRequestParams {
    * Always true, as {@link #account()} is always an {@link Address}.
    *
    * @return {@code true} if the account field only accepts a public key or XRP Ledger address, otherwise {@code false}.
-   *     Defaults to {@code true}.
+   *   Defaults to {@code true}.
    */
   @Value.Derived
   default boolean strict() {
@@ -107,7 +107,7 @@ public interface AccountInfoRequestParams extends XrplRequestParams {
    * querying for the data from the current open ledger.
    *
    * @return {@code true} if queue transactions should be returned in the response, {@code false} if not.
-   *     Defaults to {@code false}.
+   *   Defaults to {@code false}.
    */
   @Value.Default
   default boolean queue() {

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoRequestParams.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoRequestParams.java
@@ -9,7 +9,6 @@ import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.client.LegacyLedgerSpecifierUtils;
 import org.xrpl.xrpl4j.model.client.XrplRequestParams;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
-import org.xrpl.xrpl4j.model.client.common.LedgerIndexShortcut;
 import org.xrpl.xrpl4j.model.client.common.LedgerSpecifier;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
@@ -44,8 +43,8 @@ public interface AccountInfoRequestParams extends XrplRequestParams {
    */
   static AccountInfoRequestParams of(Address account) {
     return builder()
-      .account(account)
-      .build();
+        .account(account)
+        .build();
   }
 
   /**
@@ -95,7 +94,7 @@ public interface AccountInfoRequestParams extends XrplRequestParams {
    * Always true, as {@link #account()} is always an {@link Address}.
    *
    * @return {@code true} if the account field only accepts a public key or XRP Ledger address, otherwise {@code false}.
-   *   Defaults to {@code true}.
+   *     Defaults to {@code true}.
    */
   @Value.Derived
   default boolean strict() {
@@ -108,7 +107,7 @@ public interface AccountInfoRequestParams extends XrplRequestParams {
    * querying for the data from the current open ledger.
    *
    * @return {@code true} if queue transactions should be returned in the response, {@code false} if not.
-   *   Defaults to {@code false}.
+   *     Defaults to {@code false}.
    */
   @Value.Default
   default boolean queue() {

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
@@ -236,17 +236,16 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
   @Value.Check
   default void validateSpecifierNotCurrentOrClosed() {
     ledgerSpecifier().ifPresent(
-        ledgerSpecifier -> ledgerSpecifier.handle(
-            ledgerHash -> {
-            },
-            ledgerIndex -> {
-            },
-            ledgerIndexShortcut -> Preconditions.checkArgument(
-                ledgerIndexShortcut.equals(LedgerIndexShortcut.VALIDATED),
-                "Invalid LedgerIndexShortcut. The account_tx API method only accepts 'validated' when specifying " +
-                    "a shortcut."
-            )
+      ledgerSpecifier -> ledgerSpecifier.handle(
+        ledgerHash -> {
+        },
+        ledgerIndex -> {
+        },
+        ledgerIndexShortcut -> Preconditions.checkArgument(
+          ledgerIndexShortcut.equals(LedgerIndexShortcut.VALIDATED),
+          "Invalid LedgerIndexShortcut. The account_tx API method only accepts 'validated' when specifying a shortcut."
         )
+      )
     );
   }
 

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
@@ -39,7 +39,7 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
    *
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    * @deprecated Prefer one of the other defined builders so that you are overtly
-   * specifying which ledger index or type you want.
+   *     specifying which ledger index or type you want.
    */
   @Deprecated
   static ImmutableAccountTransactionsRequestParams.Builder builder() {
@@ -207,7 +207,7 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
    * ordered.)
    *
    * @return {@code true} if values should be indexed with the oldest ledger first, otherwise {@code false}. Defaults
-   * to {@code false}.
+   *     to {@code false}.
    */
   @Value.Default
   default boolean forward() {
@@ -243,7 +243,8 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
             },
             ledgerIndexShortcut -> Preconditions.checkArgument(
                 ledgerIndexShortcut.equals(LedgerIndexShortcut.VALIDATED),
-                "Invalid LedgerIndexShortcut. The account_tx API method only accepts 'validated' when specifying a shortcut."
+                "Invalid LedgerIndexShortcut. The account_tx API method only accepts 'validated' when specifying " +
+                    "a shortcut."
             )
         )
     );

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
@@ -79,11 +79,18 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
    *
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    */
-  static ImmutableAccountTransactionsRequestParams.Builder builder(LedgerIndexBound ledgerIndexMinimum, LedgerIndexBound ledgerIndexMaximum) {
-    LedgerIndexBound ledgerIndexMin = ledgerIndexMinimum, ledgerIndexMax = ledgerIndexMaximum;
+  static ImmutableAccountTransactionsRequestParams.Builder builder(
+      LedgerIndexBound ledgerIndexMinimum,
+      LedgerIndexBound ledgerIndexMaximum) {
+    LedgerIndexBound ledgerIndexMin = ledgerIndexMinimum;
+    LedgerIndexBound ledgerIndexMax = ledgerIndexMaximum;
 
-    if (ledgerIndexMin == null) ledgerIndexMin = LedgerIndexBound.of(-1);
-    if (ledgerIndexMax == null) ledgerIndexMax = LedgerIndexBound.of(-1);
+    if (ledgerIndexMin == null) {
+      ledgerIndexMin = LedgerIndexBound.of(-1);
+    }
+    if (ledgerIndexMax == null) {
+      ledgerIndexMax = LedgerIndexBound.of(-1);
+    }
 
     return ImmutableAccountTransactionsRequestParams.builder()
         .ledgerIndexMinimum(ledgerIndexMin)

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
@@ -38,8 +38,52 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
    *
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    */
+  @Deprecated
   static ImmutableAccountTransactionsRequestParams.Builder builder() {
     return ImmutableAccountTransactionsRequestParams.builder();
+  }
+
+  /**
+   * Construct a builder for this class with {@link LedgerIndex} field set.
+   *
+   * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
+   */
+  static ImmutableAccountTransactionsRequestParams.Builder builder(LedgerIndex ledgerIndex) {
+    return ImmutableAccountTransactionsRequestParams.builder().ledgerIndex(ledgerIndex);
+  }
+
+  /**
+   * Construct a builder for this class with {@link LedgerSpecifier} field set.
+   *
+   * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
+   */
+  static ImmutableAccountTransactionsRequestParams.Builder builder(LedgerSpecifier ledgerSpecifier) {
+    return ImmutableAccountTransactionsRequestParams.builder().ledgerSpecifier(Optional.ofNullable(ledgerSpecifier));
+  }
+
+  /**
+   * Construct a builder for this class with ledgerHash field set.
+   *
+   * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
+   */
+  static ImmutableAccountTransactionsRequestParams.Builder builder(Hash256 ledgerHash) {
+    return ImmutableAccountTransactionsRequestParams.builder().ledgerHash(Optional.ofNullable(ledgerHash));
+  }
+
+  /**
+   * Construct a builder for this class with ledgerIndexRange field set.
+   *
+   * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
+   */
+  static ImmutableAccountTransactionsRequestParams.Builder builder(LedgerIndexBound ledgerIndexMinimum, LedgerIndexBound ledgerIndexMaximum) {
+    LedgerIndexBound ledgerIndexMin = ledgerIndexMinimum, ledgerIndexMax = ledgerIndexMaximum;
+
+    if (ledgerIndexMin == null) ledgerIndexMin = LedgerIndexBound.of(-1);
+    if (ledgerIndexMax == null) ledgerIndexMax = LedgerIndexBound.of(-1);
+
+    return ImmutableAccountTransactionsRequestParams.builder()
+        .ledgerIndexMinimum(ledgerIndexMin)
+        .ledgerIndexMaximum(ledgerIndexMax);
   }
 
   /**

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
@@ -19,6 +19,7 @@ import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.Marker;
 
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -28,8 +29,8 @@ import javax.annotation.Nullable;
 @Value.Immutable
 @JsonSerialize(as = ImmutableAccountTransactionsRequestParams.class)
 @JsonDeserialize(
-  as = ImmutableAccountTransactionsRequestParams.class,
-  using = AccountTransactionsRequestParamsDeserializer.class
+    as = ImmutableAccountTransactionsRequestParams.class,
+    using = AccountTransactionsRequestParamsDeserializer.class
 )
 public interface AccountTransactionsRequestParams extends XrplRequestParams {
 
@@ -37,6 +38,8 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
    * Construct a builder for this class.
    *
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
+   * @deprecated Prefer one of the other defined builders so that you are overtly
+   * specifying which ledger index or type you want.
    */
   @Deprecated
   static ImmutableAccountTransactionsRequestParams.Builder builder() {
@@ -44,21 +47,10 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
   }
 
   /**
-   * Construct a builder for this class with {@link LedgerIndex} field set.
-   *
-   * @param ledgerIndex An index of type {@link LedgerIndex} to specify a particular ledger.
-   * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
-   */
-  static ImmutableAccountTransactionsRequestParams.Builder builder(LedgerIndex ledgerIndex) {
-    return ImmutableAccountTransactionsRequestParams.builder().ledgerSpecifier(
-        Optional.of(LedgerSpecifier.of(ledgerIndex))
-    );
-  }
-
-  /**
    * Construct a builder for this class with {@link LedgerSpecifier} field set.
    *
    * @param ledgerSpecifier A specifier of type {@link LedgerSpecifier} to specify a ledger.
+   *
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    */
   static ImmutableAccountTransactionsRequestParams.Builder builder(LedgerSpecifier ledgerSpecifier) {
@@ -66,21 +58,11 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
   }
 
   /**
-   * Construct a builder for this class with ledgerHash field set.
-   *
-   * @param ledgerHash Hash of type {@link Hash256} of a specific ledger.
-   * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
-   */
-  static ImmutableAccountTransactionsRequestParams.Builder builder(Hash256 ledgerHash) {
-    return ImmutableAccountTransactionsRequestParams.builder()
-        .ledgerSpecifier(Optional.of(LedgerSpecifier.of(ledgerHash)));
-  }
-
-  /**
    * Construct a builder for this class with ledgerIndexRange field set.
    *
    * @param ledgerIndexMinimum A lower bound of ledgerIndex of type {@link LedgerIndexBound}.
    * @param ledgerIndexMaximum An upper bound of ledgerIndex of type {@link LedgerIndexBound}.
+   *
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    */
   static ImmutableAccountTransactionsRequestParams.Builder builder(
@@ -89,12 +71,8 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
     LedgerIndexBound ledgerIndexMin = ledgerIndexMinimum;
     LedgerIndexBound ledgerIndexMax = ledgerIndexMaximum;
 
-    if (ledgerIndexMin == null) {
-      ledgerIndexMin = LedgerIndexBound.of(-1);
-    }
-    if (ledgerIndexMax == null) {
-      ledgerIndexMax = LedgerIndexBound.of(-1);
-    }
+    Objects.requireNonNull(ledgerIndexMinimum);
+    Objects.requireNonNull(ledgerIndexMaximum);
 
     return ImmutableAccountTransactionsRequestParams.builder()
         .ledgerIndexMinimum(ledgerIndexMin)
@@ -144,10 +122,10 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
   default LedgerIndexBound ledgerIndexMinimum() {
     // Gives deprecated field precedence
     return ledgerIndexMin()
-      .map(LedgerIndex::unsignedIntegerValue)
-      .map(UnsignedInteger::intValue)
-      .map(LedgerIndexBound::of)
-      .orElse(LedgerIndexBound.of(-1));
+        .map(LedgerIndex::unsignedIntegerValue)
+        .map(UnsignedInteger::intValue)
+        .map(LedgerIndexBound::of)
+        .orElse(LedgerIndexBound.of(-1));
   }
 
   /**
@@ -162,10 +140,10 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
   default LedgerIndexBound ledgerIndexMaximum() {
     // Gives deprecated field precedence
     return ledgerIndexMax()
-      .map(LedgerIndex::unsignedIntegerValue)
-      .map(UnsignedInteger::intValue)
-      .map(LedgerIndexBound::of)
-      .orElse(LedgerIndexBound.of(-1));
+        .map(LedgerIndex::unsignedIntegerValue)
+        .map(UnsignedInteger::intValue)
+        .map(LedgerIndexBound::of)
+        .orElse(LedgerIndexBound.of(-1));
   }
 
   /**
@@ -208,9 +186,9 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
     // If either ledgerHash or ledgerIndex are specified, return a LedgerSpecifier with the present field,
     // otherwise return empty
     return ledgerHash()
-      .map(LedgerSpecifier::of)
-      .map(Optional::of)
-      .orElseGet(() -> ledgerIndex().map(LegacyLedgerSpecifierUtils::computeLedgerSpecifierFromLedgerIndex));
+        .map(LedgerSpecifier::of)
+        .map(Optional::of)
+        .orElseGet(() -> ledgerIndex().map(LegacyLedgerSpecifierUtils::computeLedgerSpecifierFromLedgerIndex));
   }
 
   /**
@@ -229,7 +207,7 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
    * ordered.)
    *
    * @return {@code true} if values should be indexed with the oldest ledger first, otherwise {@code false}. Defaults
-   *   to {@code false}.
+   * to {@code false}.
    */
   @Value.Default
   default boolean forward() {
@@ -258,16 +236,16 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
   @Value.Check
   default void validateSpecifierNotCurrentOrClosed() {
     ledgerSpecifier().ifPresent(
-      ledgerSpecifier -> ledgerSpecifier.handle(
-        ledgerHash -> {
-        },
-        ledgerIndex -> {
-        },
-        ledgerIndexShortcut -> Preconditions.checkArgument(
-          ledgerIndexShortcut.equals(LedgerIndexShortcut.VALIDATED),
-          "Invalid LedgerIndexShortcut. The account_tx API method only accepts 'validated' when specifying a shortcut."
+        ledgerSpecifier -> ledgerSpecifier.handle(
+            ledgerHash -> {
+            },
+            ledgerIndex -> {
+            },
+            ledgerIndexShortcut -> Preconditions.checkArgument(
+                ledgerIndexShortcut.equals(LedgerIndexShortcut.VALIDATED),
+                "Invalid LedgerIndexShortcut. The account_tx API method only accepts 'validated' when specifying a shortcut."
+            )
         )
-      )
     );
   }
 
@@ -282,10 +260,10 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
     // so that they do not override the ledgerSpecifier.
     if (ledgerSpecifier().isPresent() && (ledgerIndexMinimum() != null || ledgerIndexMaximum() != null)) {
       return AccountTransactionsRequestParams.builder()
-        .from(this)
-        .ledgerIndexMinimum(null)
-        .ledgerIndexMaximum(null)
-        .build();
+          .from(this)
+          .ledgerIndexMinimum(null)
+          .ledgerIndexMaximum(null)
+          .build();
     } else {
       return this;
     }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
@@ -46,6 +46,7 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
   /**
    * Construct a builder for this class with {@link LedgerIndex} field set.
    *
+   * @param ledgerIndex An index of type {@link LedgerIndex} to specify a particular ledger.
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    */
   static ImmutableAccountTransactionsRequestParams.Builder builder(LedgerIndex ledgerIndex) {
@@ -58,6 +59,7 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
   /**
    * Construct a builder for this class with {@link LedgerSpecifier} field set.
    *
+   * @param ledgerSpecifier A specifier of type {@link LedgerSpecifier} to specify a ledger.
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    */
   static ImmutableAccountTransactionsRequestParams.Builder builder(LedgerSpecifier ledgerSpecifier) {
@@ -67,6 +69,7 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
   /**
    * Construct a builder for this class with ledgerHash field set.
    *
+   * @param ledgerHash Hash of type {@link Hash256} of a specific ledger.
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    */
   static ImmutableAccountTransactionsRequestParams.Builder builder(Hash256 ledgerHash) {
@@ -77,6 +80,8 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
   /**
    * Construct a builder for this class with ledgerIndexRange field set.
    *
+   * @param ledgerIndexMinimum A lower bound of ledgerIndex of type {@link LedgerIndexBound}.
+   * @param ledgerIndexMaximum An upper bound of ledgerIndex of type {@link LedgerIndexBound}.
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    */
   static ImmutableAccountTransactionsRequestParams.Builder builder(

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
@@ -49,7 +49,10 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    */
   static ImmutableAccountTransactionsRequestParams.Builder builder(LedgerIndex ledgerIndex) {
-    return ImmutableAccountTransactionsRequestParams.builder().ledgerIndex(ledgerIndex);
+    return ImmutableAccountTransactionsRequestParams.builder()
+        .ledgerSpecifier(
+        Optional.of(LedgerSpecifier.of(ledgerIndex))
+    );
   }
 
   /**
@@ -67,7 +70,8 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    */
   static ImmutableAccountTransactionsRequestParams.Builder builder(Hash256 ledgerHash) {
-    return ImmutableAccountTransactionsRequestParams.builder().ledgerHash(Optional.ofNullable(ledgerHash));
+    return ImmutableAccountTransactionsRequestParams.builder()
+        .ledgerSpecifier(Optional.of(LedgerSpecifier.of(ledgerHash)));
   }
 
   /**

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
@@ -29,8 +29,8 @@ import javax.annotation.Nullable;
 @Value.Immutable
 @JsonSerialize(as = ImmutableAccountTransactionsRequestParams.class)
 @JsonDeserialize(
-    as = ImmutableAccountTransactionsRequestParams.class,
-    using = AccountTransactionsRequestParamsDeserializer.class
+  as = ImmutableAccountTransactionsRequestParams.class,
+  using = AccountTransactionsRequestParamsDeserializer.class
 )
 public interface AccountTransactionsRequestParams extends XrplRequestParams {
 
@@ -39,7 +39,7 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
    *
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    * @deprecated Prefer one of the other defined builders so that you are overtly
-   *     specifying which ledger index or type you want.
+   *   specifying which ledger index or type you want.
    */
   @Deprecated
   static ImmutableAccountTransactionsRequestParams.Builder builder() {
@@ -58,7 +58,8 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
   }
 
   /**
-   * Construct a builder for this class with ledgerIndexRange field set.
+   * Construct a builder for this class with {@link LedgerIndexBound}s specified for the
+   * {@link #ledgerIndexMinimum} and {@link #ledgerIndexMaximum} fields.
    *
    * @param ledgerIndexMinimum A lower bound of ledgerIndex of type {@link LedgerIndexBound}.
    * @param ledgerIndexMaximum An upper bound of ledgerIndex of type {@link LedgerIndexBound}.
@@ -66,17 +67,15 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    */
   static ImmutableAccountTransactionsRequestParams.Builder builder(
-      LedgerIndexBound ledgerIndexMinimum,
-      LedgerIndexBound ledgerIndexMaximum) {
-    LedgerIndexBound ledgerIndexMin = ledgerIndexMinimum;
-    LedgerIndexBound ledgerIndexMax = ledgerIndexMaximum;
-
+    LedgerIndexBound ledgerIndexMinimum,
+    LedgerIndexBound ledgerIndexMaximum
+  ) {
     Objects.requireNonNull(ledgerIndexMinimum);
     Objects.requireNonNull(ledgerIndexMaximum);
 
     return ImmutableAccountTransactionsRequestParams.builder()
-        .ledgerIndexMinimum(ledgerIndexMin)
-        .ledgerIndexMaximum(ledgerIndexMax);
+      .ledgerIndexMinimum(ledgerIndexMinimum)
+      .ledgerIndexMaximum(ledgerIndexMaximum);
   }
 
   /**
@@ -122,10 +121,10 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
   default LedgerIndexBound ledgerIndexMinimum() {
     // Gives deprecated field precedence
     return ledgerIndexMin()
-        .map(LedgerIndex::unsignedIntegerValue)
-        .map(UnsignedInteger::intValue)
-        .map(LedgerIndexBound::of)
-        .orElse(LedgerIndexBound.of(-1));
+      .map(LedgerIndex::unsignedIntegerValue)
+      .map(UnsignedInteger::intValue)
+      .map(LedgerIndexBound::of)
+      .orElse(LedgerIndexBound.of(-1));
   }
 
   /**
@@ -140,10 +139,10 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
   default LedgerIndexBound ledgerIndexMaximum() {
     // Gives deprecated field precedence
     return ledgerIndexMax()
-        .map(LedgerIndex::unsignedIntegerValue)
-        .map(UnsignedInteger::intValue)
-        .map(LedgerIndexBound::of)
-        .orElse(LedgerIndexBound.of(-1));
+      .map(LedgerIndex::unsignedIntegerValue)
+      .map(UnsignedInteger::intValue)
+      .map(LedgerIndexBound::of)
+      .orElse(LedgerIndexBound.of(-1));
   }
 
   /**
@@ -186,9 +185,9 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
     // If either ledgerHash or ledgerIndex are specified, return a LedgerSpecifier with the present field,
     // otherwise return empty
     return ledgerHash()
-        .map(LedgerSpecifier::of)
-        .map(Optional::of)
-        .orElseGet(() -> ledgerIndex().map(LegacyLedgerSpecifierUtils::computeLedgerSpecifierFromLedgerIndex));
+      .map(LedgerSpecifier::of)
+      .map(Optional::of)
+      .orElseGet(() -> ledgerIndex().map(LegacyLedgerSpecifierUtils::computeLedgerSpecifierFromLedgerIndex));
   }
 
   /**
@@ -207,7 +206,7 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
    * ordered.)
    *
    * @return {@code true} if values should be indexed with the oldest ledger first, otherwise {@code false}. Defaults
-   *     to {@code false}.
+   *   to {@code false}.
    */
   @Value.Default
   default boolean forward() {
@@ -260,10 +259,10 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
     // so that they do not override the ledgerSpecifier.
     if (ledgerSpecifier().isPresent() && (ledgerIndexMinimum() != null || ledgerIndexMaximum() != null)) {
       return AccountTransactionsRequestParams.builder()
-          .from(this)
-          .ledgerIndexMinimum(null)
-          .ledgerIndexMaximum(null)
-          .build();
+        .from(this)
+        .ledgerIndexMinimum(null)
+        .ledgerIndexMaximum(null)
+        .build();
     } else {
       return this;
     }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
@@ -50,8 +50,7 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
    */
   static ImmutableAccountTransactionsRequestParams.Builder builder(LedgerIndex ledgerIndex) {
-    return ImmutableAccountTransactionsRequestParams.builder()
-        .ledgerSpecifier(
+    return ImmutableAccountTransactionsRequestParams.builder().ledgerSpecifier(
         Optional.of(LedgerSpecifier.of(ledgerIndex))
     );
   }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsTests.java
@@ -108,7 +108,7 @@ public class AccountTransactionsRequestParamsTests {
   }
 
   @Test
-  void builderWithLedgerSpecifier(){
+  void builderWithLedgerSpecifier() {
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams
         .builder(LedgerSpecifier.VALIDATED)
         .account(Address.of("foo"))
@@ -120,29 +120,30 @@ public class AccountTransactionsRequestParamsTests {
   }
 
   @Test
-  void builderWithLedgerIndex(){
+  void builderWithLedgerIndex() {
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams
-        .builder(LedgerIndex.of(UnsignedInteger.ONE))
+        .builder(LedgerSpecifier.of(UnsignedInteger.ONE))
         .account(Address.of("foo"))
         .build();
 
-    assertThat(params.ledgerIndex()).isEqualTo(Optional.of(LedgerIndex.of(UnsignedInteger.ONE)));
+    System.out.print(params);
+    assertThat(params.ledgerSpecifier()).isEqualTo(Optional.of(LedgerSpecifier.of(UnsignedInteger.ONE)));
   }
 
   @Test
-  void builderWithLedgerHash(){
+  void builderWithLedgerHash() {
     String random = "qmHJUF3lNC6rfEkZa3URngmwIRYU7bKMYKPz4er7UJKnWUItKuBCN9qKqXt8YYJ8";
 
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams
-        .builder(Hash256.of(random))
+        .builder(LedgerSpecifier.of(Hash256.of(random)))
         .account(Address.of("foo"))
         .build();
 
-    assertThat(params.ledgerHash()).isEqualTo(Optional.of(Hash256.of(random)));
+    assertThat(params.ledgerSpecifier()).isEqualTo(Optional.of(LedgerSpecifier.of(Hash256.of(random))));
   }
 
   @Test
-  void builderWithLedgerIndexRange(){
+  void builderWithLedgerIndexRange() {
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams
         .builder(LedgerIndexBound.of(12345), LedgerIndexBound.of(12347))
         .account(Address.of("foo"))
@@ -153,7 +154,7 @@ public class AccountTransactionsRequestParamsTests {
   }
 
   @Test
-  void builderWithLedgerIndexMin(){
+  void builderWithLedgerIndexMin() {
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams
         .builder(LedgerIndexBound.of(12345), null)
         .account(Address.of("foo"))
@@ -164,7 +165,7 @@ public class AccountTransactionsRequestParamsTests {
   }
 
   @Test
-  void builderWithLedgerIndexMax(){
+  void builderWithLedgerIndexMax() {
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams
         .builder(null, LedgerIndexBound.of(12345))
         .account(Address.of("foo"))

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsTests.java
@@ -174,4 +174,28 @@ public class AccountTransactionsRequestParamsTests {
     assertThat(params.ledgerIndexMinimum()).isEqualTo(LedgerIndexBound.of(-1));
     assertThat(params.ledgerIndexMaximum()).isEqualTo(LedgerIndexBound.of(12345));
   }
+
+  @Test
+  void builderWithLedgerIndexEnforced() {
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(LedgerIndex.of(UnsignedInteger.ONE))
+        .account(Address.of("foo"))
+        .build();
+
+    System.out.print(params);
+    assertThat(params.ledgerSpecifier()).isEqualTo(
+        Optional.of(LedgerSpecifier.of(LedgerIndex.of(UnsignedInteger.ONE))));
+  }
+
+  @Test
+  void builderWithLedgerHashEnforced() {
+    String random = "qmHJUF3lNC6rfEkZa3URngmwIRYU7bKMYKPz4er7UJKnWUItKuBCN9qKqXt8YYJ8";
+
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(Hash256.of(random))
+        .account(Address.of("foo"))
+        .build();
+    System.out.print(params);
+    assertThat(params.ledgerSpecifier()).isEqualTo(Optional.of(LedgerSpecifier.of(Hash256.of(random))));
+  }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsTests.java
@@ -156,7 +156,7 @@ public class AccountTransactionsRequestParamsTests {
   @Test
   void builderWithLedgerIndexMin() {
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams
-        .builder(LedgerIndexBound.of(12345), null)
+        .builder(LedgerIndexBound.of(12345), LedgerIndexBound.of(-1))
         .account(Address.of("foo"))
         .build();
 
@@ -167,35 +167,11 @@ public class AccountTransactionsRequestParamsTests {
   @Test
   void builderWithLedgerIndexMax() {
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams
-        .builder(null, LedgerIndexBound.of(12345))
+        .builder(LedgerIndexBound.of(-1), LedgerIndexBound.of(12345))
         .account(Address.of("foo"))
         .build();
 
     assertThat(params.ledgerIndexMinimum()).isEqualTo(LedgerIndexBound.of(-1));
     assertThat(params.ledgerIndexMaximum()).isEqualTo(LedgerIndexBound.of(12345));
-  }
-
-  @Test
-  void builderWithLedgerIndexEnforced() {
-    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
-        .builder(LedgerIndex.of(UnsignedInteger.ONE))
-        .account(Address.of("foo"))
-        .build();
-
-    System.out.print(params);
-    assertThat(params.ledgerSpecifier()).isEqualTo(
-        Optional.of(LedgerSpecifier.of(LedgerIndex.of(UnsignedInteger.ONE))));
-  }
-
-  @Test
-  void builderWithLedgerHashEnforced() {
-    String random = "qmHJUF3lNC6rfEkZa3URngmwIRYU7bKMYKPz4er7UJKnWUItKuBCN9qKqXt8YYJ8";
-
-    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
-        .builder(Hash256.of(random))
-        .account(Address.of("foo"))
-        .build();
-    System.out.print(params);
-    assertThat(params.ledgerSpecifier()).isEqualTo(Optional.of(LedgerSpecifier.of(Hash256.of(random))));
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsTests.java
@@ -9,6 +9,7 @@ import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndexBound;
 import org.xrpl.xrpl4j.model.client.common.LedgerSpecifier;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
 
 import java.util.Optional;
 
@@ -104,5 +105,72 @@ public class AccountTransactionsRequestParamsTests {
     assertThat(params.ledgerIndexMinimum()).isNull();
     assertThat(params.ledgerIndexMaximum()).isNull();
     assertThat(params.ledgerSpecifier()).isNotEmpty();
+  }
+
+  @Test
+  void builderWithLedgerSpecifier(){
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(LedgerSpecifier.VALIDATED)
+        .account(Address.of("foo"))
+        .build();
+
+    System.out.println(params);
+
+    assertThat(params.ledgerSpecifier()).isEqualTo(Optional.of(LedgerSpecifier.VALIDATED));
+  }
+
+  @Test
+  void builderWithLedgerIndex(){
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(LedgerIndex.of(UnsignedInteger.ONE))
+        .account(Address.of("foo"))
+        .build();
+
+    assertThat(params.ledgerIndex()).isEqualTo(Optional.of(LedgerIndex.of(UnsignedInteger.ONE)));
+  }
+
+  @Test
+  void builderWithLedgerHash(){
+    String random = "qmHJUF3lNC6rfEkZa3URngmwIRYU7bKMYKPz4er7UJKnWUItKuBCN9qKqXt8YYJ8";
+
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(Hash256.of(random))
+        .account(Address.of("foo"))
+        .build();
+
+    assertThat(params.ledgerHash()).isEqualTo(Optional.of(Hash256.of(random)));
+  }
+
+  @Test
+  void builderWithLedgerIndexRange(){
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(LedgerIndexBound.of(12345), LedgerIndexBound.of(12347))
+        .account(Address.of("foo"))
+        .build();
+
+    assertThat(params.ledgerIndexMinimum()).isEqualTo(LedgerIndexBound.of(12345));
+    assertThat(params.ledgerIndexMaximum()).isEqualTo(LedgerIndexBound.of(12347));
+  }
+
+  @Test
+  void builderWithLedgerIndexMin(){
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(LedgerIndexBound.of(12345), null)
+        .account(Address.of("foo"))
+        .build();
+
+    assertThat(params.ledgerIndexMinimum()).isEqualTo(LedgerIndexBound.of(12345));
+    assertThat(params.ledgerIndexMaximum()).isEqualTo(LedgerIndexBound.of(-1));
+  }
+
+  @Test
+  void builderWithLedgerIndexMax(){
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(null, LedgerIndexBound.of(12345))
+        .account(Address.of("foo"))
+        .build();
+
+    assertThat(params.ledgerIndexMinimum()).isEqualTo(LedgerIndexBound.of(-1));
+    assertThat(params.ledgerIndexMaximum()).isEqualTo(LedgerIndexBound.of(12345));
   }
 }


### PR DESCRIPTION
The `account_tx` rippled request method lets you specify the ledger(s) that you want the transactions from:
    * By specifying a specific `ledger_index`
    * By specifying a `ledger_index` shortcut like "validated", "current", "closed"
    * By specifying a ledger hash in `ledger_hash`
    * By specifying a lower bound in `ledger_index_min`
    * By specifying an upper bound in `ledger_index_max`
    * By specifying a `ledger range` with both ledger_index_min and ledger_index_max

This PR adds static builder constructors to support these types and make `account_tx` request less confusing.

Adds tests to check new ones and modify previous tests to use new formats. Passes all CI tests. 

Solves Issue #134