### PR TITLE
remove ledger value checks.

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
@@ -104,8 +104,6 @@ public class AccountTransactionsIT {
         .build()
     );
 
-    assertThat(results.ledgerIndexMinimum()).isEqualTo(minLedger);
-    assertThat(results.ledgerIndexMaximum()).isEqualTo(maxLedger);
     assertThat(results.transactions()).hasSize(7);
     // results are returned in descending sorted order by ledger index
     assertThat(results.transactions().get(0).transaction().ledgerIndex()).isNotEmpty().get()
@@ -154,7 +152,6 @@ public class AccountTransactionsIT {
         .build()
     );
 
-    assertThat(resultByShortcut.ledgerIndexMinimum()).isEqualTo(resultByShortcut.ledgerIndexMaximum());
     assertThat(resultByShortcut.ledgerIndexMinimum().value())
       .isEqualTo(validatedLedgerIndex.unsignedIntegerValue().longValue());
 


### PR DESCRIPTION
These checks were essentially incorrect ( from what I through my conversation with Nathan ). The docs read `earliest ledger actually searched for transactions` and won't guarantee the same values.

This comes to my attention when I ran RPC's on Clio specifically. 