### PR TITLE
V3 Fixes #205 (Make Delegated Transaction Signer return only a Signature)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can use one or more xrpl4j modules in your Maven project by using the curren
         <dependency>
             <groupId>org.xrpl4j</groupId>
             <artifactId>xrpl4j-bom</artifactId>
-            <version>2.1.0</version>
+            <version>2.1.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/xrpl4j-address-codec/README.md
+++ b/xrpl4j-address-codec/README.md
@@ -8,7 +8,7 @@ Use this module in your project by adding the following to your `pom.xml`:
 <dependency>
   <groupId>org.xrpl</groupId>
   <artifactId>xrpl4j-address-codec</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
 </dependency>
 ```
 

--- a/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/AddressCodecTest.java
+++ b/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/AddressCodecTest.java
@@ -7,11 +7,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodeException;
+import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodingFormatException;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.XAddress;
+
 
 /**
  * Unit tests for {@link AddressCodec}.
  */
+@SuppressWarnings( {"ParameterName", "MethodName", "LocalVariableName"})
 public class AddressCodecTest extends AbstractCodecTest {
 
   AddressCodec addressCodec;
@@ -145,6 +149,28 @@ public class AddressCodecTest extends AbstractCodecTest {
       publicKey -> addressCodec.decodeAccountPublicKey(publicKey),
       unsignedByteArrayFromHex("023693F15967AE357D0327974AD46FE3C127113B1110D6044FD41E723689F81CC6"),
       "aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3"
+    );
+  }
+
+  @Test
+  public void addressWithBadChecksum() {
+    Address address = Address.of("r9cZA1mLK5R5am25ArfXFmqgNwjZgnfk59");
+
+    assertThrows(
+      EncodingFormatException.class,
+      () -> addressCodec.classicAddressToXAddress(address, true),
+      "Checksum does not validate"
+    );
+  }
+
+  @Test
+  public void xAddressWithBadChecksum() {
+    XAddress xAddress = XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV5fdx1mHp98tDMoQXa");
+
+    assertThrows(
+      EncodingFormatException.class,
+      () -> addressCodec.xAddressToClassicAddress(xAddress),
+      "Checksum does not validate"
     );
   }
 }

--- a/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/XAddressTest.java
+++ b/xrpl4j-address-codec/src/test/java/org/xrpl/xrpl4j/codec/addresses/XAddressTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.DecodeException;
-import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodingFormatException;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.XAddress;
 
@@ -218,18 +217,6 @@ public class XAddressTest {
     assertThat(addressCodec.isValidClassicAddress(fromXAddress.classicAddress()));
     assertThat(addressCodec.isValidXAddress(xAddress));
   }
-
-  @Test
-  public void xAddressWithBadChecksum() {
-    XAddress xAddress = XAddress.of("XVLhHMPHU98es4dbozjVtdWzVrDjtV5fdx1mHp98tDMoQXa");
-
-    assertThrows(
-      EncodingFormatException.class,
-      () -> addressCodec.xAddressToClassicAddress(xAddress),
-      "Checksum does not validate"
-    );
-  }
-
 
   @Test
   public void xAddressWithBadPrefix() {

--- a/xrpl4j-binary-codec/README.md
+++ b/xrpl4j-binary-codec/README.md
@@ -8,7 +8,7 @@ Use this module in your project by adding the following to your `pom.xml`:
 <dependency>
   <groupId>org.xrpl</groupId>
   <artifactId>xrpl4j-binary-codec</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
 </dependency>
 ```
 

--- a/xrpl4j-bom/README.md
+++ b/xrpl4j-bom/README.md
@@ -19,7 +19,7 @@ To use this bom in your project, add the following to the `<dependencyManamgemen
             <dependency>
                 <groupId>org.xrpl.xrpl4j</groupId>
                 <artifactId>xrpl4j-bom</artifactId>
-                <version>2.1.0</version>
+                <version>2.1.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/main/java/org/xrpl/xrpl4j/crypto/bc/signing/DerivedKeyDelegatedSignatureService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/src/main/java/org/xrpl/xrpl4j/crypto/bc/signing/DerivedKeyDelegatedSignatureService.java
@@ -158,9 +158,7 @@ public class DerivedKeyDelegatedSignatureService implements DelegatedSignatureSe
   }
 
   @Override
-  public <T extends Transaction> SignatureWithKeyMetadata multiSign(
-    final KeyMetadata keyMetadata, final T transaction
-  ) {
+  public <T extends Transaction> Signature multiSign(final KeyMetadata keyMetadata, final T transaction) {
     Objects.requireNonNull(keyMetadata);
     Objects.requireNonNull(transaction);
     return getSignatureServiceSafe(keyMetadata).multiSign(keyMetadata, transaction);

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureService.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureService.java
@@ -51,7 +51,7 @@ public abstract class AbstractDelegatedSignatureService implements DelegatedSign
   }
 
   @Override
-  public <T extends Transaction> SignatureWithKeyMetadata multiSign(KeyMetadata keyMetadata, T transaction) {
+  public <T extends Transaction> Signature multiSign(KeyMetadata keyMetadata, T transaction) {
     return delegatedTransactionSigner.multiSign(keyMetadata, transaction);
   }
 

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionSigner.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/main/java/org/xrpl/xrpl4j/crypto/core/signing/DelegatedTransactionSigner.java
@@ -1,8 +1,6 @@
 package org.xrpl.xrpl4j.crypto.core.signing;
 
 import org.xrpl.xrpl4j.crypto.core.KeyMetadata;
-import org.xrpl.xrpl4j.crypto.core.keys.DelegatedKeyPairService;
-import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
 import org.xrpl.xrpl4j.model.client.channels.UnsignedClaim;
 import org.xrpl.xrpl4j.model.transactions.Transaction;
 
@@ -49,5 +47,5 @@ public interface DelegatedTransactionSigner extends DelegatedPublicKeyProvider {
    *
    * @return A {@link SingleSingedTransaction} of type {@link T} containing everything related to a signed transaction.
    */
-  <T extends Transaction> SignatureWithKeyMetadata multiSign(KeyMetadata keyMetadata, T transaction);
+  <T extends Transaction> Signature multiSign(KeyMetadata keyMetadata, T transaction);
 }

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureServiceTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedSignatureServiceTest.java
@@ -57,8 +57,7 @@ class AbstractDelegatedSignatureServiceTest {
     when(delegatedTransactionSignerMock.getPublicKey(keyMetadataMock)).thenReturn(publicKeyMock);
     when(delegatedTransactionSignerMock.sign(keyMetadataMock, transactionMock)).thenReturn(singleSignedTransactionMock);
     when(delegatedTransactionSignerMock.sign(eq(keyMetadataMock), any(UnsignedClaim.class))).thenReturn(signatureMock);
-    when(delegatedTransactionSignerMock.multiSign(keyMetadataMock, transactionMock))
-      .thenReturn(signatureWithKeyMetaMock);
+    when(delegatedTransactionSignerMock.multiSign(keyMetadataMock, transactionMock)).thenReturn(signatureMock);
 
     this.delegatedSignatureService = new AbstractDelegatedSignatureService(
       delegatedTransactionSignerMock,
@@ -90,8 +89,8 @@ class AbstractDelegatedSignatureServiceTest {
 
   @Test
   void multiSignTransaction() {
-    SignatureWithKeyMetadata actual = delegatedSignatureService.multiSign(keyMetadataMock, transactionMock);
-    assertThat(actual).isEqualTo(signatureWithKeyMetaMock);
+    Signature actual = delegatedSignatureService.multiSign(keyMetadataMock, transactionMock);
+    assertThat(actual).isEqualTo(signatureMock);
     verify(delegatedTransactionSignerMock).multiSign(keyMetadataMock, transactionMock);
   }
 

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionSignerTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/AbstractDelegatedTransactionSignerTest.java
@@ -177,9 +177,8 @@ public class AbstractDelegatedTransactionSignerTest {
     keyType = VersionType.ED25519;
     when(addressServiceMock.deriveAddress(any())).thenReturn(TestConstants.ED_ADDRESS);
 
-    SignatureWithKeyMetadata signatureWithKeyMetadata = transactionSigner.multiSign(keyMetadataMock, transactionMock);
-    assertThat(signatureWithKeyMetadata.transactionSignature()).isEqualTo(ed25519SignatureMock);
-    assertThat(signatureWithKeyMetadata.signingKeyMetadata()).isEqualTo(keyMetadataMock);
+    Signature signature = transactionSigner.multiSign(keyMetadataMock, transactionMock);
+    assertThat(signature).isEqualTo(ed25519SignatureMock);
 
     verify(addressServiceMock).deriveAddress(any());
     verifyNoMoreInteractions(addressServiceMock);
@@ -193,10 +192,9 @@ public class AbstractDelegatedTransactionSignerTest {
     keyType = VersionType.SECP256K1;
     when(addressServiceMock.deriveAddress(any())).thenReturn(TestConstants.EC_ADDRESS);
 
-    SignatureWithKeyMetadata signatureWithKeyMetadata = transactionSigner.multiSign(keyMetadataMock, transactionMock);
+    Signature signature = transactionSigner.multiSign(keyMetadataMock, transactionMock);
 
-    assertThat(signatureWithKeyMetadata.transactionSignature()).isEqualTo(secp256k1SignatureMock);
-    assertThat(signatureWithKeyMetadata.signingKeyMetadata()).isEqualTo(keyMetadataMock);
+    assertThat(signature).isEqualTo(secp256k1SignatureMock);
 
     verify(addressServiceMock).deriveAddress(any());
     verifyNoMoreInteractions(addressServiceMock);

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/MultiSignedTransactionTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/MultiSignedTransactionTest.java
@@ -1,6 +1,8 @@
 package org.xrpl.xrpl4j.crypto.core.signing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.xrpl.xrpl4j.crypto.core.TestConstants.EC_ADDRESS;
+import static org.xrpl.xrpl4j.crypto.core.TestConstants.ED_ADDRESS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Sets;
@@ -12,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
 import org.xrpl.xrpl4j.crypto.core.keys.PublicKey;
 import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
-import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
@@ -28,20 +29,20 @@ class MultiSignedTransactionTest {
   void setUp() {
     multiSignedTransaction = MultiSignedTransaction.builder()
       .signedTransaction(Payment.builder()
-        .account(Address.of(""))
+        .account(ED_ADDRESS)
         .fee(XrpCurrencyAmount.of(UnsignedLong.ONE))
         .sequence(UnsignedInteger.ONE)
         .signingPublicKey("")
         .amount(XrpCurrencyAmount.ofDrops(12345))
-        .destination(Address.of(""))
+        .destination(EC_ADDRESS)
         .build())
       .unsignedTransaction(Payment.builder()
-        .account(Address.of(""))
+        .account(ED_ADDRESS)
         .fee(XrpCurrencyAmount.of(UnsignedLong.ONE))
         .sequence(UnsignedInteger.ONE)
         .signingPublicKey("")
         .amount(XrpCurrencyAmount.ofDrops(12345))
-        .destination(Address.of(""))
+        .destination(EC_ADDRESS)
         .build())
       .signedTransactionBytes(UnsignedByteArray.fromHex(HEX_32_BYTES))
       .signatureWithPublicKeySet(Sets.newHashSet(SignatureWithPublicKey.builder()

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/SignableTransactionTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/SignableTransactionTest.java
@@ -3,6 +3,8 @@ package org.xrpl.xrpl4j.crypto.core.signing;
 import static com.jayway.jsonassert.JsonAssert.with;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.xrpl.xrpl4j.crypto.core.TestConstants.EC_ADDRESS;
+import static org.xrpl.xrpl4j.crypto.core.TestConstants.ED_ADDRESS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
@@ -13,7 +15,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
 import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
-import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.Transaction;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
@@ -55,23 +56,23 @@ class SignableTransactionTest {
     SignableTransaction signableTransaction = SignableTransaction.builder()
       .signableTransactionBytes(UnsignedByteArray.fromHex(HEX_32_BYTES))
       .originalUnsignedTransaction(Payment.builder()
-        .account(Address.of(""))
+        .account(ED_ADDRESS)
         .fee(XrpCurrencyAmount.of(UnsignedLong.ONE))
         .sequence(UnsignedInteger.ONE)
         .signingPublicKey("")
         .amount(XrpCurrencyAmount.ofDrops(12345))
-        .destination(Address.of(""))
+        .destination(EC_ADDRESS)
         .build())
       .build();
 
     String json = ObjectMapperFactory.create().writeValueAsString(signableTransaction);
-    with(json).assertThat("$.originalUnsignedTransaction.Account", is(""));
+    with(json).assertThat("$.originalUnsignedTransaction.Account", is(ED_ADDRESS.value()));
     with(json).assertThat("$.originalUnsignedTransaction.Fee", is("1"));
     with(json).assertThat("$.originalUnsignedTransaction.Sequence", is(1));
     with(json).assertThat("$.originalUnsignedTransaction.SigningPubKey", is(""));
     with(json).assertThat("$.originalUnsignedTransaction.Flags", is(2147483648L));
     with(json).assertThat("$.originalUnsignedTransaction.Amount", is("12345"));
-    with(json).assertThat("$.originalUnsignedTransaction.Destination", is(""));
+    with(json).assertThat("$.originalUnsignedTransaction.Destination", is(EC_ADDRESS.value()));
     with(json).assertThat("$.originalUnsignedTransaction.TransactionType", is("Payment"));
     with(json).assertThat("$.signableTransactionBytes", is(HEX_32_BYTES));
 

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/SingleSingedTransactionTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/core/signing/SingleSingedTransactionTest.java
@@ -1,6 +1,8 @@
 package org.xrpl.xrpl4j.crypto.core.signing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.xrpl.xrpl4j.crypto.core.TestConstants.EC_ADDRESS;
+import static org.xrpl.xrpl4j.crypto.core.TestConstants.ED_ADDRESS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
@@ -26,20 +28,20 @@ class SingleSingedTransactionTest {
   void setUp() {
     singleSingedTransaction = SingleSingedTransaction.builder()
       .signedTransaction(Payment.builder()
-        .account(Address.of(""))
+        .account(ED_ADDRESS)
         .fee(XrpCurrencyAmount.of(UnsignedLong.ONE))
         .sequence(UnsignedInteger.ONE)
         .signingPublicKey("")
         .amount(XrpCurrencyAmount.ofDrops(12345))
-        .destination(Address.of(""))
+        .destination(EC_ADDRESS)
         .build())
       .unsignedTransaction(Payment.builder()
-        .account(Address.of(""))
+        .account(ED_ADDRESS)
         .fee(XrpCurrencyAmount.of(UnsignedLong.ONE))
         .sequence(UnsignedInteger.ONE)
         .signingPublicKey("")
         .amount(XrpCurrencyAmount.ofDrops(12345))
-        .destination(Address.of(""))
+        .destination(EC_ADDRESS)
         .build())
       .signedTransactionBytes(UnsignedByteArray.fromHex(HEX_32_BYTES))
       .signature(Signature.builder()

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/AbstractSignatureServiceTest.java
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/AbstractSignatureServiceTest.java
@@ -64,7 +64,7 @@ public class AbstractSignatureServiceTest {
     when(signatureUtilsMock.toMultiSignableBytes(any(), any())).thenReturn(UnsignedByteArray.empty());
 
     when(publicKeyMock.value()).thenReturn(UnsignedByteArray.empty());
-    signerAddress = Address.of("");
+    signerAddress = Address.of("rDgZZ3wyprx4ZqrGQUkquE9Fs2Xs8XBcdw");
     when(keyPairServiceMock.deriveAddress(publicKeyMock.value())).thenReturn(signerAddress);
 
     this.signatureService = new AbstractSignatureService(

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/client/XrplClientTest.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/client/XrplClientTest.java
@@ -35,8 +35,8 @@ public class XrplClientTest {
   public void depositAuthorized() throws JsonRpcClientErrorException {
     DepositAuthorizedRequestParams depositAuthorized = DepositAuthorizedRequestParams.builder()
       .ledgerSpecifier(LedgerSpecifier.CURRENT)
-      .sourceAccount(Address.of("123"))
-      .destinationAccount(Address.of("abc"))
+      .sourceAccount(Address.of("rDgZZ3wyprx4ZqrGQUkquE9Fs2Xs8XBcdw"))
+      .destinationAccount(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .build();
     xrplClient.depositAuthorized(depositAuthorized);
 

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountSetIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountSetIT.java
@@ -23,7 +23,66 @@ import java.util.Objects;
  */
 public class AccountSetIT extends AbstractIT {
 
-  // TODO: Make an IT that sets all flags, and unsets only 1, and validate that only that 1 single flag was cleared.
+  @Test
+  public void enableAllAndDisableOne() throws JsonRpcClientErrorException {
+
+    Wallet wallet = createRandomAccount();
+
+    ///////////////////////
+    // Get validated account info and validate account state
+    AccountInfoResult accountInfo = this.scanForResult(() -> this.getValidatedAccountInfo(wallet.classicAddress()));
+    assertThat(accountInfo.status()).isNotEmpty().get().isEqualTo("success");
+    assertThat(accountInfo.accountData().flags().lsfGlobalFreeze()).isEqualTo(false);
+
+    UnsignedInteger sequence = accountInfo.accountData().sequence();
+    //////////////////////
+    // Set asfAccountTxnID (no corresponding ledger flag)
+    FeeResult feeResult = xrplClient.fee();
+    AccountSet accountSet = AccountSet.builder()
+        .account(wallet.classicAddress())
+        .fee(feeResult.drops().openLedgerFee())
+        .sequence(accountInfo.accountData().sequence())
+        .setFlag(AccountSetFlag.ACCOUNT_TXN_ID)
+        .signingPublicKey(wallet.publicKey())
+        .build();
+
+    SubmitResult<AccountSet> response = xrplClient.submit(wallet, accountSet);
+    assertThat(response.result()).isEqualTo("tesSUCCESS");
+    assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
+        .isEqualTo(response.transactionResult().hash());
+    logger.info(
+        "AccountSet transaction successful: https://testnet.xrpl.org/transactions/" + response.transactionResult().hash()
+    );
+
+    ///////////////////////
+    // Set flags one-by-one
+    sequence = sequence.plus(UnsignedInteger.ONE);
+    assertSetFlag(wallet, sequence, AccountSetFlag.DEFAULT_RIPPLE, AccountRootFlags.DEFAULT_RIPPLE);
+    sequence = sequence.plus(UnsignedInteger.ONE);
+    assertSetFlag(wallet, sequence, AccountSetFlag.DEPOSIT_AUTH, AccountRootFlags.DEPOSIT_AUTH);
+    sequence = sequence.plus(UnsignedInteger.ONE);
+    assertSetFlag(wallet, sequence, AccountSetFlag.DISALLOW_XRP, AccountRootFlags.DISALLOW_XRP);
+    sequence = sequence.plus(UnsignedInteger.ONE);
+    assertSetFlag(wallet, sequence, AccountSetFlag.REQUIRE_AUTH, AccountRootFlags.REQUIRE_AUTH);
+    sequence = sequence.plus(UnsignedInteger.ONE);
+    assertSetFlag(wallet, sequence, AccountSetFlag.REQUIRE_DEST, AccountRootFlags.REQUIRE_DEST_TAG);
+    sequence = sequence.plus(UnsignedInteger.ONE);
+    assertSetFlag(wallet, sequence, AccountSetFlag.GLOBAL_FREEZE, AccountRootFlags.GLOBAL_FREEZE);
+    sequence = sequence.plus(UnsignedInteger.ONE);
+
+    AccountRootFlags flags1 = this.scanForResult(
+      () -> this.getValidatedAccountInfo(wallet.classicAddress())
+    ).accountData().flags();
+
+    assertClearFlag(wallet, sequence, AccountSetFlag.GLOBAL_FREEZE, AccountRootFlags.GLOBAL_FREEZE);
+
+    AccountRootFlags flags2 = this.scanForResult(
+      () -> this.getValidatedAccountInfo(wallet.classicAddress())
+    ).accountData().flags();
+
+    assertThat(flags1.getValue() - flags2.getValue())
+        .isEqualTo(AccountRootFlags.GLOBAL_FREEZE.getValue());
+  }
 
   @Test
   public void disableAndEnableAllFlags() throws JsonRpcClientErrorException {

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
@@ -47,10 +47,8 @@ public class AccountTransactionsIT {
     LedgerIndexBound minLedger = LedgerIndexBound.of(61400000);
     LedgerIndexBound maxLedger = LedgerIndexBound.of(61487000);
     AccountTransactionsResult results = mainnetClient.accountTransactions(
-      AccountTransactionsRequestParams.builder()
+      AccountTransactionsRequestParams.builder(minLedger, maxLedger)
         .account(MAINNET_ADDRESS)
-        .ledgerIndexMinimum(minLedger)
-        .ledgerIndexMaximum(maxLedger)
         .build()
     );
     assertThat(results.transactions()).isNotEmpty();
@@ -59,10 +57,9 @@ public class AccountTransactionsIT {
     int transactionsFound = results.transactions().size();
     int pages = 1;
     while (results.marker().isPresent()) {
-      results = mainnetClient.accountTransactions(AccountTransactionsRequestParams.builder()
+      results = mainnetClient.accountTransactions(AccountTransactionsRequestParams
+          .builder(minLedger, maxLedger)
         .account(MAINNET_ADDRESS)
-        .ledgerIndexMinimum(minLedger)
-        .ledgerIndexMaximum(maxLedger)
         .marker(results.marker().get())
         .build());
       assertThat(results.transactions()).isNotEmpty();
@@ -83,10 +80,8 @@ public class AccountTransactionsIT {
     // Sometimes we will get a "server busy" error back in this test, so if we do get that, we should just wait
     // a few seconds until asking again.
     AccountTransactionsResult results = getAccountTransactions(
-      AccountTransactionsRequestParams.builder()
+      AccountTransactionsRequestParams.builder(minLedger, maxLedger)
         .account(MAINNET_ADDRESS)
-        .ledgerIndexMinimum(minLedger)
-        .ledgerIndexMaximum(maxLedger)
         .build()
     );
 
@@ -108,9 +103,8 @@ public class AccountTransactionsIT {
   @Test
   void listTransactionsWithLedgerSpecifiers() throws JsonRpcClientErrorException {
     AccountTransactionsResult resultByShortcut = getAccountTransactions(
-      AccountTransactionsRequestParams.builder()
+      AccountTransactionsRequestParams.builder(LedgerSpecifier.VALIDATED)
         .account(MAINNET_ADDRESS)
-        .ledgerSpecifier(Optional.of(LedgerSpecifier.VALIDATED))
         .build()
     );
 
@@ -130,18 +124,14 @@ public class AccountTransactionsIT {
     LedgerIndex validatedLedgerIndex = ledger.ledgerIndexSafe();
 
     AccountTransactionsResult resultByLedgerIndex = getAccountTransactions(
-      AccountTransactionsRequestParams.builder()
+      AccountTransactionsRequestParams.builder(LedgerSpecifier.of(validatedLedgerIndex))
         .account(MAINNET_ADDRESS)
-        .ledgerSpecifier(
-          Optional.of(LedgerSpecifier.of(validatedLedgerIndex))
-        )
         .build()
     );
 
     AccountTransactionsResult resultByLedgerHash = getAccountTransactions(
-      AccountTransactionsRequestParams.builder()
+      AccountTransactionsRequestParams.builder(LedgerSpecifier.of(validatedLedgerHash))
         .account(MAINNET_ADDRESS)
-        .ledgerSpecifier(Optional.of(LedgerSpecifier.of(validatedLedgerHash)))
         .build()
     );
 

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/AbstractIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/AbstractIT.java
@@ -325,6 +325,18 @@ public abstract class AbstractIT {
     return new BcSignatureService();
   }
 
+  protected Wallet constructRandomAccount() {
+    ///////////////////////
+    // Create the account
+    SeedWalletGenerationResult seedResult = walletFactory.randomWallet();
+    final Wallet wallet = seedResult.wallet();
+    logger.info("Generated testnet wallet with Address={}", wallet.address());
+
+    fundAccount(wallet);
+
+    return wallet;
+  }
+
   private KeyStore loadKeyStore() {
     final String jksFileName = "crypto/crypto.p12";
     final char[] jksPassword = "password".toCharArray();

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/AccountSetIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/AccountSetIT.java
@@ -2,7 +2,6 @@ package org.xrpl.xrpl4j.tests.v3;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
@@ -14,6 +13,7 @@ import org.xrpl.xrpl4j.model.client.transactions.SubmitResult;
 import org.xrpl.xrpl4j.model.flags.Flags.AccountRootFlags;
 import org.xrpl.xrpl4j.model.transactions.AccountSet;
 import org.xrpl.xrpl4j.model.transactions.AccountSet.AccountSetFlag;
+import org.xrpl.xrpl4j.model.transactions.CheckCreate;
 
 import java.util.Objects;
 
@@ -25,12 +25,10 @@ import java.util.Objects;
  */
 public class AccountSetIT extends AbstractIT {
 
-  // TODO: Make an IT that sets all flags, and unsets only 1, and validate that only that 1 single flag was cleared.
-
   @Test
-  public void disableAndEnableAllFlags() throws JsonRpcClientErrorException, JsonProcessingException {
+  public void enableAllAndDisableOne() throws JsonRpcClientErrorException {
 
-    Wallet wallet = createRandomAccountEd25519();
+    Wallet wallet = constructRandomAccount();
 
     ///////////////////////
     // Get validated account info and validate account state
@@ -50,14 +48,74 @@ public class AccountSetIT extends AbstractIT {
       .signingPublicKey(wallet.publicKey().base16Value())
       .build();
 
-    SingleSingedTransaction<AccountSet> signedAccountSet = signatureService.sign(
-      wallet.privateKey(), accountSet
-    );
-    SubmitResult<AccountSet> response = xrplClient.submit(signedAccountSet);
-    logger.info(
-      "AccountSet transaction successful: https://testnet.xrpl.org/transactions/{}", response.transactionResult().hash()
-    );
+    SubmitResult<AccountSet> response = xrplClient.submit(wallet, accountSet);
     assertThat(response.result()).isEqualTo("tesSUCCESS");
+    assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
+      .isEqualTo(response.transactionResult().hash());
+    logger.info(
+      "AccountSet transaction successful: https://testnet.xrpl.org/transactions/" + response.transactionResult().hash()
+    );
+
+    ///////////////////////
+    // Set flags one-by-one
+    sequence = sequence.plus(UnsignedInteger.ONE);
+    assertSetFlag(wallet, sequence, AccountSetFlag.DEFAULT_RIPPLE, AccountRootFlags.DEFAULT_RIPPLE);
+    sequence = sequence.plus(UnsignedInteger.ONE);
+    assertSetFlag(wallet, sequence, AccountSetFlag.DEPOSIT_AUTH, AccountRootFlags.DEPOSIT_AUTH);
+    sequence = sequence.plus(UnsignedInteger.ONE);
+    assertSetFlag(wallet, sequence, AccountSetFlag.DISALLOW_XRP, AccountRootFlags.DISALLOW_XRP);
+    sequence = sequence.plus(UnsignedInteger.ONE);
+    assertSetFlag(wallet, sequence, AccountSetFlag.REQUIRE_AUTH, AccountRootFlags.REQUIRE_AUTH);
+    sequence = sequence.plus(UnsignedInteger.ONE);
+    assertSetFlag(wallet, sequence, AccountSetFlag.REQUIRE_DEST, AccountRootFlags.REQUIRE_DEST_TAG);
+    sequence = sequence.plus(UnsignedInteger.ONE);
+    assertSetFlag(wallet, sequence, AccountSetFlag.GLOBAL_FREEZE, AccountRootFlags.GLOBAL_FREEZE);
+    sequence = sequence.plus(UnsignedInteger.ONE);
+
+    AccountRootFlags flags1 = this.scanForResult(
+      () -> this.getValidatedAccountInfo(wallet.classicAddress())
+    ).accountData().flags();
+
+    assertClearFlag(wallet, sequence, AccountSetFlag.GLOBAL_FREEZE, AccountRootFlags.GLOBAL_FREEZE);
+
+    AccountRootFlags flags2 = this.scanForResult(
+      () -> this.getValidatedAccountInfo(wallet.classicAddress())
+    ).accountData().flags();
+
+    assertThat(flags1.getValue() - flags2.getValue())
+      .isEqualTo(AccountRootFlags.GLOBAL_FREEZE.getValue());
+  }
+
+  @Test
+  public void disableAndEnableAllFlags() throws JsonRpcClientErrorException {
+
+    org.xrpl.xrpl4j.wallet.Wallet wallet = createRandomAccount();
+
+    ///////////////////////
+    // Get validated account info and validate account state
+    AccountInfoResult accountInfo = this.scanForResult(() -> this.getValidatedAccountInfo(wallet.classicAddress()));
+    assertThat(accountInfo.status()).isNotEmpty().get().isEqualTo("success");
+    assertThat(accountInfo.accountData().flags().lsfGlobalFreeze()).isEqualTo(false);
+
+    UnsignedInteger sequence = accountInfo.accountData().sequence();
+    //////////////////////
+    // Set asfAccountTxnID (no corresponding ledger flag)
+    FeeResult feeResult = xrplClient.fee();
+    AccountSet accountSet = AccountSet.builder()
+      .account(wallet.classicAddress())
+      .fee(feeResult.drops().openLedgerFee())
+      .sequence(accountInfo.accountData().sequence())
+      .setFlag(AccountSetFlag.ACCOUNT_TXN_ID)
+      .signingPublicKey(wallet.publicKey())
+      .build();
+
+    SubmitResult<AccountSet> response = xrplClient.submit(wallet, accountSet);
+    assertThat(response.result()).isEqualTo("tesSUCCESS");
+    assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
+      .isEqualTo(response.transactionResult().hash());
+    logger.info(
+      "AccountSet transaction successful: https://testnet.xrpl.org/transactions/" + response.transactionResult().hash()
+    );
 
     ///////////////////////
     // Set flags one-by-one
@@ -97,7 +155,7 @@ public class AccountSetIT extends AbstractIT {
     final UnsignedInteger sequence,
     final AccountSetFlag accountSetFlag,
     final AccountRootFlags accountRootFlag
-  ) throws JsonRpcClientErrorException, JsonProcessingException {
+  ) throws JsonRpcClientErrorException {
     Objects.requireNonNull(wallet);
     Objects.requireNonNull(accountSetFlag);
 
@@ -110,9 +168,15 @@ public class AccountSetIT extends AbstractIT {
       .signingPublicKey(wallet.publicKey().base16Value())
       .build();
 
-    SingleSingedTransaction<AccountSet> signedAccountSet = signatureService.sign(wallet.privateKey(), accountSet);
-    SubmitResult<AccountSet> response = xrplClient.submit(signedAccountSet);
+    SingleSingedTransaction<AccountSet> signedAccountSet = signatureService.sign(
+      wallet.privateKey(), accountSet
+    );
+    SubmitResult<CheckCreate> response = xrplClient.submit(signedAccountSet);
+
+    SubmitResult<AccountSet> response = xrplClient.submit(wallet, accountSet);
     assertThat(response.result()).isEqualTo("tesSUCCESS");
+    assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
+      .isEqualTo(response.transactionResult().hash());
     logger.info(
       "AccountSet SetFlag transaction successful (asf={}; arf={}): https://testnet.xrpl.org/transactions/{}",
       accountSetFlag, accountRootFlag, response.transactionResult().hash()
@@ -133,7 +197,7 @@ public class AccountSetIT extends AbstractIT {
     final UnsignedInteger sequence,
     final AccountSetFlag accountSetFlag,
     final AccountRootFlags accountRootFlag
-  ) throws JsonRpcClientErrorException, JsonProcessingException {
+  ) throws JsonRpcClientErrorException {
     Objects.requireNonNull(wallet);
     Objects.requireNonNull(accountSetFlag);
 
@@ -145,10 +209,10 @@ public class AccountSetIT extends AbstractIT {
       .clearFlag(accountSetFlag)
       .signingPublicKey(wallet.publicKey().base16Value())
       .build();
-
-    SingleSingedTransaction<AccountSet> signedAccountSet = signatureService.sign(wallet.privateKey(), accountSet);
-    SubmitResult<AccountSet> response = xrplClient.submit(signedAccountSet);
+    SubmitResult<AccountSet> response = xrplClient.submit(wallet, accountSet);
     assertThat(response.result()).isEqualTo("tesSUCCESS");
+    assertThat(response.transactionResult().transaction().hash()).isNotEmpty().get()
+      .isEqualTo(response.transactionResult().hash());
     logger.info(
       "AccountSet ClearFlag transaction successful (asf={}; arf={}): https://testnet.xrpl.org/transactions/{}",
       accountSetFlag, accountRootFlag, response.transactionResult().hash()

--- a/xrpl4j-integration-tests/src/test/resources/rippled/rippled.cfg
+++ b/xrpl4j-integration-tests/src/test/resources/rippled/rippled.cfg
@@ -1272,3 +1272,6 @@ validators.txt
 account_reserve = 20000000   # 20 XRP
 owner_reserve = 5000000   # 5 XRP
 reference_fee = 10           # 10 drops
+
+[path_search_max]
+7

--- a/xrpl4j-keypairs/README.md
+++ b/xrpl4j-keypairs/README.md
@@ -8,7 +8,7 @@ Use this module in your project by adding the following to your `pom.xml`:
 <dependency>
   <groupId>org.xrpl</groupId>
   <artifactId>xrpl4j-keypairs</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
 </dependency>
 ```
 

--- a/xrpl4j-model/README.md
+++ b/xrpl4j-model/README.md
@@ -9,7 +9,7 @@ Use this module in your project by adding the following to your `pom.xml`:
 <dependency>
   <groupId>org.xrpl</groupId>
   <artifactId>xrpl4j-model</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
 </dependency>
 ```
 

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoRequestParams.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountInfoRequestParams.java
@@ -9,7 +9,6 @@ import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.client.LegacyLedgerSpecifierUtils;
 import org.xrpl.xrpl4j.model.client.XrplRequestParams;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
-import org.xrpl.xrpl4j.model.client.common.LedgerIndexShortcut;
 import org.xrpl.xrpl4j.model.client.common.LedgerSpecifier;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParams.java
@@ -19,6 +19,7 @@ import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.Marker;
 
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -37,9 +38,44 @@ public interface AccountTransactionsRequestParams extends XrplRequestParams {
    * Construct a builder for this class.
    *
    * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
+   * @deprecated Prefer one of the other defined builders so that you are overtly
+   *   specifying which ledger index or type you want.
    */
+  @Deprecated
   static ImmutableAccountTransactionsRequestParams.Builder builder() {
     return ImmutableAccountTransactionsRequestParams.builder();
+  }
+
+  /**
+   * Construct a builder for this class with {@link LedgerSpecifier} field set.
+   *
+   * @param ledgerSpecifier A specifier of type {@link LedgerSpecifier} to specify a ledger.
+   *
+   * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
+   */
+  static ImmutableAccountTransactionsRequestParams.Builder builder(LedgerSpecifier ledgerSpecifier) {
+    return ImmutableAccountTransactionsRequestParams.builder().ledgerSpecifier(Optional.ofNullable(ledgerSpecifier));
+  }
+
+  /**
+   * Construct a builder for this class with {@link LedgerIndexBound}s specified for the
+   * {@link #ledgerIndexMinimum} and {@link #ledgerIndexMaximum} fields.
+   *
+   * @param ledgerIndexMinimum A lower bound of ledgerIndex of type {@link LedgerIndexBound}.
+   * @param ledgerIndexMaximum An upper bound of ledgerIndex of type {@link LedgerIndexBound}.
+   *
+   * @return An {@link ImmutableAccountTransactionsRequestParams.Builder}.
+   */
+  static ImmutableAccountTransactionsRequestParams.Builder builder(
+    LedgerIndexBound ledgerIndexMinimum,
+    LedgerIndexBound ledgerIndexMaximum
+  ) {
+    Objects.requireNonNull(ledgerIndexMinimum);
+    Objects.requireNonNull(ledgerIndexMaximum);
+
+    return ImmutableAccountTransactionsRequestParams.builder()
+      .ledgerIndexMinimum(ledgerIndexMinimum)
+      .ledgerIndexMaximum(ledgerIndexMaximum);
   }
 
   /**

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/SubmitMultiSignedResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/SubmitMultiSignedResult.java
@@ -34,7 +34,8 @@ public interface SubmitMultiSignedResult<TxnType extends Transaction> extends Xr
    * Text result code indicating the preliminary result of the transaction, for example "tesSUCCESS".
    *
    * @return An optionally-present {@link String} containing the result of the submission.
-   * @deprecated Use {@link #result()} instead.
+   * @deprecated This field will be typed as a {@link String} in a future release. Until then, use
+   *   {@link #result()}.
    */
   @Deprecated
   @Value.Auxiliary
@@ -46,7 +47,10 @@ public interface SubmitMultiSignedResult<TxnType extends Transaction> extends Xr
    * Text result code indicating the preliminary result of the transaction, for example "tesSUCCESS".
    *
    * @return A {@link String} containing the result of the submission.
+   * @deprecated This will be removed in a future version and replaced by a field of the same type called
+   *   {@link #engineResult()}.
    */
+  @Deprecated
   @JsonProperty("engine_result")
   String result();
 
@@ -54,7 +58,8 @@ public interface SubmitMultiSignedResult<TxnType extends Transaction> extends Xr
    * Numeric code indicating the preliminary result of the transaction, directly correlated to {@link #engineResult()}.
    *
    * @return An optionally-present {@link String} containing the result code of the submission.
-   * @deprecated Use {@link #resultCode()} instead.
+   * @deprecated This field will be typed as a {@link String} in a future release. Until then, use
+   *   {@link #resultCode()}.
    */
   @Deprecated
   @Value.Auxiliary
@@ -66,7 +71,10 @@ public interface SubmitMultiSignedResult<TxnType extends Transaction> extends Xr
    * Numeric code indicating the preliminary result of the transaction, directly correlated to {@link #engineResult()}.
    *
    * @return An {@link Integer} containing the result code of the submission.
+   * @deprecated This will be removed in a future version and replaced by a field of the same type called
+   *   {@link #engineResultCode()}.
    */
+  @Deprecated
   @JsonProperty("engine_result_code")
   Integer resultCode();
 
@@ -74,7 +82,8 @@ public interface SubmitMultiSignedResult<TxnType extends Transaction> extends Xr
    * Human-readable explanation of the transaction's preliminary result.
    *
    * @return An optionally-present {@link String} containing the result message of the submission.
-   * @deprecated Use {@link #resultMessage()} instead.
+   * @deprecated This field will be typed as a {@link String} in a future release. Until then, use
+   *   {@link #resultMessage()}.
    */
   @Deprecated
   @Value.Auxiliary
@@ -86,7 +95,10 @@ public interface SubmitMultiSignedResult<TxnType extends Transaction> extends Xr
    * Human-readable explanation of the transaction's preliminary result.
    *
    * @return A {@link String} containing the result message of the submission.
+   * @deprecated This will be removed in a future version and replaced by a field of the same type called
+   *   {@link #engineResultMessage()}.
    */
+  @Deprecated
   @JsonProperty("engine_result_message")
   String resultMessage();
 

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/transactions/SubmitResult.java
@@ -37,8 +37,9 @@ public interface SubmitResult<TxnType extends Transaction> extends XrplResult {
   /**
    * Text result code indicating the preliminary result of the transaction, for example "tesSUCCESS".
    *
-   * @return An optionally-present {@link String} containing the result of the submission.
-   * @deprecated use {@link #result()} instead.
+   * @return {@link String} containing the result of the submission.
+   * @deprecated This field will be typed as a {@link String} in a future release. Until then, use
+   *   {@link #result()}.
    */
   @Deprecated
   @Value.Auxiliary
@@ -50,7 +51,10 @@ public interface SubmitResult<TxnType extends Transaction> extends XrplResult {
    * Text result code indicating the preliminary result of the transaction, for example "tesSUCCESS".
    *
    * @return {@link String} containing the result of the submission.
+   * @deprecated This will be removed in a future version and replaced by a field of the same type called
+   *   {@link #engineResult()}.
    */
+  @Deprecated
   @JsonProperty("engine_result")
   String result();
 
@@ -58,7 +62,8 @@ public interface SubmitResult<TxnType extends Transaction> extends XrplResult {
    * Human-readable explanation of the transaction's preliminary result.
    *
    * @return An optionally-present {@link String} containing the result message of the submission.
-   * @deprecated Use {@link #resultMessage()} instead.
+   * @deprecated This field will be typed as a {@link String} in a future release. Until then, use
+   *   {@link #resultMessage()}.
    */
   @Deprecated
   @Value.Auxiliary
@@ -70,7 +75,10 @@ public interface SubmitResult<TxnType extends Transaction> extends XrplResult {
    * Human-readable explanation of the transaction's preliminary result.
    *
    * @return A {@link String} containing the result message of the submission.
+   * @deprecated This will be removed in a future version and replaced by a field of the same type called
+   *   {@link #engineResultMessage()}.
    */
+  @Deprecated
   @JsonProperty("engine_result_message")
   String resultMessage();
 

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/TransactionType.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/TransactionType.java
@@ -117,7 +117,7 @@ public enum TransactionType {
       }
     }
 
-    throw new IllegalArgumentException("No matching AccountSetFlag enum value for int value " + value);
+    throw new IllegalArgumentException("No matching TransactionType enum value for String value " + value);
   }
 
   /**

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -36,6 +36,16 @@ public class Wrappers {
       return this.value();
     }
 
+    /**
+     * Validates that a {@link Address}'s value's length is equal to 34 characters and starts with `r`.
+     */
+    @Value.Check
+    public void validateAddress() {
+      Preconditions.checkArgument(this.value().startsWith("r"),"Invalid Address: Bad Prefix");
+      Preconditions.checkArgument(this.value().length() >= 25 && this.value().length() <= 35,
+        "Classic Addresses must be (25,35) characters long inclusive.");
+    }
+
   }
 
   /**

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountTransactionsRequestParamsTests.java
@@ -9,6 +9,7 @@ import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndexBound;
 import org.xrpl.xrpl4j.model.client.common.LedgerSpecifier;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
 
 import java.util.Optional;
 
@@ -17,7 +18,7 @@ public class AccountTransactionsRequestParamsTests {
   @Test
   void constructDefaultParams() {
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams.builder()
-      .account(Address.of("foo"))
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .build();
 
     assertThat(params.ledgerIndexMinimum()).isEqualTo(LedgerIndexBound.of(-1));
@@ -28,7 +29,7 @@ public class AccountTransactionsRequestParamsTests {
   @Test
   void constructWithLedgerIndexMax() {
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams.builder()
-      .account(Address.of("foo"))
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .ledgerIndexMaximum(LedgerIndexBound.of(12345))
       .build();
 
@@ -40,7 +41,7 @@ public class AccountTransactionsRequestParamsTests {
   @Test
   void constructWithledgerIndexMinimum() {
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams.builder()
-      .account(Address.of("foo"))
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .ledgerIndexMinimum(LedgerIndexBound.of(12345))
       .build();
 
@@ -52,7 +53,7 @@ public class AccountTransactionsRequestParamsTests {
   @Test
   void constructWithLedgerSpecifier() {
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams.builder()
-      .account(Address.of("foo"))
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .ledgerSpecifier(Optional.of(LedgerSpecifier.of(LedgerIndex.of(UnsignedInteger.ONE))))
       .build();
 
@@ -66,7 +67,7 @@ public class AccountTransactionsRequestParamsTests {
     assertThrows(
       IllegalArgumentException.class,
       () -> AccountTransactionsRequestParams.builder()
-        .account(Address.of("foo"))
+        .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
         .ledgerSpecifier(Optional.of(LedgerSpecifier.CURRENT))
         .build()
     );
@@ -75,7 +76,7 @@ public class AccountTransactionsRequestParamsTests {
   @Test
   void constructWithLedgerSpecifierAndBounds() {
     AccountTransactionsRequestParams params = AccountTransactionsRequestParams.builder()
-      .account(Address.of("foo"))
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .ledgerIndexMinimum(LedgerIndexBound.of(12345))
       .ledgerSpecifier(Optional.of(LedgerSpecifier.VALIDATED))
       .build();
@@ -85,7 +86,7 @@ public class AccountTransactionsRequestParamsTests {
     assertThat(params.ledgerSpecifier()).isNotEmpty();
 
     params = AccountTransactionsRequestParams.builder()
-      .account(Address.of("foo"))
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .ledgerIndexMaximum(LedgerIndexBound.of(12345))
       .ledgerSpecifier(Optional.of(LedgerSpecifier.VALIDATED))
       .build();
@@ -95,7 +96,7 @@ public class AccountTransactionsRequestParamsTests {
     assertThat(params.ledgerSpecifier()).isNotEmpty();
 
     params = AccountTransactionsRequestParams.builder()
-      .account(Address.of("foo"))
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .ledgerIndexMaximum(LedgerIndexBound.of(12345))
       .ledgerIndexMinimum(LedgerIndexBound.of(12345))
       .ledgerSpecifier(Optional.of(LedgerSpecifier.VALIDATED))
@@ -104,5 +105,73 @@ public class AccountTransactionsRequestParamsTests {
     assertThat(params.ledgerIndexMinimum()).isNull();
     assertThat(params.ledgerIndexMaximum()).isNull();
     assertThat(params.ledgerSpecifier()).isNotEmpty();
+  }
+
+  @Test
+  void builderWithLedgerSpecifier() {
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(LedgerSpecifier.VALIDATED)
+        .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+        .build();
+
+    System.out.println(params);
+
+    assertThat(params.ledgerSpecifier()).isEqualTo(Optional.of(LedgerSpecifier.VALIDATED));
+  }
+
+  @Test
+  void builderWithLedgerIndex() {
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(LedgerSpecifier.of(UnsignedInteger.ONE))
+        .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+        .build();
+
+    System.out.print(params);
+    assertThat(params.ledgerSpecifier()).isEqualTo(Optional.of(LedgerSpecifier.of(UnsignedInteger.ONE)));
+  }
+
+  @Test
+  void builderWithLedgerHash() {
+    String random = "qmHJUF3lNC6rfEkZa3URngmwIRYU7bKMYKPz4er7UJKnWUItKuBCN9qKqXt8YYJ8";
+
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(LedgerSpecifier.of(Hash256.of(random)))
+        .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+        .build();
+
+    assertThat(params.ledgerSpecifier()).isEqualTo(Optional.of(LedgerSpecifier.of(Hash256.of(random))));
+  }
+
+  @Test
+  void builderWithLedgerIndexRange() {
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(LedgerIndexBound.of(12345), LedgerIndexBound.of(12347))
+        .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+        .build();
+
+    assertThat(params.ledgerIndexMinimum()).isEqualTo(LedgerIndexBound.of(12345));
+    assertThat(params.ledgerIndexMaximum()).isEqualTo(LedgerIndexBound.of(12347));
+  }
+
+  @Test
+  void builderWithLedgerIndexMin() {
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(LedgerIndexBound.of(12345), LedgerIndexBound.of(-1))
+        .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+        .build();
+
+    assertThat(params.ledgerIndexMinimum()).isEqualTo(LedgerIndexBound.of(12345));
+    assertThat(params.ledgerIndexMaximum()).isEqualTo(LedgerIndexBound.of(-1));
+  }
+
+  @Test
+  void builderWithLedgerIndexMax() {
+    AccountTransactionsRequestParams params = AccountTransactionsRequestParams
+        .builder(LedgerIndexBound.of(-1), LedgerIndexBound.of(12345))
+        .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
+        .build();
+
+    assertThat(params.ledgerIndexMinimum()).isEqualTo(LedgerIndexBound.of(-1));
+    assertThat(params.ledgerIndexMaximum()).isEqualTo(LedgerIndexBound.of(12345));
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/AddressTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/AddressTest.java
@@ -1,0 +1,33 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class AddressTest {
+
+  @Test
+  public void addressWithBadPrefix() {
+
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> Address.of("c9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"),
+      "Invalid Address: Bad Prefix"
+    );
+  }
+
+  @Test
+  public void addressOfIncorrectLength() {
+
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> Address.of("r9cZA1mLK5R"),
+      "Classic Addresses must be (25,35) characters long inclusive."
+    );
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> Address.of("rAJYB9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"),
+      "Classic Addresses must be (25,35) characters long inclusive."
+    );
+  }
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmountTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmountTest.java
@@ -43,7 +43,7 @@ public class CurrencyAmountTest {
   @Test
   public void handleIssuance() {
     final IssuedCurrencyAmount issuedCurrencyAmount = IssuedCurrencyAmount.builder()
-      .issuer(Address.of("foo"))
+      .issuer(Address.of("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59Ba"))
       .currency("USD")
       .value("100")
       .build();
@@ -93,7 +93,7 @@ public class CurrencyAmountTest {
   @Test
   public void mapIssuance() {
     final IssuedCurrencyAmount issuedCurrencyAmount = IssuedCurrencyAmount.builder()
-      .issuer(Address.of("foo"))
+      .issuer(Address.of("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59Ba"))
       .currency("USD")
       .value("100")
       .build();

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/EscrowCreateTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/EscrowCreateTest.java
@@ -17,9 +17,9 @@ public class EscrowCreateTest {
     EscrowCreate.builder()
       .sequence(UnsignedInteger.ONE)
       .fee(XrpCurrencyAmount.ofDrops(1))
-      .account(Address.of("account"))
+      .account(Address.of("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59Ba"))
       .amount(XrpCurrencyAmount.ofDrops(1))
-      .destination(Address.of("destination"))
+      .destination(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .build();
   }
 
@@ -30,9 +30,9 @@ public class EscrowCreateTest {
       () -> EscrowCreate.builder()
         .sequence(UnsignedInteger.ONE)
         .fee(XrpCurrencyAmount.ofDrops(1))
-        .account(Address.of("account"))
+        .account(Address.of("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59Ba"))
         .amount(XrpCurrencyAmount.ofDrops(1))
-        .destination(Address.of("destination"))
+        .destination(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
         .cancelAfter(UnsignedLong.ONE)
         .finishAfter(UnsignedLong.valueOf(2L))
         .build(),
@@ -45,9 +45,9 @@ public class EscrowCreateTest {
     EscrowCreate.builder()
       .sequence(UnsignedInteger.ONE)
       .fee(XrpCurrencyAmount.ofDrops(1))
-      .account(Address.of("account"))
+      .account(Address.of("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59Ba"))
       .amount(XrpCurrencyAmount.ofDrops(1))
-      .destination(Address.of("destination"))
+      .destination(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .cancelAfter(UnsignedLong.valueOf(2L))
       .finishAfter(UnsignedLong.ONE)
       .build();
@@ -60,9 +60,9 @@ public class EscrowCreateTest {
       () -> EscrowCreate.builder()
         .sequence(UnsignedInteger.ONE)
         .fee(XrpCurrencyAmount.ofDrops(1))
-        .account(Address.of("account"))
+        .account(Address.of("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59Ba"))
         .amount(XrpCurrencyAmount.ofDrops(1))
-        .destination(Address.of("destination"))
+        .destination(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
         .cancelAfter(UnsignedLong.ONE)
         .finishAfter(UnsignedLong.ONE)
         .build(),

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/EscrowFinishTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/EscrowFinishTest.java
@@ -18,18 +18,18 @@ public class EscrowFinishTest {
   public void testNormalizeWithNoFulfillmentNoCondition() {
     EscrowFinish actual = EscrowFinish.builder()
       .fee(XrpCurrencyAmount.ofDrops(1))
-      .account(Address.of("account"))
+      .account(Address.of("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59Ba"))
       .sequence(UnsignedInteger.ONE)
-      .owner(Address.of("owner"))
+      .owner(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .offerSequence(UnsignedInteger.ZERO)
       .build();
 
     assertThat(actual.condition()).isNotPresent();
     assertThat(actual.fulfillment()).isNotPresent();
     assertThat(actual.fee()).isEqualTo(XrpCurrencyAmount.ofDrops(1));
-    assertThat(actual.account()).isEqualTo(Address.of("account"));
+    assertThat(actual.account()).isEqualTo(Address.of("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59Ba"));
     assertThat(actual.sequence()).isEqualTo(UnsignedInteger.ONE);
-    assertThat(actual.owner()).isEqualTo(Address.of("owner"));
+    assertThat(actual.owner()).isEqualTo(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"));
     assertThat(actual.offerSequence()).isEqualTo(UnsignedInteger.ZERO);
   }
 
@@ -41,9 +41,9 @@ public class EscrowFinishTest {
       IllegalStateException.class,
       () -> EscrowFinish.builder()
         .fee(XrpCurrencyAmount.ofDrops(1))
-        .account(Address.of("account"))
+        .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
         .sequence(UnsignedInteger.ONE)
-        .owner(Address.of("owner"))
+        .owner(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
         .offerSequence(UnsignedInteger.ZERO)
         .fulfillment(fulfillment)
         .build(),
@@ -59,9 +59,9 @@ public class EscrowFinishTest {
       IllegalStateException.class,
       () -> EscrowFinish.builder()
         .fee(XrpCurrencyAmount.ofDrops(1))
-        .account(Address.of("account"))
+        .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
         .sequence(UnsignedInteger.ONE)
-        .owner(Address.of("owner"))
+        .owner(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
         .offerSequence(UnsignedInteger.ZERO)
         .condition(fulfillment.getDerivedCondition())
         .build(),
@@ -77,18 +77,18 @@ public class EscrowFinishTest {
 
     EscrowFinish actual = EscrowFinish.builder()
       .fee(XrpCurrencyAmount.ofDrops(330))
-      .account(Address.of("account"))
+      .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .sequence(UnsignedInteger.ONE)
-      .owner(Address.of("owner"))
+      .owner(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .offerSequence(UnsignedInteger.ZERO)
       .fulfillment(fulfillment)
       .condition(fulfillment.getDerivedCondition())
       .build();
 
     assertThat(actual.condition()).isPresent();
-    assertThat(actual.account()).isEqualTo(Address.of("account"));
+    assertThat(actual.account()).isEqualTo(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"));
     assertThat(actual.sequence()).isEqualTo(UnsignedInteger.ONE);
-    assertThat(actual.owner()).isEqualTo(Address.of("owner"));
+    assertThat(actual.owner()).isEqualTo(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"));
     assertThat(actual.offerSequence()).isEqualTo(UnsignedInteger.ZERO);
 
     assertThat(actual.fulfillment()).isPresent();
@@ -104,9 +104,9 @@ public class EscrowFinishTest {
       IllegalStateException.class,
       () -> EscrowFinish.builder()
         .fee(XrpCurrencyAmount.ofDrops(1))
-        .account(Address.of("account"))
+        .account(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
         .sequence(UnsignedInteger.ONE)
-        .owner(Address.of("owner"))
+        .owner(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
         .offerSequence(UnsignedInteger.ZERO)
         .fulfillment(fulfillment)
         .condition(fulfillment.getDerivedCondition())
@@ -119,9 +119,9 @@ public class EscrowFinishTest {
   public void testNormalizeWithVariousFulfillmentSizes() {
     Builder builder = EscrowFinish.builder()
       .fee(XrpCurrencyAmount.ofDrops(1))
-      .account(Address.of("account"))
+      .account(Address.of("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59Ba"))
       .sequence(UnsignedInteger.ONE)
-      .owner(Address.of("owner"))
+      .owner(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .offerSequence(UnsignedInteger.ZERO);
 
     // 0 bytes

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/PaymentTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/PaymentTest.java
@@ -33,8 +33,8 @@ public class PaymentTest {
   private Payment xrpPayment() {
     return Payment.builder()
       .sequence(UnsignedInteger.ONE)
-      .account(Address.of("foo"))
-      .destination(Address.of("dest"))
+      .account(Address.of("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59Ba"))
+      .destination(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .fee(XrpCurrencyAmount.ofDrops(1000L))
       .amount(XrpCurrencyAmount.ofDrops(2000L))
       .build();
@@ -43,10 +43,11 @@ public class PaymentTest {
   private Payment issuedCurrencyPayment() {
     return Payment.builder()
       .sequence(UnsignedInteger.ONE)
-      .account(Address.of("foo"))
-      .destination(Address.of("dest"))
+      .account(Address.of("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59Ba"))
+      .destination(Address.of("rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH"))
       .fee(XrpCurrencyAmount.ofDrops(1000L))
-      .amount(IssuedCurrencyAmount.builder().currency("USD").issuer(Address.of("foo")).value("500").build())
-      .build();
+      .amount(IssuedCurrencyAmount.builder().currency("USD").issuer(
+        Address.of("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59Ba")).value("500").build()
+      ).build();
   }
 }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/TransactionTypeTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/TransactionTypeTests.java
@@ -1,0 +1,54 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+
+/**
+ * Unit tests for {@link TransactionType}.
+ */
+public class TransactionTypeTests {
+
+  @ParameterizedTest
+  @ArgumentsSource(value = TransactionTypeValidArgumentProvider.class)
+  public void shouldReturnTransactionTypeForValidValues(String value) {
+    TransactionType transactionType = TransactionType.forValue(value);
+    assertNotNull(transactionType);
+    assertTrue(transactionType instanceof TransactionType);
+  }
+
+  @EmptySource
+  @NullSource
+  @ParameterizedTest
+  @ArgumentsSource(value = TransactionTypeInvalidArgumentProvider.class)
+  public void shouldThrowIllegalArgumentExceptionForInvalidValues(String value) {
+    assertThrows(IllegalArgumentException.class, () -> TransactionType.forValue(value),
+      "No matching TransactionType enum value for String value " + value);
+  }
+
+  public static class TransactionTypeValidArgumentProvider implements ArgumentsProvider {
+
+    @Override
+    public java.util.stream.Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      return java.util.stream.Stream.of(TransactionType.values()).map(TransactionType::value).map(Arguments::of);
+    }
+
+  }
+
+  public static class TransactionTypeInvalidArgumentProvider implements ArgumentsProvider {
+
+    @Override
+    public java.util.stream.Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      return java.util.stream.Stream.of("bla", "blaaa", "123").map(Arguments::of);
+    }
+
+  }
+}


### PR DESCRIPTION
Changes the signature of `DelegatedSignatureService` to only return a `Signature`