### PR TITLE
Add `AccountSetTransactionFlags` so that we can set multiple AccountRoot flags in one transaction

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountSetIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountSetIT.java
@@ -8,6 +8,7 @@ import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
 import org.xrpl.xrpl4j.model.client.accounts.AccountInfoResult;
 import org.xrpl.xrpl4j.model.client.fees.FeeResult;
 import org.xrpl.xrpl4j.model.client.transactions.SubmitResult;
+import org.xrpl.xrpl4j.model.flags.Flags;
 import org.xrpl.xrpl4j.model.flags.Flags.AccountRootFlags;
 import org.xrpl.xrpl4j.model.transactions.AccountSet;
 import org.xrpl.xrpl4j.model.transactions.AccountSet.AccountSetFlag;
@@ -142,6 +143,89 @@ public class AccountSetIT extends AbstractIT {
     assertClearFlag(wallet, sequence, AccountSetFlag.DEPOSIT_AUTH, AccountRootFlags.DEPOSIT_AUTH);
     sequence = sequence.plus(UnsignedInteger.ONE);
     assertClearFlag(wallet, sequence, AccountSetFlag.DEFAULT_RIPPLE, AccountRootFlags.DEFAULT_RIPPLE);
+  }
+
+  @Test
+  void enableAndDisableFlagsUsingTransactionFlags() throws JsonRpcClientErrorException {
+    Wallet wallet = createRandomAccount();
+
+    ///////////////////////
+    // Get validated account info and validate account state
+    AccountInfoResult accountInfo = this.scanForResult(() -> this.getValidatedAccountInfo(wallet.classicAddress()));
+    assertThat(accountInfo.status()).isNotEmpty().get().isEqualTo("success");
+    assertThat(accountInfo.accountData().flags().lsfGlobalFreeze()).isEqualTo(false);
+
+    UnsignedInteger sequence = accountInfo.accountData().sequence();
+
+    FeeResult feeResult = xrplClient.fee();
+    AccountSet enableAccountSet = AccountSet.builder()
+      .account(wallet.classicAddress())
+      .fee(feeResult.drops().openLedgerFee())
+      .sequence(sequence)
+      .signingPublicKey(wallet.publicKey())
+      .flags(
+        Flags.AccountSetTransactionFlags.builder()
+          .tfRequireDestTag()
+          .tfRequireAuth()
+          .tfDisallowXrp()
+          .build()
+      )
+      .build();
+
+    SubmitResult<AccountSet> enableResponse = xrplClient.submit(wallet, enableAccountSet);
+    assertThat(enableResponse.result()).isEqualTo("tesSUCCESS");
+    assertThat(enableResponse.transactionResult().transaction().hash()).isNotEmpty().get()
+      .isEqualTo(enableResponse.transactionResult().hash());
+    logger.info(
+      "AccountSet SetFlag transaction successful: https://testnet.xrpl.org/transactions/{}",
+      enableResponse.transactionResult().hash()
+    );
+
+    /////////////////////////
+    // Validate Account State
+    this.scanForResult(
+      () -> this.getValidatedAccountInfo(wallet.classicAddress()),
+      accountInfoResult -> {
+        logger.info("AccountInfoResponse Flags: {}", accountInfoResult.accountData().flags());
+        return accountInfoResult.accountData().flags().isSet(AccountRootFlags.REQUIRE_DEST_TAG) &&
+          accountInfoResult.accountData().flags().isSet(AccountRootFlags.REQUIRE_AUTH) &&
+          accountInfoResult.accountData().flags().isSet(AccountRootFlags.DISALLOW_XRP);
+      });
+
+
+    AccountSet disableAccountSet = AccountSet.builder()
+      .account(wallet.classicAddress())
+      .fee(feeResult.drops().openLedgerFee())
+      .sequence(sequence.plus(UnsignedInteger.ONE))
+      .signingPublicKey(wallet.publicKey())
+      .flags(
+        Flags.AccountSetTransactionFlags.builder()
+          .tfOptionalDestTag()
+          .tfOptionalAuth()
+          .tfAllowXrp()
+          .build()
+      )
+      .build();
+
+    SubmitResult<AccountSet> disableResponse = xrplClient.submit(wallet, disableAccountSet);
+    assertThat(disableResponse.result()).isEqualTo("tesSUCCESS");
+    assertThat(disableResponse.transactionResult().transaction().hash()).isNotEmpty().get()
+      .isEqualTo(disableResponse.transactionResult().hash());
+    logger.info(
+      "AccountSet SetFlag transaction successful: https://testnet.xrpl.org/transactions/{}",
+      disableResponse.transactionResult().hash()
+    );
+
+    /////////////////////////
+    // Validate Account State
+    this.scanForResult(
+      () -> this.getValidatedAccountInfo(wallet.classicAddress()),
+      accountInfoResult -> {
+        logger.info("AccountInfoResponse Flags: {}", accountInfoResult.accountData().flags());
+        return !accountInfoResult.accountData().flags().isSet(AccountRootFlags.REQUIRE_DEST_TAG) &&
+          !accountInfoResult.accountData().flags().isSet(AccountRootFlags.REQUIRE_AUTH) &&
+          !accountInfoResult.accountData().flags().isSet(AccountRootFlags.DISALLOW_XRP);
+      });
   }
 
   //////////////////////

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/flags/Flags.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/flags/Flags.java
@@ -1,6 +1,7 @@
 package org.xrpl.xrpl4j.model.flags;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.base.Preconditions;
 import org.xrpl.xrpl4j.model.ledger.PayChannelObject;
 import org.xrpl.xrpl4j.model.transactions.AccountSet;
 import org.xrpl.xrpl4j.model.transactions.OfferCreate;
@@ -532,6 +533,289 @@ public class Flags {
      */
     public boolean lsfOneOwnerCount() {
       return this.isSet(SignerListFlags.ONE_OWNER_COUNT);
+    }
+  }
+
+  /**
+   * {@link TransactionFlags} for {@link AccountSet} transactions. Note that using these directly is
+   * discouraged, but can be useful when setting multiple flags for an account.
+   */
+  public static class AccountSetTransactionFlags extends TransactionFlags {
+    /**
+     * Constant for an unset flag.
+     */
+    protected static final AccountSetTransactionFlags UNSET = new AccountSetTransactionFlags(0);
+
+    /**
+     * Constant for the {@code tfRequireDestTag} flag.
+     */
+    protected static final AccountSetTransactionFlags REQUIRE_DEST_TAG = new AccountSetTransactionFlags(0x00010000);
+
+    /**
+     * Constant for the {@code tfOptionalDestTag} flag.
+     */
+    protected static final AccountSetTransactionFlags OPTIONAL_DEST_TAG = new AccountSetTransactionFlags(0x00020000);
+
+    /**
+     * Constant for the {@code tfRequireAuth} flag.
+     */
+    protected static final AccountSetTransactionFlags REQUIRE_AUTH = new AccountSetTransactionFlags(0x00040000);
+
+    /**
+     * Constant for the {@code tfOptionalAuth} flag.
+     */
+    protected static final AccountSetTransactionFlags OPTIONAL_AUTH = new AccountSetTransactionFlags(0x00080000);
+
+    /**
+     * Constant for the {@code tfDisallowXRP} flag.
+     */
+    protected static final AccountSetTransactionFlags DISALLOW_XRP = new AccountSetTransactionFlags(0x00100000);
+
+    /**
+     * Constant for the {@code tfAllowXRP} flag.
+     */
+    protected static final AccountSetTransactionFlags ALLOW_XRP = new AccountSetTransactionFlags(0x00200000);
+
+    private AccountSetTransactionFlags(long value) {
+      super(value);
+    }
+
+    private static AccountSetTransactionFlags of(
+      boolean tfFullyCanonicalSig,
+      boolean tfRequireDestTag,
+      boolean tfOptionalDestTag,
+      boolean tfRequireAuth,
+      boolean tfOptionalAuth,
+      boolean tfDisallowXrp,
+      boolean tfAllowXrp
+    ) {
+      Preconditions.checkArgument(
+        !(tfRequireDestTag && tfOptionalDestTag),
+        "tfRequireDestTag and tfOptionalDestTag cannot both be set to true."
+      );
+
+      Preconditions.checkArgument(
+        !(tfRequireAuth && tfOptionalAuth),
+        "tfRequireAuth and tfOptionalAuth cannot both be set to true."
+      );
+
+      Preconditions.checkArgument(
+        !(tfDisallowXrp && tfAllowXrp),
+        "tfDisallowXrp and tfAllowXrp cannot both be set to true."
+      );
+      return new AccountSetTransactionFlags(
+        Flags.of(
+          tfFullyCanonicalSig ? TransactionFlags.FULLY_CANONICAL_SIG : UNSET,
+          tfRequireDestTag ? REQUIRE_DEST_TAG : UNSET,
+          tfOptionalDestTag ? OPTIONAL_DEST_TAG : UNSET,
+          tfRequireAuth ? REQUIRE_AUTH : UNSET,
+          tfOptionalAuth ? OPTIONAL_AUTH : UNSET,
+          tfDisallowXrp ? DISALLOW_XRP : UNSET,
+          tfAllowXrp ? ALLOW_XRP : UNSET
+        ).getValue()
+      );
+    }
+
+    /**
+     * Construct {@link AccountSetTransactionFlags} with a given value.
+     *
+     * @param value The long-number encoded flags value of this {@link AccountSetTransactionFlags}.
+     *
+     * @return New {@link AccountSetTransactionFlags}.
+     */
+    public static AccountSetTransactionFlags of(long value) {
+      AccountSetTransactionFlags flags = new AccountSetTransactionFlags(value);
+
+      Preconditions.checkArgument(
+        !(flags.tfRequireDestTag() && flags.tfOptionalDestTag()),
+        "tfRequireDestTag and tfOptionalDestTag cannot both be set to true."
+      );
+
+      Preconditions.checkArgument(
+        !(flags.tfRequireAuth() && flags.tfOptionalAuth()),
+        "tfRequireAuth and tfOptionalAuth cannot both be set to true."
+      );
+
+      Preconditions.checkArgument(
+        !(flags.tfDisallowXrp() && flags.tfAllowXrp()),
+        "tfDisallowXrp and tfAllowXrp cannot both be set to true."
+      );
+
+      return flags;
+    }
+
+    /**
+     * Create a new {@link AccountSetTransactionFlags.Builder}.
+     *
+     * @return A new {@link AccountSetTransactionFlags.Builder}.
+     */
+    public static AccountSetTransactionFlags.Builder builder() {
+      return new AccountSetTransactionFlags.Builder();
+    }
+
+    /**
+     * Require a fully canonical signature.
+     *
+     * @return {@code true} if {@code tfFullyCanonicalSig} is set, otherwise {@code false}.
+     */
+    public boolean tfFullyCanonicalSig() {
+      return this.isSet(TransactionFlags.FULLY_CANONICAL_SIG);
+    }
+
+    /**
+     * Whether or not the {@code tfRequireDestTag} flag is set.
+     *
+     * @return {@code true} if {@code tfRequireDestTag} is set, otherwise {@code false}.
+     */
+    public boolean tfRequireDestTag() {
+      return this.isSet(REQUIRE_DEST_TAG);
+    }
+
+    /**
+     * Whether or not the {@code tfOptionalDestTag} flag is set.
+     *
+     * @return {@code true} if {@code tfOptionalDestTag} is set, otherwise {@code false}.
+     */
+    public boolean tfOptionalDestTag() {
+      return this.isSet(OPTIONAL_DEST_TAG);
+    }
+
+    /**
+     * Whether or not the {@code tfRequireAuth} flag is set.
+     *
+     * @return {@code true} if {@code tfRequireAuth} is set, otherwise {@code false}.
+     */
+    public boolean tfRequireAuth() {
+      return this.isSet(REQUIRE_AUTH);
+    }
+
+    /**
+     * Whether or not the {@code tfOptionalAuth} flag is set.
+     *
+     * @return {@code true} if {@code tfOptionalAuth} is set, otherwise {@code false}.
+     */
+    public boolean tfOptionalAuth() {
+      return this.isSet(OPTIONAL_AUTH);
+    }
+
+    /**
+     * Whether or not the {@code tfDisallowXrp} flag is set.
+     *
+     * @return {@code true} if {@code tfDisallowXrp} is set, otherwise {@code false}.
+     */
+    public boolean tfDisallowXrp() {
+      return this.isSet(DISALLOW_XRP);
+    }
+
+    /**
+     * Whether or not the {@code tfAllowXrp} flag is set.
+     *
+     * @return {@code true} if {@code tfAllowXrp} is set, otherwise {@code false}.
+     */
+    public boolean tfAllowXrp() {
+      return this.isSet(ALLOW_XRP);
+    }
+
+    /**
+     * A builder class for {@link AccountSetTransactionFlags}.
+     */
+    public static class Builder {
+      private boolean tfFullyCanonicalSig = true;
+      boolean tfRequireDestTag = false;
+      boolean tfOptionalDestTag = false;
+      boolean tfRequireAuth = false;
+      boolean tfOptionalAuth = false;
+      boolean tfDisallowXrp = false;
+      boolean tfAllowXrp = false;
+
+      /**
+       * Set {@code tfFullyCanonicalSig} to the given value.
+       *
+       * @param tfFullyCanonicalSig A boolean value.
+       *
+       * @return The same {@link AccountSetTransactionFlags.Builder}.
+       */
+      public AccountSetTransactionFlags.Builder tfFullyCanonicalSig(boolean tfFullyCanonicalSig) {
+        this.tfFullyCanonicalSig = tfFullyCanonicalSig;
+        return this;
+      }
+
+      /**
+       * Set {@code tfRequireDestTag} to the given value.
+       *
+       * @return The same {@link AccountSetTransactionFlags.Builder}.
+       */
+      public AccountSetTransactionFlags.Builder tfRequireDestTag() {
+        this.tfRequireDestTag = true;
+        return this;
+      }
+
+      /**
+       * Set {@code tfOptionalDestTag} to the given value.
+       *
+       * @return The same {@link AccountSetTransactionFlags.Builder}.
+       */
+      public AccountSetTransactionFlags.Builder tfOptionalDestTag() {
+        this.tfOptionalDestTag = true;
+        return this;
+      }
+
+      /**
+       * Set {@code tfRequireAuth} to the given value.
+       *
+       * @return The same {@link AccountSetTransactionFlags.Builder}.
+       */
+      public AccountSetTransactionFlags.Builder tfRequireAuth() {
+        this.tfRequireAuth = true;
+        return this;
+      }
+
+      /**
+       * Set {@code tfOptionalAuth} to the given value.
+       *
+       * @return The same {@link AccountSetTransactionFlags.Builder}.
+       */
+      public AccountSetTransactionFlags.Builder tfOptionalAuth() {
+        this.tfOptionalAuth = true;
+        return this;
+      }
+
+      /**
+       * Set {@code tfDisallowXrp} to the given value.
+       *
+       * @return The same {@link AccountSetTransactionFlags.Builder}.
+       */
+      public AccountSetTransactionFlags.Builder tfDisallowXrp() {
+        this.tfDisallowXrp = true;
+        return this;
+      }
+
+      /**
+       * Set {@code tfAllowXrp} to the given value.
+       *
+       * @return The same {@link AccountSetTransactionFlags.Builder}.
+       */
+      public AccountSetTransactionFlags.Builder tfAllowXrp() {
+        this.tfAllowXrp = true;
+        return this;
+      }
+
+      /**
+       * Build a new {@link AccountSetTransactionFlags} from the current boolean values.
+       *
+       * @return A new {@link AccountSetTransactionFlags}.
+       */
+      public AccountSetTransactionFlags build() {
+        return AccountSetTransactionFlags.of(
+          tfFullyCanonicalSig,
+          tfRequireDestTag,
+          tfOptionalDestTag,
+          tfRequireAuth,
+          tfOptionalAuth,
+          tfDisallowXrp,
+          tfAllowXrp
+        );
+      }
     }
   }
 

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/flags/Flags.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/flags/Flags.java
@@ -721,12 +721,12 @@ public class Flags {
      */
     public static class Builder {
       private boolean tfFullyCanonicalSig = true;
-      boolean tfRequireDestTag = false;
-      boolean tfOptionalDestTag = false;
-      boolean tfRequireAuth = false;
-      boolean tfOptionalAuth = false;
-      boolean tfDisallowXrp = false;
-      boolean tfAllowXrp = false;
+      private boolean tfRequireDestTag = false;
+      private boolean tfOptionalDestTag = false;
+      private boolean tfRequireAuth = false;
+      private boolean tfOptionalAuth = false;
+      private boolean tfDisallowXrp = false;
+      private boolean tfAllowXrp = false;
 
       /**
        * Set {@code tfFullyCanonicalSig} to the given value.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/AccountSet.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/AccountSet.java
@@ -41,9 +41,9 @@ public interface AccountSet extends Transaction {
    * @return Always {@link Flags.TransactionFlags} with {@code tfFullyCanonicalSig} set.
    */
   @JsonProperty("Flags")
-  @Derived
-  default TransactionFlags flags() {
-    return new TransactionFlags.Builder().tfFullyCanonicalSig(true).build();
+  @Value.Default
+  default Flags.AccountSetTransactionFlags flags() {
+    return new Flags.AccountSetTransactionFlags.Builder().tfFullyCanonicalSig(true).build();
   }
 
   /**

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/AccountSetTransactionFlagsTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/flags/AccountSetTransactionFlagsTests.java
@@ -1,0 +1,166 @@
+package org.xrpl.xrpl4j.model.flags;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+public class AccountSetTransactionFlagsTests extends AbstractFlagsTest {
+
+  public static Stream<Arguments> data() {
+    return getBooleanCombinations(7);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testFlagsConstructionWithIndividualFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfRequireDestTag,
+    boolean tfOptionalDestTag,
+    boolean tfRequireAuth,
+    boolean tfOptionalAuth,
+    boolean tfDisallowXrp,
+    boolean tfAllowXrp
+  ) {
+    Flags.AccountSetTransactionFlags.Builder builder = Flags.AccountSetTransactionFlags.builder()
+      .tfFullyCanonicalSig(tfFullyCanonicalSig);
+
+    if (tfRequireDestTag) {
+      builder.tfRequireDestTag();
+    }
+
+    if (tfOptionalDestTag) {
+      builder.tfOptionalDestTag();
+    }
+
+    if (tfRequireAuth) {
+      builder.tfRequireAuth();
+    }
+
+    if (tfOptionalAuth) {
+      builder.tfOptionalAuth();
+    }
+
+    if (tfDisallowXrp) {
+      builder.tfDisallowXrp();
+    }
+
+    if (tfAllowXrp) {
+      builder.tfAllowXrp();
+    }
+
+    if (tfRequireDestTag && tfOptionalDestTag) {
+      assertThatThrownBy(
+        builder::build
+      ).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("tfRequireDestTag and tfOptionalDestTag cannot both be set to true.");
+      return;
+    }
+
+    if (tfRequireAuth && tfOptionalAuth) {
+      assertThatThrownBy(
+        builder::build
+      ).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("tfRequireAuth and tfOptionalAuth cannot both be set to true.");
+      return;
+    }
+
+    if (tfDisallowXrp && tfAllowXrp) {
+      assertThatThrownBy(
+        builder::build
+      ).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("tfDisallowXrp and tfAllowXrp cannot both be set to true.");
+      return;
+    }
+
+    Flags.AccountSetTransactionFlags flags = builder.build();
+    long expectedFlags = getExpectedFlags(
+      tfFullyCanonicalSig,
+      tfRequireDestTag,
+      tfOptionalDestTag,
+      tfRequireAuth,
+      tfOptionalAuth,
+      tfDisallowXrp,
+      tfAllowXrp
+    );
+    assertThat(flags.getValue()).isEqualTo(expectedFlags);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDeriveIndividualFlagsFromFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfRequireDestTag,
+    boolean tfOptionalDestTag,
+    boolean tfRequireAuth,
+    boolean tfOptionalAuth,
+    boolean tfDisallowXrp,
+    boolean tfAllowXrp
+  ) {
+    long expectedFlags = getExpectedFlags(
+      tfFullyCanonicalSig,
+      tfRequireDestTag,
+      tfOptionalDestTag,
+      tfRequireAuth,
+      tfOptionalAuth,
+      tfDisallowXrp,
+      tfAllowXrp
+    );
+
+    if (tfRequireDestTag && tfOptionalDestTag) {
+      assertThatThrownBy(
+        () -> Flags.AccountSetTransactionFlags.of(expectedFlags)
+      ).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("tfRequireDestTag and tfOptionalDestTag cannot both be set to true.");
+      return;
+    }
+
+    if (tfRequireAuth && tfOptionalAuth) {
+      assertThatThrownBy(
+        () -> Flags.AccountSetTransactionFlags.of(expectedFlags)
+      ).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("tfRequireAuth and tfOptionalAuth cannot both be set to true.");
+      return;
+    }
+
+    if (tfDisallowXrp && tfAllowXrp) {
+      assertThatThrownBy(
+        () -> Flags.AccountSetTransactionFlags.of(expectedFlags)
+      ).isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("tfDisallowXrp and tfAllowXrp cannot both be set to true.");
+      return;
+    }
+
+    Flags.AccountSetTransactionFlags flags = Flags.AccountSetTransactionFlags.of(expectedFlags);
+
+    assertThat(flags.getValue()).isEqualTo(expectedFlags);
+    assertThat(flags.tfFullyCanonicalSig()).isEqualTo(tfFullyCanonicalSig);
+    assertThat(flags.tfRequireDestTag()).isEqualTo(tfRequireDestTag);
+    assertThat(flags.tfRequireAuth()).isEqualTo(tfRequireAuth);
+    assertThat(flags.tfOptionalAuth()).isEqualTo(tfOptionalAuth);
+    assertThat(flags.tfDisallowXrp()).isEqualTo(tfDisallowXrp);
+    assertThat(flags.tfAllowXrp()).isEqualTo(tfAllowXrp);
+  }
+
+  private long getExpectedFlags(
+    boolean tfFullyCanonicalSig,
+    boolean tfRequireDestTag,
+    boolean tfOptionalDestTag,
+    boolean tfRequireAuth,
+    boolean tfOptionalAuth,
+    boolean tfDisallowXrp,
+    boolean tfAllowXrp
+  ) {
+    return (tfFullyCanonicalSig ? Flags.AccountSetTransactionFlags.FULLY_CANONICAL_SIG.getValue() : 0L) |
+      (tfRequireDestTag ? Flags.AccountSetTransactionFlags.REQUIRE_DEST_TAG.getValue() : 0L) |
+      (tfOptionalDestTag ? Flags.AccountSetTransactionFlags.OPTIONAL_DEST_TAG.getValue() : 0L) |
+      (tfRequireAuth ? Flags.AccountSetTransactionFlags.REQUIRE_AUTH.getValue() : 0L) |
+      (tfOptionalAuth ? Flags.AccountSetTransactionFlags.OPTIONAL_AUTH.getValue() : 0L) |
+      (tfDisallowXrp ? Flags.AccountSetTransactionFlags.DISALLOW_XRP.getValue() : 0L) |
+      (tfAllowXrp ? Flags.AccountSetTransactionFlags.ALLOW_XRP.getValue() : 0L);
+  }
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/AccountSetTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/AccountSetTests.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.flags.Flags;
 
 public class AccountSetTests {
 
@@ -31,6 +32,38 @@ public class AccountSetTests {
     assertThat(accountSet.messageKey()).isNotEmpty().get()
       .isEqualTo("03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB");
     assertThat(accountSet.transferRate()).isNotEmpty().get().isEqualTo(UnsignedInteger.valueOf(1000000001));
+    assertThat(accountSet.flags()).isEqualTo(Flags.AccountSetTransactionFlags.builder().build());
+  }
+
+  @Test
+  void accountSetWithSetFlagAndTransactionFlags() {
+    Flags.AccountSetTransactionFlags flags = Flags.AccountSetTransactionFlags.builder()
+      .tfRequireAuth()
+      .tfRequireDestTag()
+      .tfDisallowXrp()
+      .build();
+    AccountSet accountSet = AccountSet.builder()
+      .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+      .fee(XrpCurrencyAmount.ofDrops(12))
+      .sequence(UnsignedInteger.valueOf(5))
+      .domain("6578616D706C652E636F6D")
+      .setFlag(AccountSet.AccountSetFlag.ACCOUNT_TXN_ID)
+      .flags(flags)
+      .messageKey("03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB")
+      .transferRate(UnsignedInteger.valueOf(1000000001))
+      .tickSize(UnsignedInteger.valueOf(15))
+      .build();
+
+    assertThat(accountSet.transactionType()).isEqualTo(TransactionType.ACCOUNT_SET);
+    assertThat(accountSet.account()).isEqualTo(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"));
+    assertThat(accountSet.fee().value()).isEqualTo(UnsignedLong.valueOf(12));
+    assertThat(accountSet.sequence()).isEqualTo(UnsignedInteger.valueOf(5));
+    assertThat(accountSet.domain()).isNotEmpty().get().isEqualTo("6578616D706C652E636F6D");
+    assertThat(accountSet.setFlag()).isNotEmpty().get().isEqualTo(AccountSet.AccountSetFlag.ACCOUNT_TXN_ID);
+    assertThat(accountSet.messageKey()).isNotEmpty().get()
+      .isEqualTo("03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB");
+    assertThat(accountSet.transferRate()).isNotEmpty().get().isEqualTo(UnsignedInteger.valueOf(1000000001));
+    assertThat(accountSet.flags()).isEqualTo(flags);
   }
 
   @Test


### PR DESCRIPTION
Adds `AccountSetTransactionFlags` corresponding to the `tf` flags for the `AccountSet` transaction. The docs say that using these flags is discouraged, but we should give developers the option to use them, as using them can save them from having to submit multiple `AccountSet` transactions to set multiple flags.