### PR TITLE
Add missing optional field to NFTokenBurn

### DIFF
--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/NfTokenBurn.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/NfTokenBurn.java
@@ -49,6 +49,16 @@ public interface NfTokenBurn extends Transaction {
    */
   @JsonProperty("TokenID")
   NfTokenId tokenId();
+    
+  /**
+   * Indicates the {@link Address} of the account that owns the NFToken if it is different
+   * than the Account field. Only used to burn tokens which have the lsfBurnable flag enabled
+   * and are not owned by the signing account.
+   *
+   * @return An {@link Address} of the account that owns the NFToken specified by TokenID.
+   */
+  @JsonProperty("Owner")
+  Address owner();
 
   /**
    * Set of {@link Flags.TransactionFlags}s for this {@link NfTokenBurn}, which only allows

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/NfTokenBurn.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/NfTokenBurn.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.flags.Flags;
 
+import java.util.Optional;
 
 /**
  * The {@link NfTokenBurn} transaction is used to remove an NfToken object from the
@@ -58,7 +59,7 @@ public interface NfTokenBurn extends Transaction {
    * @return An {@link Address} of the account that owns the NFToken specified by TokenID.
    */
   @JsonProperty("Owner")
-  Address owner();
+  Optional<Address> owner();
 
   /**
    * Set of {@link Flags.TransactionFlags}s for this {@link NfTokenBurn}, which only allows

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/NfTokenBurnTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/NfTokenBurnTest.java
@@ -22,6 +22,23 @@ public class NfTokenBurnTest {
   }
 
   @Test
+  public void buildTxWithOwner() {
+
+    NfTokenId id = NfTokenId.of("000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65");
+    Address ownerAddress = Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
+    NfTokenBurn nfTokenBurn = NfTokenBurn.builder()
+      .fee(XrpCurrencyAmount.ofDrops(1))
+      .account(Address.of("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59Ba"))
+      .owner(ownerAddress)
+      .tokenId(id)
+      .build();
+
+    assertThat(id.equals(nfTokenBurn.tokenId()));
+    assertThat(nfTokenBurn.tokenId()).isEqualTo(id);
+    assertThat(nfTokenBurn.owner().get()).isEqualTo(ownerAddress);
+  }
+
+  @Test
   public void buildTxWithMissingParam() {
 
     assertThrows(


### PR DESCRIPTION
When burning a token with lsfBurnable enabled as the original minter, you need to specify the current `Owner` of the NFToken. Otherwise `rippled` will default to searching the normal `Account` for the NFToken and will return `tecNO_ENTRY` since someone else has the NFT.

I haven't worked with this repo before, so I may be missing tests/additional logic which is required to make this change work. Please let me know if that is the case!

Also, this field is optional - I'm not sure if there's any other annotations required to specify that this is an optional field.

Opened in response to this issue: https://github.com/XRPLF/xrpl.js/issues/1947