### PR TITLE
Fix Issue #200

### DIFF
--- a/xrpl4j-binary-codec/src/main/java/org/xrpl/xrpl4j/codec/binary/types/STObjectType.java
+++ b/xrpl4j-binary-codec/src/main/java/org/xrpl/xrpl4j/codec/binary/types/STObjectType.java
@@ -74,7 +74,7 @@ public class STObjectType extends SerializedType<STObjectType> {
       /**
        * The Account field must not be a part of the UNLModify pseudotransaction encoding, due to a bug in rippled.
        */
-      if (isUNLModify && "Account".equals(fieldName)) {
+      if (isUNLModify && fieldName.equals("Account")) {
         continue;
       }
 

--- a/xrpl4j-binary-codec/src/main/java/org/xrpl/xrpl4j/codec/binary/types/STObjectType.java
+++ b/xrpl4j-binary-codec/src/main/java/org/xrpl/xrpl4j/codec/binary/types/STObjectType.java
@@ -60,9 +60,24 @@ public class STObjectType extends SerializedType<STObjectType> {
   public STObjectType fromJson(JsonNode node) {
     UnsignedByteArray byteList = UnsignedByteArray.empty();
     BinarySerializer serializer = new BinarySerializer(byteList);
+    boolean isUNLModify;
+    try {
+      isUNLModify = "UNLModify".equals(node.get("TransactionType").asText());
+    } catch (Exception e) {
+      isUNLModify = false;
+    }
+
 
     List<FieldWithValue<JsonNode>> fields = new ArrayList<>();
     for (String fieldName : Lists.newArrayList(node.fieldNames())) {
+
+      /**
+       * The Account field must not be a part of the UNLModify pseudotransaction encoding, due to a bug in rippled.
+       */
+      if (isUNLModify && "Account".equals(fieldName)) {
+        continue;
+      }
+
       JsonNode fieldNode = node.get(fieldName);
       definitionsService.getFieldInstance(fieldName)
         .filter(FieldInstance::isSerialized)

--- a/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodecTest.java
+++ b/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodecTest.java
@@ -151,7 +151,10 @@ class XrplBinaryCodecTest {
     // Results with and without `Account` are same since it is skipped while decoding.
     assertThat(encoder.encode(jsonWithoutAccount)).isEqualTo(expected);
 
-    String jsonDisablingUNLModify = "{" +
+    String expectedDisabledUnlModify = "120066240000000026040B52006840000000000000007300701321EDB6FC8E" +
+      "803EE8EDC2793F1EC917B2EE41D35255618DEB91D3F9B1FC89B75D453900101100";
+
+    String jsonDisablingUnlModify = "{" +
       "\"Account\":\"rrrrrrrrrrrrrrrrrrrrrhoLvTp\"," +
       "\"Fee\":\"0\"," +
       "\"LedgerSequence\":67850752," +
@@ -160,7 +163,7 @@ class XrplBinaryCodecTest {
       "\"TransactionType\":\"UNLModify\"," +
       "\"UNLModifyDisabling\":0," +
       "\"UNLModifyValidator\":\"EDB6FC8E803EE8EDC2793F1EC917B2EE41D35255618DEB91D3F9B1FC89B75D4539\"}";
-    assertThat(encoder.encode(jsonWithoutAccount)).isEqualTo(expected);
+    assertThat(encoder.encode(jsonDisablingUnlModify)).isEqualTo(expectedDisabledUnlModify);
   }
 
   @Test

--- a/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodecTest.java
+++ b/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodecTest.java
@@ -111,7 +111,6 @@ class XrplBinaryCodecTest {
       "{\"Fee\":{\"currency\":\"USD\",\"value\":\"123\",\"issuer\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\"}}";
     String hex = "68D5045EADB112E00000000000000000000000000055534400000000005E7B112523F68D2F5E879DB4EAC51C6698A69304";
     assertThat(encoder.encode(json)).isEqualTo(hex);
-    System.out.println(encoder.decode(hex) + " " + json);
     assertThat(encoder.decode(hex)).isEqualTo(json);
   }
 
@@ -150,6 +149,17 @@ class XrplBinaryCodecTest {
       "\"UNLModifyDisabling\":1," +
       "\"UNLModifyValidator\":\"EDB6FC8E803EE8EDC2793F1EC917B2EE41D35255618DEB91D3F9B1FC89B75D4539\"}";
     // Results with and without `Account` are same since it is skipped while decoding.
+    assertThat(encoder.encode(jsonWithoutAccount)).isEqualTo(expected);
+
+    String jsonDisablingUNLModify = "{" +
+      "\"Account\":\"rrrrrrrrrrrrrrrrrrrrrhoLvTp\"," +
+      "\"Fee\":\"0\"," +
+      "\"LedgerSequence\":67850752," +
+      "\"Sequence\":0," +
+      "\"SigningPubKey\":\"\"," +
+      "\"TransactionType\":\"UNLModify\"," +
+      "\"UNLModifyDisabling\":0," +
+      "\"UNLModifyValidator\":\"EDB6FC8E803EE8EDC2793F1EC917B2EE41D35255618DEB91D3F9B1FC89B75D4539\"}";
     assertThat(encoder.encode(jsonWithoutAccount)).isEqualTo(expected);
   }
 

--- a/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodecTest.java
+++ b/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodecTest.java
@@ -3,11 +3,15 @@ package org.xrpl.xrpl4j.codec.binary;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.xrpl.xrpl4j.codec.binary.serdes.BinaryParser;
+import org.xrpl.xrpl4j.codec.binary.types.STObjectType;
 import org.xrpl.xrpl4j.codec.fixtures.FixtureUtils;
 import org.xrpl.xrpl4j.codec.fixtures.data.WholeObject;
 
@@ -107,6 +111,7 @@ class XrplBinaryCodecTest {
       "{\"Fee\":{\"currency\":\"USD\",\"value\":\"123\",\"issuer\":\"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\"}}";
     String hex = "68D5045EADB112E00000000000000000000000000055534400000000005E7B112523F68D2F5E879DB4EAC51C6698A69304";
     assertThat(encoder.encode(json)).isEqualTo(hex);
+    System.out.println(encoder.decode(hex) + " " + json);
     assertThat(encoder.decode(hex)).isEqualTo(json);
   }
 
@@ -121,7 +126,7 @@ class XrplBinaryCodecTest {
   }
 
   @Test
-  void encodeUnlModify() throws JsonProcessingException {
+  void encodeDecodeUnlModify() throws JsonProcessingException {
     String json = "{" +
       "\"Account\":\"rrrrrrrrrrrrrrrrrrrrrhoLvTp\"," +
       "\"Fee\":\"0\"," +
@@ -135,6 +140,17 @@ class XrplBinaryCodecTest {
     String expected = "120066240000000026040B52006840000000000000007300701321EDB6FC8E803EE8EDC2793F1EC9" +
       "17B2EE41D35255618DEB91D3F9B1FC89B75D453900101101";
     assertThat(expected).isEqualTo(encoder.encode(json));
+
+    String jsonWithoutAccount = "{" +
+      "\"Fee\":\"0\"," +
+      "\"LedgerSequence\":67850752," +
+      "\"Sequence\":0," +
+      "\"SigningPubKey\":\"\"," +
+      "\"TransactionType\":\"UNLModify\"," +
+      "\"UNLModifyDisabling\":1," +
+      "\"UNLModifyValidator\":\"EDB6FC8E803EE8EDC2793F1EC917B2EE41D35255618DEB91D3F9B1FC89B75D4539\"}";
+    // Results with and without `Account` are same since it is skipped while decoding.
+    assertThat(encoder.encode(jsonWithoutAccount)).isEqualTo(expected);
   }
 
   @Test

--- a/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodecTest.java
+++ b/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodecTest.java
@@ -121,6 +121,23 @@ class XrplBinaryCodecTest {
   }
 
   @Test
+  void encodeUnlModify() throws JsonProcessingException {
+    String json = "{" +
+      "\"Account\":\"rrrrrrrrrrrrrrrrrrrrrhoLvTp\"," +
+      "\"Fee\":\"0\"," +
+      "\"LedgerSequence\":67850752," +
+      "\"Sequence\":0," +
+      "\"SigningPubKey\":\"\"," +
+      "\"TransactionType\":\"UNLModify\"," +
+      "\"UNLModifyDisabling\":1," +
+      "\"UNLModifyValidator\":\"EDB6FC8E803EE8EDC2793F1EC917B2EE41D35255618DEB91D3F9B1FC89B75D4539\"}";
+
+    String expected = "120066240000000026040B52006840000000000000007300701321EDB6FC8E803EE8EDC2793F1EC9" +
+      "17B2EE41D35255618DEB91D3F9B1FC89B75D453900101101";
+    assertThat(expected).isEqualTo(encoder.encode(json));
+  }
+
+  @Test
   void encodeForSigning() throws JsonProcessingException {
     String json =
       "{\"Account\":\"r45dBj4S3VvMMYXxr9vHX4Z4Ma6ifPMCkK\",\"TransactionType\":\"Payment\",\"Fee\":\"789\"," +


### PR DESCRIPTION
Do not encode `Account` when txtype = `UNLModify`
Fixes https://github.com/XRPLF/xrpl4j/issues/200