### PR TITLE
Fixes #211 Improve the way memos are constructed

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractIT {
 
+  public static final String SUCCESS_STATUS = "tesSUCCESS";
   public static final Duration POLL_INTERVAL = Duration.ONE_HUNDRED_MILLISECONDS;
 
   protected static XrplEnvironment xrplEnvironment = XrplEnvironment.getConfiguredEnvironment();

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/TransactionWithMemoIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/TransactionWithMemoIT.java
@@ -5,20 +5,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
 import org.xrpl.xrpl4j.model.client.accounts.AccountInfoResult;
-import org.xrpl.xrpl4j.model.client.common.LedgerSpecifier;
 import org.xrpl.xrpl4j.model.client.fees.FeeResult;
-import org.xrpl.xrpl4j.model.client.ledger.LedgerRequestParams;
-import org.xrpl.xrpl4j.model.client.ledger.LedgerResult;
 import org.xrpl.xrpl4j.model.client.transactions.SubmitResult;
 import org.xrpl.xrpl4j.model.client.transactions.TransactionResult;
+import org.xrpl.xrpl4j.model.transactions.Memo;
+import org.xrpl.xrpl4j.model.transactions.MemoWrapper;
 import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 import org.xrpl.xrpl4j.wallet.Wallet;
 
-public class SubmitPaymentIT extends AbstractIT {
+public class TransactionWithMemoIT extends AbstractIT {
 
+  /**
+   * Tests a transaction that has a memo containing only a nibble (i.e., a half byte).
+   */
   @Test
-  public void sendPayment() throws JsonRpcClientErrorException {
+  public void transactionWithMemoNibble() throws JsonRpcClientErrorException {
     Wallet sourceWallet = createRandomAccount();
     Wallet destinationWallet = createRandomAccount();
 
@@ -34,6 +36,11 @@ public class SubmitPaymentIT extends AbstractIT {
       .destination(destinationWallet.classicAddress())
       .amount(amount)
       .signingPublicKey(sourceWallet.publicKey())
+      .addMemos(MemoWrapper.builder()
+        .memo(Memo.builder()
+          .memoData("A")
+          .build())
+        .build())
       .build();
 
     SubmitResult<Payment> result = xrplClient.submit(sourceWallet, payment);
@@ -52,61 +59,50 @@ public class SubmitPaymentIT extends AbstractIT {
 
     assertThat(validatedPayment.metadata().get().deliveredAmount()).hasValue(amount);
     assertThat(validatedPayment.metadata().get().transactionResult()).isEqualTo(SUCCESS_STATUS);
-
-    assertPaymentCloseTimeMatchesLedgerCloseTime(validatedPayment);
   }
 
+  /**
+   * Tests a transaction that has a memo containing only a nibble (i.e., a half byte).
+   */
   @Test
-  public void sendPaymentFromSecp256k1Wallet() throws JsonRpcClientErrorException {
-    Wallet senderWallet = walletFactory.fromSeed("sp5fghtJtpUorTwvof1NpDXAzNwf5", true);
-    logger.info("Generated source testnet wallet with address " + senderWallet.xAddress());
-
-    fundAccount(senderWallet);
-
+  public void transactionWithPlaintextMemo() throws JsonRpcClientErrorException {
+    Wallet sourceWallet = createRandomAccount();
     Wallet destinationWallet = createRandomAccount();
 
     FeeResult feeResult = xrplClient.fee();
     AccountInfoResult accountInfo = this.scanForResult(
-      () -> this.getValidatedAccountInfo(senderWallet.classicAddress())
+      () -> this.getValidatedAccountInfo(sourceWallet.classicAddress())
     );
-
+    XrpCurrencyAmount amount = XrpCurrencyAmount.ofDrops(12345);
     Payment payment = Payment.builder()
-      .account(senderWallet.classicAddress())
+      .account(sourceWallet.classicAddress())
       .fee(feeResult.drops().openLedgerFee())
       .sequence(accountInfo.accountData().sequence())
       .destination(destinationWallet.classicAddress())
-      .amount(XrpCurrencyAmount.ofDrops(12345))
-      .signingPublicKey(senderWallet.publicKey())
+      .amount(amount)
+      .signingPublicKey(sourceWallet.publicKey())
+      .addMemos(MemoWrapper.builder()
+        .memo(Memo.withPlaintext("Hello World").build())
+        .build()
+      )
       .build();
 
-    SubmitResult<Payment> result = xrplClient.submit(senderWallet, payment);
-    assertThat(result.result()).isEqualTo("tesSUCCESS");
+    SubmitResult<Payment> result = xrplClient.submit(sourceWallet, payment);
+    assertThat(result.result()).isEqualTo(SUCCESS_STATUS);
     assertThat(result.transactionResult().transaction().hash()).isNotEmpty().get()
       .isEqualTo(result.transactionResult().hash());
     logger.info("Payment successful: https://testnet.xrpl.org/transactions/" +
       result.transactionResult().hash()
     );
 
-    this.scanForResult(
+    TransactionResult<Payment> validatedPayment = this.scanForResult(
       () -> this.getValidatedTransaction(
         result.transactionResult().hash(),
         Payment.class)
     );
-  }
 
-  private void assertPaymentCloseTimeMatchesLedgerCloseTime(TransactionResult<Payment> validatedPayment)
-    throws JsonRpcClientErrorException {
-    LedgerResult ledger = xrplClient.ledger(
-        LedgerRequestParams.builder()
-          .ledgerSpecifier(LedgerSpecifier.of(validatedPayment.ledgerIndexSafe()))
-          .build()
-    );
-
-    assertThat(validatedPayment.transaction().closeDateHuman()).isNotEmpty()
-      .isEqualTo(validatedPayment.closeDateHuman());
-    assertThat(ledger.ledger().closeTimeHuman()).isNotEmpty();
-    assertThat(validatedPayment.closeDateHuman()).isNotEmpty().get()
-      .isEqualTo(ledger.ledger().closeTimeHuman().get());
+    assertThat(validatedPayment.metadata().get().deliveredAmount()).hasValue(amount);
+    assertThat(validatedPayment.metadata().get().transactionResult()).isEqualTo(SUCCESS_STATUS);
   }
 
 }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Memo.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Memo.java
@@ -27,10 +27,17 @@ import java.util.Optional;
 @JsonDeserialize(as = ImmutableMemo.class)
 public abstract class Memo {
 
-  static ImmutableMemo.Builder withPlainText(final String plainText) {
+  /**
+   * Construct a {@link ImmutableMemo.Builder} by properly hex-encoding {@code plaintext}.
+   *
+   * @param plaintext A UTF-8 {@link String}.
+   *
+   * @return A {@link ImmutableMemo.Builder}.
+   */
+  public static ImmutableMemo.Builder withPlaintext(final String plaintext) {
     return builder()
       .memoFormat(BaseEncoding.base16().encode("text/plain".getBytes(StandardCharsets.UTF_8)))
-      .memoData(BaseEncoding.base16().encode(plainText.getBytes(StandardCharsets.UTF_8)));
+      .memoData(BaseEncoding.base16().encode(plaintext.getBytes(StandardCharsets.UTF_8)));
   }
 
   /**
@@ -38,7 +45,7 @@ public abstract class Memo {
    *
    * @return An {@link ImmutableMemo.Builder}.
    */
-  static ImmutableMemo.Builder builder() {
+  public static ImmutableMemo.Builder builder() {
     return ImmutableMemo.builder();
   }
 
@@ -106,7 +113,6 @@ public abstract class Memo {
    *
    * @return {@code true} if {@code input} is hex-encoded; {@code false} otherwise.
    */
-
   private static boolean isHex(final char input) {
     return (input >= '0' && input <= '9') || (input >= 'a' && input <= 'f') || (input >= 'A' && input <= 'F');
   }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Memo.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Memo.java
@@ -90,20 +90,13 @@ public abstract class Memo {
    */
   private static boolean isHex(final String input) {
     Objects.requireNonNull(input);
-    boolean isHex = true;
-    try {
-      for (char c : input.toCharArray()) {
-        if (!isHex(c)) {
-          isHex = false;
-          break;
-        }
+    for (char c : input.toCharArray()) {
+      if (!isHex(c)) {
+        return false;
       }
-    } catch (NumberFormatException e) {
-      e.printStackTrace();
-      // parsing failed, string is not a valid hex number
-      isHex = false;
     }
-    return isHex;
+
+    return true;
   }
 
   /**

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Memo.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Memo.java
@@ -3,8 +3,13 @@ package org.xrpl.xrpl4j.model.transactions;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Preconditions;
+import com.google.common.io.BaseEncoding;
 import org.immutables.value.Value;
+import org.immutables.value.Value.Check;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -20,7 +25,13 @@ import java.util.Optional;
 @Value.Immutable
 @JsonSerialize(as = ImmutableMemo.class)
 @JsonDeserialize(as = ImmutableMemo.class)
-public interface Memo {
+public abstract class Memo {
+
+  static ImmutableMemo.Builder withPlainText(final String plainText) {
+    return builder()
+      .memoFormat(BaseEncoding.base16().encode("text/plain".getBytes(StandardCharsets.UTF_8)))
+      .memoData(BaseEncoding.base16().encode(plainText.getBytes(StandardCharsets.UTF_8)));
+  }
 
   /**
    * Construct a builder for this class.
@@ -37,24 +48,73 @@ public interface Memo {
    * @return An {@link Optional} of type {@link String} containing the memo data.
    */
   @JsonProperty("MemoData")
-  Optional<String> memoData();
+  public abstract Optional<String> memoData();
 
   /**
-   * Hex value representing characters allowed in URLs. Conventionally containing information on how the memo
-   * is encoded.
+   * Hex value representing characters allowed in URLs. Conventionally containing information on how the memo is
+   * encoded.
    *
    * @return An {@link Optional} of type {@link String} containing the memo format.
    */
   @JsonProperty("MemoFormat")
-  Optional<String> memoFormat();
+  public abstract Optional<String> memoFormat();
 
   /**
-   * Hex value representing characters allowed in URLs. Conventionally, a unique relation that defines the format
-   * of this memo.
+   * Hex value representing characters allowed in URLs. Conventionally, a unique relation that defines the format of
+   * this memo.
    *
    * @return An {@link Optional} of type {@link String} containing the memo type.
    */
   @JsonProperty("MemoType")
-  Optional<String> memoType();
+  public abstract Optional<String> memoType();
 
+  @Check
+  void check() {
+    memoData().ifPresent(
+      memoData -> Preconditions.checkState(isHex(memoData), "MemoData must be a hex-encoded string")
+    );
+    memoFormat().ifPresent(
+      memoFormat -> Preconditions.checkState(isHex(memoFormat), "MemoFormat must be a hex-encoded string")
+    );
+    memoType().ifPresent(
+      memoType -> Preconditions.checkState(isHex(memoType), "MemoType must be a hex-encoded string")
+    );
+  }
+
+  /**
+   * Determines if an input string is hex-encoded.
+   *
+   * @param input A {@link String}.
+   *
+   * @return {@code true} if every character in {@code input} is hex-encoded; {@code false} otherwise.
+   */
+  private static boolean isHex(final String input) {
+    Objects.requireNonNull(input);
+    boolean isHex = true;
+    try {
+      for (char c : input.toCharArray()) {
+        if (!isHex(c)) {
+          isHex = false;
+          break;
+        }
+      }
+    } catch (NumberFormatException e) {
+      e.printStackTrace();
+      // parsing failed, string is not a valid hex number
+      isHex = false;
+    }
+    return isHex;
+  }
+
+  /**
+   * Determines if an input char is hex-encoded.
+   *
+   * @param input A {@link char}.
+   *
+   * @return {@code true} if {@code input} is hex-encoded; {@code false} otherwise.
+   */
+
+  private static boolean isHex(final char input) {
+    return (input >= '0' && input <= '9') || (input >= 'a' && input <= 'f') || (input >= 'A' && input <= 'F');
+  }
 }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/TransactionType.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/TransactionType.java
@@ -117,7 +117,7 @@ public enum TransactionType {
       }
     }
 
-    throw new IllegalArgumentException("No matching AccountSetFlag enum value for int value " + value);
+    throw new IllegalArgumentException("No matching TransactionType enum value for String value " + value);
   }
 
   /**

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/MemoTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/MemoTest.java
@@ -1,0 +1,67 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link Memo}.
+ */
+class MemoTest {
+
+  @Test
+  void testEmptyMemo() {
+    final Memo emptyMemo = Memo.builder().build();
+    assertThat(emptyMemo.memoData()).isEmpty();
+    assertThat(emptyMemo.memoType()).isEmpty();
+    assertThat(emptyMemo.memoFormat()).isEmpty();
+  }
+
+  @Test
+  void testMemoWithNonHexFields() {
+    IllegalStateException thrownException = Assertions.assertThrows(IllegalStateException.class, () -> {
+      Memo.builder()
+        .memoData("Hello World")
+        .memoType("0123456789ABCDEF")
+        .memoFormat("0123456789ABCDEF")
+        .build();
+    });
+    assertThat(thrownException.getMessage()).isEqualTo("MemoData must be a hex-encoded string");
+
+    thrownException = Assertions.assertThrows(IllegalStateException.class, () -> {
+      Memo.builder()
+        .memoData("0123456789ABCDEF")
+        .memoType("Hello World")
+        .memoFormat("0123456789ABCDEF")
+        .build();
+    });
+    assertThat(thrownException.getMessage()).isEqualTo("MemoType must be a hex-encoded string");
+
+    thrownException = Assertions.assertThrows(IllegalStateException.class, () -> {
+      Memo.builder()
+        .memoData("0123456789ABCDEF")
+        .memoType("0123456789ABCDEF")
+        .memoFormat("Hello World")
+        .build();
+    });
+    assertThat(thrownException.getMessage()).isEqualTo("MemoFormat must be a hex-encoded string");
+  }
+
+  @Test
+  void testMemoWithAllHexFields() {
+    assertThat(Memo.builder()
+      .memoData("0123456789ABCDEF")
+      .memoType("0123456789ABCDEF")
+      .memoFormat("0123456789ABCDEF")
+      .build()).isNotNull();
+  }
+
+  @Test
+  void testBuildFromPlain() {
+    final Memo plainTextMemo = Memo.withPlainText("Hello World").build();
+    assertThat(plainTextMemo.memoType()).isEmpty();
+    assertThat(plainTextMemo.memoFormat().get()).isEqualTo("746578742F706C61696E");
+    assertThat(plainTextMemo.memoData().get()).isEqualTo("48656C6C6F20576F726C64");
+  }
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/MemoTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/MemoTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link Memo}.
  */
+@SuppressWarnings( {"OptionalGetWithoutIsPresent", "ResultOfMethodCallIgnored"})
 class MemoTest {
 
   @Test
@@ -19,32 +20,77 @@ class MemoTest {
   }
 
   @Test
+  void testSingleHexCharMemo() {
+    final Memo emptyMemo = Memo.builder()
+      .memoData("A")
+      .build();
+    assertThat(emptyMemo.memoData()).isNotEmpty();
+    assertThat(emptyMemo.memoData().get()).isEqualTo("A");
+    assertThat(emptyMemo.memoType()).isEmpty();
+    assertThat(emptyMemo.memoFormat()).isEmpty();
+  }
+
+  @Test
+  void lowercaseHexChars() {
+    final Memo emptyMemo = Memo.builder()
+      .memoData("abcdef1234")
+      .memoType("abcdef1234")
+      .memoFormat("abcdef1234")
+      .build();
+    assertThat(emptyMemo.memoData()).isNotEmpty();
+    assertThat(emptyMemo.memoData().get()).isEqualTo("abcdef1234");
+    assertThat(emptyMemo.memoType()).isNotEmpty();
+    assertThat(emptyMemo.memoType().get()).isEqualTo("abcdef1234");
+    assertThat(emptyMemo.memoFormat()).isNotEmpty();
+    assertThat(emptyMemo.memoFormat().get()).isEqualTo("abcdef1234");
+  }
+
+  @Test
+  void uppercaseHexChars() {
+    final Memo emptyMemo = Memo.builder()
+      .memoData("ABCDEF1234")
+      .memoType("ABCDEF1234")
+      .memoFormat("ABCDEF1234")
+      .build();
+    assertThat(emptyMemo.memoData()).isNotEmpty();
+    assertThat(emptyMemo.memoData().get()).isEqualTo("ABCDEF1234");
+    assertThat(emptyMemo.memoType()).isNotEmpty();
+    assertThat(emptyMemo.memoType().get()).isEqualTo("ABCDEF1234");
+    assertThat(emptyMemo.memoFormat()).isNotEmpty();
+    assertThat(emptyMemo.memoFormat().get()).isEqualTo("ABCDEF1234");
+  }
+
+  @Test
+  void testWithPlaintextSingleChar() {
+    Memo memo = Memo.withPlaintext("Z").build();
+    assertThat(memo.memoData()).isNotEmpty();
+    assertThat(memo.memoData().get()).isEqualTo("5A");
+    assertThat(memo.memoType()).isEmpty();
+    assertThat(memo.memoFormat()).isNotEmpty();
+    assertThat(memo.memoFormat().get()).isEqualTo("746578742F706C61696E");
+  }
+
+  @Test
   void testMemoWithNonHexFields() {
-    IllegalStateException thrownException = Assertions.assertThrows(IllegalStateException.class, () -> {
-      Memo.builder()
-        .memoData("Hello World")
-        .memoType("0123456789ABCDEF")
-        .memoFormat("0123456789ABCDEF")
-        .build();
-    });
+    IllegalStateException thrownException = Assertions.assertThrows(IllegalStateException.class, () -> Memo.builder()
+      .memoData("Hello World")
+      .memoType("0123456789ABCDEF")
+      .memoFormat("0123456789ABCDEF")
+      .build());
     assertThat(thrownException.getMessage()).isEqualTo("MemoData must be a hex-encoded string");
 
-    thrownException = Assertions.assertThrows(IllegalStateException.class, () -> {
-      Memo.builder()
-        .memoData("0123456789ABCDEF")
-        .memoType("Hello World")
-        .memoFormat("0123456789ABCDEF")
-        .build();
-    });
+    thrownException = Assertions.assertThrows(IllegalStateException.class, () -> Memo.builder()
+      .memoData("0123456789ABCDEF")
+      .memoType("Hello World")
+      .memoFormat("0123456789ABCDEF")
+      .build());
     assertThat(thrownException.getMessage()).isEqualTo("MemoType must be a hex-encoded string");
 
-    thrownException = Assertions.assertThrows(IllegalStateException.class, () -> {
-      Memo.builder()
-        .memoData("0123456789ABCDEF")
-        .memoType("0123456789ABCDEF")
-        .memoFormat("Hello World")
-        .build();
-    });
+    thrownException = Assertions.assertThrows(IllegalStateException.class, () -> Memo.builder()
+      .memoData("0123456789ABCDEF")
+      .memoType("0123456789ABCDEF")
+      .memoFormat("Hello World")
+      .build());
     assertThat(thrownException.getMessage()).isEqualTo("MemoFormat must be a hex-encoded string");
   }
 
@@ -59,7 +105,7 @@ class MemoTest {
 
   @Test
   void testBuildFromPlain() {
-    final Memo plainTextMemo = Memo.withPlainText("Hello World").build();
+    final Memo plainTextMemo = Memo.withPlaintext("Hello World").build();
     assertThat(plainTextMemo.memoType()).isEmpty();
     assertThat(plainTextMemo.memoFormat().get()).isEqualTo("746578742F706C61696E");
     assertThat(plainTextMemo.memoData().get()).isEqualTo("48656C6C6F20576F726C64");

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/TransactionTypeTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/TransactionTypeTests.java
@@ -1,0 +1,54 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+
+/**
+ * Unit tests for {@link TransactionType}.
+ */
+public class TransactionTypeTests {
+
+  @ParameterizedTest
+  @ArgumentsSource(value = TransactionTypeValidArgumentProvider.class)
+  public void shouldReturnTransactionTypeForValidValues(String value) {
+    TransactionType transactionType = TransactionType.forValue(value);
+    assertNotNull(transactionType);
+    assertTrue(transactionType instanceof TransactionType);
+  }
+
+  @EmptySource
+  @NullSource
+  @ParameterizedTest
+  @ArgumentsSource(value = TransactionTypeInvalidArgumentProvider.class)
+  public void shouldThrowIllegalArgumentExceptionForInvalidValues(String value) {
+    assertThrows(IllegalArgumentException.class, () -> TransactionType.forValue(value),
+      "No matching TransactionType enum value for String value " + value);
+  }
+
+  public static class TransactionTypeValidArgumentProvider implements ArgumentsProvider {
+
+    @Override
+    public java.util.stream.Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      return java.util.stream.Stream.of(TransactionType.values()).map(TransactionType::value).map(Arguments::of);
+    }
+
+  }
+
+  public static class TransactionTypeInvalidArgumentProvider implements ArgumentsProvider {
+
+    @Override
+    public java.util.stream.Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      return java.util.stream.Stream.of("bla", "blaaa", "123").map(Arguments::of);
+    }
+
+  }
+}


### PR DESCRIPTION
* Add checks to make sure that memos Strings are hex-encoded
* Add a utility method to construct a memo with text/plain content-type (format)

Signed-off-by: David Fuelling <sappenin@gmail.com>