### PR TITLE
add unit tests for Uint32 and Uint64 types

### DIFF
--- a/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/types/UInt16TypeUnitTest.java
+++ b/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/types/UInt16TypeUnitTest.java
@@ -2,12 +2,11 @@ package org.xrpl.xrpl4j.codec.binary.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedLong;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class UIntTypeTest {
+class UInt16TypeUnitTest {
 
   private final UInt16Type codec = new UInt16Type();
 
@@ -19,7 +18,7 @@ class UIntTypeTest {
   }
 
   @Test
-  void encode() throws JsonProcessingException {
+  void encode() {
     assertThat(codec.fromJson("0").toHex()).isEqualTo("0000");
     assertThat(codec.fromJson("15").toHex()).isEqualTo("000F");
     assertThat(codec.fromJson("65535").toHex()).isEqualTo("FFFF");

--- a/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/types/UInt32TypeUnitTest.java
+++ b/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/types/UInt32TypeUnitTest.java
@@ -1,0 +1,33 @@
+package org.xrpl.xrpl4j.codec.binary.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class UInt32TypeUnitTest {
+
+  private final UInt32Type codec = new UInt32Type();
+
+  @Test
+  void decode() {
+    assertThat(codec.fromHex("00000000").valueOf()).isEqualTo(UnsignedLong.valueOf(0));
+    assertThat(codec.fromHex("0000000F").valueOf()).isEqualTo(UnsignedLong.valueOf(15));
+    assertThat(codec.fromHex("FFFFFFFF").valueOf()).isEqualTo(UnsignedLong.valueOf(4294967295L));
+  }
+
+  @Test
+  void encode() {
+    assertThat(codec.fromJson("0").toHex()).isEqualTo("00000000");
+    assertThat(codec.fromJson("15").toHex()).isEqualTo("0000000F");
+    assertThat(codec.fromJson("65535").toHex()).isEqualTo("0000FFFF");
+    assertThat(codec.fromJson("4294967295").toHex()).isEqualTo("FFFFFFFF");
+  }
+
+  @Test
+  void encodeOutOfBounds() {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> codec.fromJson("4294967296"));
+  }
+
+}

--- a/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/types/UInt64TypeUnitTest.java
+++ b/xrpl4j-binary-codec/src/test/java/org/xrpl/xrpl4j/codec/binary/types/UInt64TypeUnitTest.java
@@ -1,0 +1,34 @@
+package org.xrpl.xrpl4j.codec.binary.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class UInt64TypeUnitTest {
+  private final UInt64Type codec = new UInt64Type();
+  private static UnsignedLong maxUint64 = UnsignedLong.valueOf("FFFFFFFFFFFFFFFF", 16);
+
+  @Test
+  void decode() {
+    assertThat(codec.fromHex("0000000000000000").valueOf()).isEqualTo(UnsignedLong.valueOf(0));
+    assertThat(codec.fromHex("000000000000000F").valueOf()).isEqualTo(UnsignedLong.valueOf(15));
+    assertThat(codec.fromHex("00000000FFFFFFFF").valueOf()).isEqualTo(UnsignedLong.valueOf(4294967295L));
+    assertThat(codec.fromHex("FFFFFFFFFFFFFFFF").valueOf()).isEqualTo(maxUint64);
+  }
+
+  @Test
+  void encode() {
+    assertThat(codec.fromJson("0").toHex()).isEqualTo("0000000000000000");
+    assertThat(codec.fromJson("15").toHex()).isEqualTo("000000000000000F");
+    assertThat(codec.fromJson("65535").toHex()).isEqualTo("000000000000FFFF");
+    assertThat(codec.fromJson("4294967295").toHex()).isEqualTo("00000000FFFFFFFF");
+    assertThat(codec.fromJson(maxUint64.toString()).toHex()).isEqualTo("FFFFFFFFFFFFFFFF");
+  }
+
+  @Test
+  void encodeOutOfBounds() {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> codec.fromJson("18446744073709551616"));
+  }
+}


### PR DESCRIPTION
These tests were written in order to address the Zero Encoding issue #83.
And xrpl4j seems to handle the case and works without any issues.