### PR TITLE
remove ledger index asserts from v3 ITs

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/AccountTransactionsIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/AccountTransactionsIT.java
@@ -89,8 +89,6 @@ public class AccountTransactionsIT {
         .build()
     );
 
-    assertThat(results.ledgerIndexMinimum()).isEqualTo(minLedger);
-    assertThat(results.ledgerIndexMaximum()).isEqualTo(maxLedger);
     assertThat(results.transactions()).hasSize(16);
     // results are returned in descending sorted order by ledger index
     assertThat(results.transactions().get(0).resultTransaction().ledgerIndex())
@@ -140,7 +138,6 @@ public class AccountTransactionsIT {
         .build()
     );
 
-    assertThat(resultByShortcut.ledgerIndexMinimum()).isEqualTo(resultByShortcut.ledgerIndexMaximum());
     assertThat(resultByShortcut.ledgerIndexMinimum().value())
       .isEqualTo(validatedLedgerIndex.unsignedIntegerValue().longValue());
 


### PR DESCRIPTION
Apply changes similar to https://github.com/XRPLF/xrpl4j/pull/265/files on the second set of ITs in v3