### PR TITLE
add test for payment with paths

### DIFF
--- a/xrpl4j-client/src/test/java/org/xrpl/xrpl4j/client/XrplClientTest.java
+++ b/xrpl4j-client/src/test/java/org/xrpl/xrpl4j/client/XrplClientTest.java
@@ -34,6 +34,7 @@ import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import okhttp3.HttpUrl;
+import org.assertj.core.util.Lists;
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -103,6 +104,7 @@ import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;
 import org.xrpl.xrpl4j.model.transactions.OfferCancel;
 import org.xrpl.xrpl4j.model.transactions.OfferCreate;
+import org.xrpl.xrpl4j.model.transactions.PathStep;
 import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.PaymentChannelClaim;
 import org.xrpl.xrpl4j.model.transactions.PaymentChannelCreate;
@@ -1306,6 +1308,24 @@ public class XrplClientTest {
       .amount(XrpCurrencyAmount.ofDrops(2000L))
       .signingPublicKey("ED5F5AC8B98974A3CA843326D9B88CEBD0560177B973EE0B149F782CFAA06DC66A")
       .build();
+    assertDoesNotThrow(() -> xrplClient.signTransaction(wallet, payment));
+  }
+
+  @Test
+  public void signPaymentWithPaths_DoesNotThrow() {
+    List<PathStep> paths = Lists.newArrayList(
+      PathStep.builder().account(Address.of("rUpy3eEg8rqjqfUoLeBnZkscbKbFsKXC3v")).currency("ABC").build(),
+      PathStep.builder().account(Address.of("rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW")).currency("XYZ").build()
+    );
+    Payment payment = Payment.builder()
+      .account(wallet.classicAddress())
+      .amount(XrpCurrencyAmount.ofDrops(10))
+      .destination(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+      .signingPublicKey(wallet.publicKey())
+      .fee(XrpCurrencyAmount.ofDrops(12))
+      .addPaths(paths)
+      .build();
+
     assertDoesNotThrow(() -> xrplClient.signTransaction(wallet, payment));
   }
 

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/BinarySerializationTests.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/BinarySerializationTests.java
@@ -29,6 +29,7 @@ import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import com.ripple.cryptoconditions.CryptoConditionReader;
 import com.ripple.cryptoconditions.der.DerEncodingException;
+import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.codec.binary.XrplBinaryCodec;
 import org.xrpl.xrpl4j.model.flags.Flags;
@@ -51,6 +52,7 @@ import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;
 import org.xrpl.xrpl4j.model.transactions.OfferCancel;
 import org.xrpl.xrpl4j.model.transactions.OfferCreate;
+import org.xrpl.xrpl4j.model.transactions.PathStep;
 import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.PaymentChannelClaim;
 import org.xrpl.xrpl4j.model.transactions.PaymentChannelCreate;
@@ -60,6 +62,8 @@ import org.xrpl.xrpl4j.model.transactions.SignerListSet;
 import org.xrpl.xrpl4j.model.transactions.Transaction;
 import org.xrpl.xrpl4j.model.transactions.TrustSet;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
+
+import java.util.List;
 
 public class BinarySerializationTests {
 
@@ -487,6 +491,30 @@ public class BinarySerializationTests {
       "96C3580A399F0EE78611C8E3E1EB13000181143A4C02EA95AD6AC3BED92FA036E0BBFB712C030CE1F1";
 
     assertSerializesAndDeserializes(signerListSet, expectedBinary);
+  }
+
+  @Test
+  public void serializePaymentWithPaths() throws JsonProcessingException {
+
+    List<PathStep> paths = Lists.newArrayList(
+      PathStep.builder().account(Address.of("rUpy3eEg8rqjqfUoLeBnZkscbKbFsKXC3v")).currency("ABC").build(),
+      PathStep.builder().account(Address.of("rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW")).currency("XYZ").build()
+    );
+    Payment payment = Payment.builder()
+      .account(Address.of("raKEEVSGnKSD9Zyvxu4z6Pqpm4ABH8FS6n"))
+      .amount(XrpCurrencyAmount.ofDrops(10))
+      .destination(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+      .signingPublicKey("32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A")
+      .fee(XrpCurrencyAmount.ofDrops(12))
+      .addPaths(paths)
+      .build();
+    
+    String expected = "1200002280000000240000000061400000000000000A68400000000000000C732132D2471DB72B27E3310" +
+      "F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A81143A4C02EA95AD6AC3BED92FA036E0BBFB712C030C83144B4E9C0" +
+      "6F24296074F7BC48F92A97916C6DC5EA90112117908A7F0EDD48EA896C3580A399F0EE78611C8E3000000000000000000000000" +
+      "414243000000000011204288D2E47F8EF6C99BCC457966320D1240971100000000000000000000000058595A000000000000";
+
+    assertSerializesAndDeserializes(payment, expected);
   }
 
   private <T extends Transaction> void assertSerializesAndDeserializes(


### PR DESCRIPTION
The library doesn't break when signed a Payment with Paths and also serializes/deserializes it correctly.
Addresses: #82 (first two)