### PR TITLE
Update FeeUtils logic

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SignerListSetIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SignerListSetIT.java
@@ -43,12 +43,10 @@ import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.Signer;
 import org.xrpl.xrpl4j.model.transactions.SignerListSet;
 import org.xrpl.xrpl4j.model.transactions.SignerWrapper;
-import org.xrpl.xrpl4j.model.transactions.Transaction;
 import org.xrpl.xrpl4j.model.transactions.TransactionResultCodes;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 import org.xrpl.xrpl4j.wallet.Wallet;
 
-import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SubmitMultisignedIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/SubmitMultisignedIT.java
@@ -27,7 +27,6 @@ import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.Signer;
 import org.xrpl.xrpl4j.model.transactions.SignerListSet;
 import org.xrpl.xrpl4j.model.transactions.SignerWrapper;
-import org.xrpl.xrpl4j.model.transactions.Transaction;
 import org.xrpl.xrpl4j.model.transactions.TransactionResultCodes;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 import org.xrpl.xrpl4j.wallet.Wallet;

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/IssuedCurrencyIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/IssuedCurrencyIT.java
@@ -159,7 +159,9 @@ public class IssuedCurrencyIT extends AbstractIT {
 
     ///////////////////////////
     // Send some xrpl4jCoin to the counterparty account.
-    issueBalance(xrpl4jCoin, trustLine.limitPeer(), issuerWallet, counterpartyWallet, calculateFeeDynamically(feeResult));
+    issueBalance(
+      xrpl4jCoin, trustLine.limitPeer(), issuerWallet, counterpartyWallet, calculateFeeDynamically(feeResult)
+    );
 
     ///////////////////////////
     // Validate that the TrustLine balance was updated as a result of the Payment.

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/SignerListSetIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/SignerListSetIT.java
@@ -22,7 +22,6 @@ import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.Signer;
 import org.xrpl.xrpl4j.model.transactions.SignerListSet;
 import org.xrpl.xrpl4j.model.transactions.SignerWrapper;
-import org.xrpl.xrpl4j.model.transactions.Transaction;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
 import java.util.Comparator;

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/TransactUsingDelegatedSignatureService.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/TransactUsingDelegatedSignatureService.java
@@ -26,7 +26,6 @@ import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.Signer;
 import org.xrpl.xrpl4j.model.transactions.SignerListSet;
 import org.xrpl.xrpl4j.model.transactions.SignerWrapper;
-import org.xrpl.xrpl4j.model.transactions.Transaction;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
 import java.util.Comparator;

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/TransactUsingSignatureService.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/v3/TransactUsingSignatureService.java
@@ -29,7 +29,6 @@ import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.Signer;
 import org.xrpl.xrpl4j.model.transactions.SignerListSet;
 import org.xrpl.xrpl4j.model.transactions.SignerWrapper;
-import org.xrpl.xrpl4j.model.transactions.Transaction;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
 import java.util.Comparator;

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/fees/FeeResult.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/fees/FeeResult.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.client.fees;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,8 +33,8 @@ import org.xrpl.xrpl4j.model.jackson.modules.UnsignedIntegerStringDeserializer;
 import java.util.Optional;
 
 /**
- * The result of a "fee" rippled API call, which reports the current state of the open-ledger requirements
- * for the transaction cost.
+ * The result of a "fee" rippled API call, which reports the current state of the open-ledger requirements for the
+ * transaction cost.
  */
 @Immutable
 @JsonSerialize(as = ImmutableFeeResult.class)
@@ -78,8 +78,8 @@ public interface FeeResult extends XrplResult {
   FeeDrops drops();
 
   /**
-   * The approximate number of transactions expected to be included in the current ledger.
-   * This is based on the number of transactions in the previous ledger.
+   * The approximate number of transactions expected to be included in the current ledger. This is based on the number
+   * of transactions in the previous ledger.
    *
    * @return An {@link UnsignedInteger} denoting the expected ledger size.
    */
@@ -106,8 +106,8 @@ public interface FeeResult extends XrplResult {
   FeeLevels levels();
 
   /**
-   * The maximum number of transactions that the transaction queue can currently hold.
-   * Optional because this may not be present on older versions of rippled.
+   * The maximum number of transactions that the transaction queue can currently hold. Optional because this may not be
+   * present on older versions of rippled.
    *
    * @return An optionally-present {@link UnsignedInteger} denoting the maximum queue size.
    */

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/fees/FeeUtils.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/fees/FeeUtils.java
@@ -1,12 +1,46 @@
 package org.xrpl.xrpl4j.model.client.fees;
 
+import static org.xrpl.xrpl4j.model.transactions.CurrencyAmount.MAX_XRP_IN_DROPS;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.primitives.UnsignedLong;
+import org.immutables.value.Value.Derived;
+import org.immutables.value.Value.Immutable;
+import org.xrpl.xrpl4j.model.immutables.FluentCompareTo;
 import org.xrpl.xrpl4j.model.ledger.SignerListObject;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.util.Arrays;
 import java.util.Objects;
 
+/**
+ * Utils relating to XRPL fees.
+ */
 public class FeeUtils {
+
+  private static final BigInteger MAX_UNSIGNED_LONG = UnsignedLong.MAX_VALUE.bigIntegerValue();
+
+  private static final BigDecimal ONE_POINT_ONE = new BigDecimal("1.1");
+
+  private static final BigDecimal ZERO_POINT_ONE = new BigDecimal("0.1");
+
+  private static final BigInteger FIVE_HUNDRED = BigInteger.valueOf(500);
+
+  private static final BigDecimal TWO = new BigDecimal(2);
+
+  private static final BigDecimal THREE = new BigDecimal(3);
+
+  private static final BigInteger FIFTEEN = BigInteger.valueOf(15);
+
+  private static final BigInteger TEN_THOUSAND = BigInteger.valueOf(10000);
+
+  private static final BigInteger ONE_THOUSAND = BigInteger.valueOf(1000);
+
 
   /**
    * Computes the fee necessary for a multisigned transaction.
@@ -30,65 +64,378 @@ public class FeeUtils {
       .times(XrpCurrencyAmount.of(UnsignedLong.valueOf(signerList.signerEntries().size() + 1)));
   }
 
-
   /**
-   * Get value of fee to be used for submitting a transaction on the ledger. The value is calculated depending on the
-   * load on the job queue.
+   * Calculate a suggested fee to be used for submitting a transaction to the XRPL. The calculated value depends on the
+   * current size of the job queue as compared to its total capacity.
    *
-   * @param feeResult {@link FeeResult} object received from XrplClient#fee() rippled call.
+   * @param feeResult {@link FeeResult} object obtained by querying the ledger (e.g., via an `XrplClient#fee()` call).
    *
    * @return {@link XrpCurrencyAmount} value of the fee that should be used for the transaction.
+   *
+   * @sse "https://xrpl.org/fee.html"
+   * @see "https://github.com/XRPL-Labs/XUMM-App/blob/master/src/services/LedgerService.ts#L244"
    */
   public static XrpCurrencyAmount calculateFeeDynamically(final FeeResult feeResult) {
     Objects.requireNonNull(feeResult);
 
-    double currentQueueSize = feeResult.currentQueueSize().doubleValue();
-    double maxQueueSize = feeResult.maxQueueSize().get().doubleValue();
-    double queuePercentage = currentQueueSize / maxQueueSize;
-    FeeDrops drops = feeResult.drops();
-    int minimumFee = drops.minimumFee().value().intValue();
-    int medianFee = drops.medianFee().value().intValue();
-    int openLedgerFee = drops.openLedgerFee().value().intValue();
+    final DecomposedFees decomposedFees = DecomposedFees.builder(feeResult);
+    final BigDecimal queuePercentage = decomposedFees.queuePercentage();
 
-    // calculate the lowest fee the user is able to pay if the queue is empty
-    final long feeLow = Math.round(
-      Math.min(
-        Math.max(
-          minimumFee * 1.5,
-          Math.round(Math.max(medianFee, openLedgerFee) / 500)
-        ),
-        1000
-      )
-    );
+    final UnsignedLong feeLow = computeFeeLow(decomposedFees); // <- empty tx queue
+    final UnsignedLong feeMedium = computeFeeMedium(decomposedFees, feeLow); // <- in-between tx queue size
+    final UnsignedLong feeHigh = computeFeeHigh(decomposedFees); // <- full tx queue
 
-    long possibleFeeMedium;
-    if (queuePercentage > 0.1) {
-      possibleFeeMedium = Math.round((minimumFee + openLedgerFee) / 3);
-    } else if (queuePercentage == 0) {
-      possibleFeeMedium = Math.max(10 * minimumFee, openLedgerFee);
-    } else {
-      possibleFeeMedium = Math.max(10 * minimumFee, Math.round((minimumFee + medianFee) / 2));
-    }
-
-    // calculate the lowest fee the user is able to pay if there are txns in the queue
-    final long feeMedium = Math.round(Math.min(possibleFeeMedium, Math.min((int) (feeLow * 15), 10000)));
-
-    // calculate the lowest fee the user is able to pay if the txn queue is full
-    final long feeHigh = Math.round(Math.min(
-      Math.max(10 * minimumFee, Math.round(Math.max(medianFee, openLedgerFee) * 1.1)),
-      100000
-    ));
-
-    XrpCurrencyAmount fee;
-    if (queuePercentage == 0) {  // if queue is empty
+    final XrpCurrencyAmount fee;
+    if (queueIsEmpty(queuePercentage)) {
+      // queue is empty
       fee = XrpCurrencyAmount.ofDrops(feeLow);
-    } else if (0 < queuePercentage && queuePercentage < 1) {  // queue has txns in it but is not full
+    } else if (queueIsNotEmptyAndNotFull(queuePercentage)) {
       fee = XrpCurrencyAmount.ofDrops(feeMedium);
-    } else {  // if queue is full
+    } else { // queue is full
       fee = XrpCurrencyAmount.ofDrops(feeHigh);
     }
 
     return fee;
   }
 
+  /**
+   * Calculate the lowest fee the user is able to pay if the queue is empty.
+   *
+   * @param decomposedFees A {@link DecomposedFees} that contains information about current XRPL fees.
+   *
+   * @return An {@link UnsignedLong} representing the lowest fee.
+   */
+  private static UnsignedLong computeFeeLow(final DecomposedFees decomposedFees) {
+    Objects.requireNonNull(decomposedFees);
+
+    final BigInteger adjustedMinimumFeeDrops = decomposedFees.adjustedMinimumFeeDrops();
+    final BigInteger medianFee = decomposedFees.medianFeeDrops();
+    final BigInteger openLedgerFee = decomposedFees.openLedgerFeeDrops();
+
+    final UnsignedLong feeLow =
+      toUnsignedLongSafe(
+        min(
+          max(
+            adjustedMinimumFeeDrops, // min fee * 1.50
+            divideToBigInteger(max(medianFee, openLedgerFee), FIVE_HUNDRED)
+          ),
+          ONE_THOUSAND
+        ));
+
+    // Cap `feeLow` to the size of an UnsignedLong.
+    return feeLow;
+  }
+
+  private static UnsignedLong computeFeeMedium(
+    final DecomposedFees decomposedFees,
+    final UnsignedLong feeLow
+  ) {
+    Objects.requireNonNull(decomposedFees);
+    Objects.requireNonNull(feeLow);
+
+    final BigInteger minimumFee = decomposedFees.adjustedMinimumFeeDrops();
+    final BigDecimal minimumFeeBd = decomposedFees.adjustedMinimumFeeDropsAsBigDecimal();
+    final BigDecimal medianFeeBd = decomposedFees.medianFeeDropsAsBigDecimal();
+    final BigInteger openLedgerFee = decomposedFees.openLedgerFeeDrops();
+    final BigDecimal queuePercentage = decomposedFees.queuePercentage();
+
+    final BigInteger possibleFeeMedium;
+    if (FluentCompareTo.is(queuePercentage).greaterThan(ZERO_POINT_ONE)) {
+      final BigDecimal openLedgerFeeBd = decomposedFees.openLedgerFeeDropsAsBigDecimal();
+      possibleFeeMedium = minimumFeeBd.add(openLedgerFeeBd).divide(THREE, 0, RoundingMode.HALF_UP).toBigIntegerExact();
+    } else if (FluentCompareTo.is(queuePercentage).equalTo(BigDecimal.ZERO)) {
+      possibleFeeMedium = max(minimumFee.multiply(BigInteger.TEN), openLedgerFee);
+    } else {
+      BigInteger minMed = minimumFeeBd.add(medianFeeBd).divide(TWO, 0, RoundingMode.HALF_UP).toBigIntegerExact();
+      possibleFeeMedium = max(minimumFee.multiply(BigInteger.TEN), minMed);
+    }
+
+    final BigInteger feeLowTimes15 = feeLow.bigIntegerValue().multiply(FIFTEEN);
+
+    // calculate the lowest fee the user is able to pay if there are txns in the queue
+    final BigInteger feeMedium = min(
+      possibleFeeMedium,
+      feeLowTimes15,
+      TEN_THOUSAND
+    );
+
+    return toUnsignedLongSafe(feeMedium);
+  }
+
+  private static UnsignedLong computeFeeHigh(
+    final DecomposedFees decomposedFees
+  ) {
+    Objects.requireNonNull(decomposedFees);
+
+    final BigInteger minimumFee = decomposedFees.adjustedMinimumFeeDrops();
+    final BigInteger medianFee = decomposedFees.medianFeeDrops();
+    final BigInteger openLedgerFee = decomposedFees.openLedgerFeeDrops();
+
+    final BigInteger highFee = min(
+      max(
+        minimumFee.multiply(BigInteger.TEN),
+        multiplyToBigInteger(
+          max(medianFee, openLedgerFee),
+          ONE_POINT_ONE
+        )
+      ),
+      TEN_THOUSAND
+    );
+    return toUnsignedLongSafe(highFee);
+  }
+
+  /**
+   * Helper method to determine if a transaction queue is empty by inspecting a `percent-full` measurement.
+   *
+   * @param queuePercentage A {@link BigDecimal} representing the percent-full value for a tx queue.
+   *
+   * @return {@code true} if the queue is empty; {@code false} otherwise.
+   */
+  @VisibleForTesting
+  protected static boolean queueIsEmpty(final BigDecimal queuePercentage) {
+    Objects.requireNonNull(queuePercentage);
+    return FluentCompareTo.is(queuePercentage).lessThanOrEqualTo(BigDecimal.ZERO);
+  }
+
+  /**
+   * Helper method to determine if a transaction queue is both non-empty, but not completely full, by inspecting a
+   * `percent-full` measurement.
+   *
+   * @param queuePercentage A {@link BigDecimal} representing the percent-full value for a tx queue.
+   *
+   * @return {@code true} if the queue is empty; {@code false} otherwise.
+   */
+  @VisibleForTesting
+  protected static boolean queueIsNotEmptyAndNotFull(final BigDecimal queuePercentage) {
+    Objects.requireNonNull(queuePercentage);
+    return FluentCompareTo.is(queuePercentage).betweenExclusive(BigDecimal.ZERO, BigDecimal.ONE);
+  }
+
+  /**
+   * Convert {@code value} into an {@link UnsignedLong}.
+   *
+   * @param value A {@link BigInteger} to convert.
+   *
+   * @return An equivalent {@code value} as an {@link UnsignedLong}.
+   */
+  public static UnsignedLong toUnsignedLongSafe(final BigInteger value) {
+    final UnsignedLong valueNotMoreThanMax = UnsignedLong.valueOf(
+      min(value, MAX_UNSIGNED_LONG)
+    );
+    return valueNotMoreThanMax;
+  }
+
+  /**
+   * Pick the smaller of the two supplied inputs.
+   *
+   * @param input1      A {@link BigInteger} to potentially choose as the min (i.e., smallest) value.
+   * @param otherInputs A potentially empty array of {@link BigInteger}'s to compare and potentially choose from.
+   *
+   * @return The smallest value of any supplied inputs, or {@code input1} if that is the only supplied input.
+   */
+  @VisibleForTesting
+  static BigInteger min(final BigInteger input1, final BigInteger... otherInputs) {
+    Objects.requireNonNull(input1);
+    Objects.requireNonNull(otherInputs);
+
+    return Arrays.stream(otherInputs)
+      .min(BigInteger::compareTo)
+      .orElse(input1)
+      .min(input1);
+  }
+
+  /**
+   * Pick the larger of the two supplied inputs.
+   *
+   * @param input1      A {@link BigInteger} to potentially choose as the max (i.e., largest) value.
+   * @param otherInputs A potentially empty array of {@link BigInteger}'s to compare and potentially choose from.
+   *
+   * @return The largest value of any supplied inputs, or {@code input1} if that is the only supplied input.
+   */
+  @VisibleForTesting
+  static BigInteger max(final BigInteger input1, final BigInteger... otherInputs) {
+    Objects.requireNonNull(input1);
+    Objects.requireNonNull(otherInputs);
+
+    return Arrays.stream(otherInputs)
+      .max(BigInteger::compareTo)
+      .orElse(input1)
+      .max(input1);
+  }
+
+  /**
+   * Divides two {@link BigDecimal} numbers and then converts the result into a rounded {@link BigInteger}.
+   *
+   * @param numerator   A {@link BigInteger} numerator for purposes of division.
+   * @param denominator A {@link BigInteger} denominator for purposes of division.
+   *
+   * @return A {@link BigInteger} result.
+   */
+  @VisibleForTesting
+  static BigInteger divideToBigInteger(final BigDecimal numerator, final BigDecimal denominator) {
+    Objects.requireNonNull(numerator);
+    Objects.requireNonNull(denominator);
+    Preconditions.checkArgument(FluentCompareTo.is(denominator).greaterThan(BigDecimal.ZERO));
+    return numerator.divide(denominator, 0, RoundingMode.HALF_UP).toBigIntegerExact();
+  }
+
+  /**
+   * Divides two {@link BigInteger} numbers and then converts the result into a rounded {@link BigInteger}.
+   *
+   * @param numerator   A {@link BigInteger} numerator for purposes of division.
+   * @param denominator A {@link BigInteger} denominator for purposes of division.
+   *
+   * @return A {@link BigInteger} result.
+   */
+  @VisibleForTesting
+  static BigInteger divideToBigInteger(final BigInteger numerator, final BigInteger denominator) {
+    return divideToBigInteger(
+      new BigDecimal(numerator), new BigDecimal(denominator)
+    );
+  }
+
+  /**
+   * Multiply input1 {@link BigInteger} by input1 {@link BigDecimal} and then return the result as input1 rounded
+   * {@link BigInteger}.
+   *
+   * @param input1 The first {@link BigInteger}.
+   * @param input2 The second {@link BigInteger}.
+   *
+   * @return The multiplied amount.
+   */
+  @VisibleForTesting
+  static BigInteger multiplyToBigInteger(final BigInteger input1, final BigDecimal input2) {
+    Objects.requireNonNull(input1);
+    Objects.requireNonNull(input2);
+    return new BigDecimal(input1).multiply(input2).setScale(0, RoundingMode.HALF_UP).toBigIntegerExact();
+  }
+
+  /**
+   * Helper object that exists solely to aid fee calculation so that BigInteger/BigDecimal objects don't have to be
+   * created more than once per call, and to put data into a state that simplifies fee calculation logic.
+   */
+  @Immutable
+  interface DecomposedFees {
+
+    BigDecimal ONE_POINT_FIVE = new BigDecimal("1.5");
+    BigInteger MAX_XRP_IN_DROPS_BIG_INT = BigInteger.valueOf(MAX_XRP_IN_DROPS);
+
+    /**
+     * Build a new instance of {@link DecomposedFees} from the supplied input.
+     *
+     * @param feeResult A {@link FeeResult} to use as input.
+     *
+     * @return A {@link DecomposedFees}.
+     */
+    static DecomposedFees builder(final FeeResult feeResult) {
+      Objects.requireNonNull(feeResult);
+
+      final BigDecimal currentQueueSize = new BigDecimal(feeResult.currentQueueSize().bigIntegerValue());
+      final BigDecimal maxQueueSize = feeResult.maxQueueSize()
+        .map($ -> new BigDecimal($.bigIntegerValue()))
+        .orElse(new BigDecimal(5000)); // Arbitrary value, but should generally be present.
+      // Don't divide by 0
+      final BigDecimal queuePercentage = FluentCompareTo.is(currentQueueSize).equalTo(BigDecimal.ZERO) ?
+        BigDecimal.ZERO :
+        currentQueueSize.divide(maxQueueSize, MathContext.DECIMAL128);
+
+      return builder(feeResult.drops(), queuePercentage);
+    }
+
+    /**
+     * Build a new instance of {@link DecomposedFees} from the supplied input.
+     *
+     * @param feeDrops        A {@link FeeDrops} to use as input.
+     * @param queuePercentage A {@link BigDecimal} representing how full the transaction queue is.
+     *
+     * @return A {@link DecomposedFees}.
+     */
+    static DecomposedFees builder(
+      final FeeDrops feeDrops,
+      final BigDecimal queuePercentage
+    ) {
+      Objects.requireNonNull(feeDrops);
+      Objects.requireNonNull(queuePercentage);
+      Preconditions.checkArgument(FluentCompareTo.is(queuePercentage).greaterThanEqualTo(BigDecimal.ZERO));
+      Preconditions.checkArgument(FluentCompareTo.is(queuePercentage).lessThanOrEqualTo(BigDecimal.ONE));
+
+      // Min fee should be about 50% larger (rounded) than the indicated min.
+      final BigInteger adjustedMinimumFeeDrops =
+        min(
+          MAX_XRP_IN_DROPS_BIG_INT,
+          new BigDecimal(feeDrops.minimumFee().value().bigIntegerValue())
+            .multiply(ONE_POINT_FIVE)
+            .setScale(0, RoundingMode.HALF_DOWN)
+            .toBigIntegerExact()
+        );
+
+      return ImmutableDecomposedFees.builder()
+        .adjustedMinimumFeeDrops(adjustedMinimumFeeDrops)
+        .medianFeeDrops(feeDrops.medianFee().value().bigIntegerValue())
+        .openLedgerFeeDrops(feeDrops.openLedgerFee().value().bigIntegerValue())
+        .queuePercentage(queuePercentage)
+        .build();
+    }
+
+    /**
+     * The minimum ledger fee as found in the supplied {@link FeeDrops} that was used to construct this instance.,
+     * adjusted to be at least 50% larger than what was supplied in order to provide a buffer for fee calcuations.
+     *
+     * @return A {@link BigInteger} representing the adjusted minimum fee (in drops).
+     */
+    BigInteger adjustedMinimumFeeDrops();
+
+    /**
+     * An equivalent of {@link #adjustedMinimumFeeDrops()}, but as a {@link BigDecimal}.
+     *
+     * @return A {@link BigDecimal} representing the adjusted minimum transaction fee on ledger (in drops).
+     */
+    @Derived
+    default BigDecimal adjustedMinimumFeeDropsAsBigDecimal() {
+      return new BigDecimal(adjustedMinimumFeeDrops());
+    }
+
+    /**
+     * The median ledger fee as found in the supplied {@link FeeDrops} that was used to construct this instance.
+     *
+     * @return A {@link BigInteger} representing the median transaction fee on ledger (in drops).
+     */
+    BigInteger medianFeeDrops();
+
+    /**
+     * An equivalent of {@link #medianFeeDrops()}, but as a {@link BigDecimal}.
+     *
+     * @return A {@link BigDecimal} representing the median transaction fee on ledger (in drops).
+     */
+    @Derived
+    default BigDecimal medianFeeDropsAsBigDecimal() {
+      return new BigDecimal(medianFeeDrops());
+    }
+
+    /**
+     * The open ledger fee as found in the supplied {@link FeeDrops} that was used to construct this instance.
+     *
+     * @return A {@link BigInteger} representing open ledger fee on ledger (in drops).
+     */
+    BigInteger openLedgerFeeDrops();
+
+    /**
+     * An equivalent of {@link #openLedgerFeeDrops()}, but as a {@link BigDecimal}.
+     *
+     * @return A {@link BigInteger} representing open ledger fee on ledger (in drops).
+     */
+    @Derived
+    default BigDecimal openLedgerFeeDropsAsBigDecimal() {
+      return new BigDecimal(openLedgerFeeDrops());
+    }
+
+    /**
+     * Measures the fullness of the transaction queue by representing the percent full that the queue is. For example,
+     * if the transaction queue can hold two transactions, and one is in the queue, then this value would be 50%, or
+     * 0.5.
+     *
+     * @return A {@link BigDecimal}.
+     */
+    BigDecimal queuePercentage();
+  }
 }

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/fees/FeeUtils.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/fees/FeeUtils.java
@@ -75,7 +75,7 @@ public class FeeUtils {
    *
    * @return {@link XrpCurrencyAmount} value of the fee that should be used for the transaction.
    *
-   * @sse "https://xrpl.org/fee.html"
+   * @see "https://xrpl.org/fee.html"
    * @see "https://github.com/XRPL-Labs/XUMM-App/blob/master/src/services/LedgerService.ts#L244"
    */
   public static XrpCurrencyAmount calculateFeeDynamically(final FeeResult feeResult) {

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/fees/FeeUtils.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/fees/FeeUtils.java
@@ -56,8 +56,10 @@ public class FeeUtils {
    *
    * @return An {@link XrpCurrencyAmount} representing the multisig fee.
    */
-  public static XrpCurrencyAmount computeMultiSigFee(final XrpCurrencyAmount currentLedgerFeeDrops,
-    final SignerListObject signerList) {
+  public static XrpCurrencyAmount computeMultiSigFee(
+    final XrpCurrencyAmount currentLedgerFeeDrops,
+    final SignerListObject signerList
+  ) {
     Objects.requireNonNull(currentLedgerFeeDrops);
     Objects.requireNonNull(signerList);
 

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/fees/FeeUtils.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/client/fees/FeeUtils.java
@@ -213,7 +213,9 @@ public class FeeUtils {
    * @return An equivalent {@code value} as an {@link UnsignedLong}, or {@link UnsignedLong#MAX_VALUE} if the input
    *   would overflow during conversion.
    */
-  public static UnsignedLong toUnsignedLongSafe(final BigInteger value) {
+  // TODO: Move to MathUtils once all v3 modules are condensed and MathUtils is accessible.
+  @VisibleForTesting
+  static UnsignedLong toUnsignedLongSafe(final BigInteger value) {
     Objects.requireNonNull(value);
     final UnsignedLong valueNotMoreThanMax = UnsignedLong.valueOf(min(value, MAX_UNSIGNED_LONG));
     return valueNotMoreThanMax;
@@ -227,6 +229,7 @@ public class FeeUtils {
    *
    * @return The smallest value of any supplied inputs, or {@code input1} if that is the only supplied input.
    */
+  // TODO: Move to MathUtils once all v3 modules are condensed and MathUtils is accessible.
   @VisibleForTesting
   static BigInteger min(final BigInteger input1, final BigInteger... otherInputs) {
     Objects.requireNonNull(input1);
@@ -243,6 +246,7 @@ public class FeeUtils {
    *
    * @return The largest value of any supplied inputs, or {@code input1} if that is the only supplied input.
    */
+  // TODO: Move to MathUtils once all v3 modules are condensed and MathUtils is accessible.
   @VisibleForTesting
   static BigInteger max(final BigInteger input1, final BigInteger... otherInputs) {
     Objects.requireNonNull(input1);

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmount.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmount.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.transactions;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,13 +31,17 @@ import java.util.function.Function;
  */
 public interface CurrencyAmount {
 
+  long ONE_XRP_IN_DROPS = 1_000_000L;
+  long MAX_XRP = 100_000_000_000L; // <-- per https://xrpl.org/rippleapi-reference.html#value
+  long MAX_XRP_IN_DROPS = MAX_XRP * ONE_XRP_IN_DROPS;
+
   /**
    * Handle this {@link CurrencyAmount} depending on its actual polymorphic sub-type.
    *
-   * @param xrpCurrencyAmountHandler     A {@link Consumer} that is called if this instance is of type {@link
-   *                                     XrpCurrencyAmount}.
-   * @param issuedCurrencyAmountConsumer A {@link Consumer} that is called if this instance is of type {@link
-   *                                     IssuedCurrencyAmount}.
+   * @param xrpCurrencyAmountHandler     A {@link Consumer} that is called if this instance is of type
+   *                                     {@link XrpCurrencyAmount}.
+   * @param issuedCurrencyAmountConsumer A {@link Consumer} that is called if this instance is of type
+   *                                     {@link IssuedCurrencyAmount}.
    */
   default void handle(
     final Consumer<XrpCurrencyAmount> xrpCurrencyAmountHandler,
@@ -58,10 +62,10 @@ public interface CurrencyAmount {
   /**
    * Map this {@link CurrencyAmount} to an instance of {@link R}, depending on its actualy polymorphic sub-type.
    *
-   * @param xrpCurrencyAmountMapper    A {@link Function} that is called if this instance is of type {@link
-   *                                   XrpCurrencyAmount}.
-   * @param issuedCurrencyAmountMapper A {@link Function} that is called if this instance is  of type {@link
-   *                                   IssuedCurrencyAmount}.
+   * @param xrpCurrencyAmountMapper    A {@link Function} that is called if this instance is of type
+   *                                   {@link XrpCurrencyAmount}.
+   * @param issuedCurrencyAmountMapper A {@link Function} that is called if this instance is  of type
+   *                                   {@link IssuedCurrencyAmount}.
    * @param <R>                        The type of object to return after mapping.
    *
    * @return A {@link R} that is constructed by the appropriate mapper function.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.transactions;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -61,7 +61,7 @@ public class Wrappers {
      */
     @Value.Check
     public void validateAddress() {
-      Preconditions.checkArgument(this.value().startsWith("r"),"Invalid Address: Bad Prefix");
+      Preconditions.checkArgument(this.value().startsWith("r"), "Invalid Address: Bad Prefix");
       Preconditions.checkArgument(this.value().length() >= 25 && this.value().length() <= 35,
         "Classic Addresses must be (25,35) characters long inclusive.");
     }
@@ -133,8 +133,22 @@ public class Wrappers {
   @JsonDeserialize(as = XrpCurrencyAmount.class)
   abstract static class _XrpCurrencyAmount extends Wrapper<UnsignedLong> implements Serializable, CurrencyAmount {
 
+    /**
+     * @deprecated Prefer {@link CurrencyAmount#ONE_XRP_IN_DROPS}.
+     */
+    @Deprecated
     static final long ONE_XRP_IN_DROPS = 1_000_000L;
+
+    /**
+     * @deprecated Prefer {@link CurrencyAmount#MAX_XRP}.
+     */
+    @Deprecated
     static final long MAX_XRP = 100_000_000_000L; // <-- per https://xrpl.org/rippleapi-reference.html#value
+
+    /**
+     * @deprecated Prefer {@link CurrencyAmount#MAX_XRP_IN_DROPS}.
+     */
+    @Deprecated
     static final long MAX_XRP_IN_DROPS = MAX_XRP * ONE_XRP_IN_DROPS;
     static final BigDecimal SMALLEST_XRP = new BigDecimal("0.000001");
     static final DecimalFormat FORMATTER = new DecimalFormat("###,###");

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -134,22 +134,29 @@ public class Wrappers {
   abstract static class _XrpCurrencyAmount extends Wrapper<UnsignedLong> implements Serializable, CurrencyAmount {
 
     /**
+     * One XRP, in drops.
+     *
      * @deprecated Prefer {@link CurrencyAmount#ONE_XRP_IN_DROPS}.
      */
     @Deprecated
     static final long ONE_XRP_IN_DROPS = 1_000_000L;
 
     /**
+     * The largest XRP amount.
+     *
      * @deprecated Prefer {@link CurrencyAmount#MAX_XRP}.
      */
     @Deprecated
     static final long MAX_XRP = 100_000_000_000L; // <-- per https://xrpl.org/rippleapi-reference.html#value
 
     /**
+     * The largest XRP amount, in drops.
+     *
      * @deprecated Prefer {@link CurrencyAmount#MAX_XRP_IN_DROPS}.
      */
     @Deprecated
     static final long MAX_XRP_IN_DROPS = MAX_XRP * ONE_XRP_IN_DROPS;
+
     static final BigDecimal SMALLEST_XRP = new BigDecimal("0.000001");
     static final DecimalFormat FORMATTER = new DecimalFormat("###,###");
 
@@ -196,8 +203,8 @@ public class Wrappers {
      * @return A {@link BigDecimal} representing this value denominated in whole XRP units.
      */
     public BigDecimal toXrp() {
-      return new BigDecimal(this.value().bigIntegerValue())
-        .divide(BigDecimal.valueOf(ONE_XRP_IN_DROPS), MathContext.DECIMAL128);
+      return new BigDecimal(this.value().bigIntegerValue()).divide(BigDecimal.valueOf(ONE_XRP_IN_DROPS),
+        MathContext.DECIMAL128);
     }
 
     /**
@@ -243,11 +250,9 @@ public class Wrappers {
      */
     @Value.Check
     protected void check() {
-      Preconditions.checkState(
-        FluentCompareTo.is(value()).lessThanOrEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS)),
-        String.format(
-          "XRP Amounts may not exceed %s drops (100B XRP, denominated in Drops)", FORMATTER.format(MAX_XRP_IN_DROPS))
-      );
+      Preconditions.checkState(FluentCompareTo.is(value()).lessThanOrEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS)),
+        String.format("XRP Amounts may not exceed %s drops (100B XRP, denominated in Drops)",
+          FORMATTER.format(MAX_XRP_IN_DROPS)));
     }
 
   }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/fees/DecomposedFeesTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/fees/DecomposedFeesTest.java
@@ -1,0 +1,151 @@
+package org.xrpl.xrpl4j.model.client.fees;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+import static org.xrpl.xrpl4j.model.client.fees.FeeUtils.DecomposedFees.MAX_XRP_IN_DROPS_BIG_INT;
+import static org.xrpl.xrpl4j.model.transactions.CurrencyAmount.MAX_XRP_IN_DROPS;
+
+import com.google.common.primitives.UnsignedInteger;
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Optional;
+
+/**
+ * Unit tests for {@link FeeUtils.DecomposedFees}.
+ */
+public class DecomposedFeesTest {
+
+  @Mock
+  FeeDrops feeDropsMock;
+
+  @Mock
+  FeeResult feeResultMock;
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+
+    when(feeResultMock.drops()).thenReturn(feeDropsMock);
+    when(feeResultMock.currentQueueSize()).thenReturn(UnsignedInteger.ZERO);
+    when(feeResultMock.maxQueueSize()).thenReturn(Optional.of(UnsignedInteger.ONE));
+
+    when(feeDropsMock.minimumFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.ZERO).build());
+    when(feeDropsMock.medianFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.ZERO).build());
+    when(feeDropsMock.openLedgerFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.ZERO).build());
+  }
+
+  @Test
+  void buildWithZeroFees() {
+    when(feeDropsMock.minimumFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.ZERO).build());
+    when(feeDropsMock.medianFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.ZERO).build());
+    when(feeDropsMock.openLedgerFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.ZERO).build());
+
+    FeeUtils.DecomposedFees decomposedFees = FeeUtils.DecomposedFees.builder(feeResultMock);
+
+    assertThat(decomposedFees.adjustedMinimumFeeDrops()).isEqualTo(BigInteger.ZERO);
+    assertThat(decomposedFees.adjustedMinimumFeeDropsAsBigDecimal()).isEqualTo(BigDecimal.ZERO);
+    assertThat(decomposedFees.medianFeeDrops()).isEqualTo(BigInteger.ZERO);
+    assertThat(decomposedFees.medianFeeDropsAsBigDecimal()).isEqualTo(BigDecimal.ZERO);
+    assertThat(decomposedFees.openLedgerFeeDrops()).isEqualTo(BigInteger.ZERO);
+    assertThat(decomposedFees.openLedgerFeeDropsAsBigDecimal()).isEqualTo(BigDecimal.ZERO);
+  }
+
+  @Test
+  void buildWithOneFees() {
+    when(feeDropsMock.minimumFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.ONE).build());
+    when(feeDropsMock.medianFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.ONE).build());
+    when(feeDropsMock.openLedgerFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.ONE).build());
+
+    FeeUtils.DecomposedFees decomposedFees = FeeUtils.DecomposedFees.builder(feeResultMock);
+
+    assertThat(decomposedFees.adjustedMinimumFeeDrops()).isEqualTo(BigInteger.ONE);
+    assertThat(decomposedFees.adjustedMinimumFeeDropsAsBigDecimal()).isEqualTo(BigDecimal.ONE);
+    assertThat(decomposedFees.medianFeeDrops()).isEqualTo(BigInteger.ONE);
+    assertThat(decomposedFees.medianFeeDropsAsBigDecimal()).isEqualTo(BigDecimal.ONE);
+    assertThat(decomposedFees.openLedgerFeeDrops()).isEqualTo(BigInteger.ONE);
+    assertThat(decomposedFees.openLedgerFeeDropsAsBigDecimal()).isEqualTo(BigDecimal.ONE);
+  }
+
+  @Test
+  void buildWithTenFees() {
+    when(feeDropsMock.minimumFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.valueOf(10L)).build());
+    when(feeDropsMock.medianFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.valueOf(10L)).build());
+    when(feeDropsMock.openLedgerFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.valueOf(10L)).build());
+
+    FeeUtils.DecomposedFees decomposedFees = FeeUtils.DecomposedFees.builder(feeResultMock);
+
+    assertThat(decomposedFees.adjustedMinimumFeeDrops()).isEqualTo(BigInteger.valueOf(15L));
+    assertThat(decomposedFees.adjustedMinimumFeeDropsAsBigDecimal()).isEqualTo(BigDecimal.valueOf(15L));
+    assertThat(decomposedFees.medianFeeDrops()).isEqualTo(BigInteger.valueOf(10L));
+    assertThat(decomposedFees.medianFeeDropsAsBigDecimal()).isEqualTo(BigDecimal.valueOf(10L));
+    assertThat(decomposedFees.openLedgerFeeDrops()).isEqualTo(BigInteger.valueOf(10L));
+    assertThat(decomposedFees.openLedgerFeeDropsAsBigDecimal()).isEqualTo(BigDecimal.valueOf(10L));
+  }
+
+  @Test
+  void buildWithMaxFees() {
+    when(feeResultMock.currentQueueSize()).thenReturn(UnsignedInteger.MAX_VALUE);
+    when(feeResultMock.maxQueueSize()).thenReturn(Optional.of(UnsignedInteger.MAX_VALUE));
+
+    final UnsignedLong maxFees = UnsignedLong.valueOf(MAX_XRP_IN_DROPS);
+    when(feeDropsMock.minimumFee()).thenReturn(
+      XrpCurrencyAmount.builder().value(maxFees).build());
+    when(feeDropsMock.medianFee()).thenReturn(
+      XrpCurrencyAmount.builder().value(maxFees).build());
+    when(feeDropsMock.openLedgerFee()).thenReturn(
+      XrpCurrencyAmount.builder().value(maxFees).build());
+
+    FeeUtils.DecomposedFees decomposedFees = FeeUtils.DecomposedFees.builder(feeResultMock);
+
+    assertThat(decomposedFees.adjustedMinimumFeeDrops()).isEqualTo(MAX_XRP_IN_DROPS_BIG_INT);
+    assertThat(decomposedFees.adjustedMinimumFeeDropsAsBigDecimal())
+      .isEqualTo(new BigDecimal(maxFees.bigIntegerValue()));
+    assertThat(decomposedFees.medianFeeDrops()).isEqualTo(MAX_XRP_IN_DROPS_BIG_INT);
+    assertThat(decomposedFees.medianFeeDropsAsBigDecimal())
+      .isEqualTo(new BigDecimal(maxFees.bigIntegerValue()));
+    assertThat(decomposedFees.openLedgerFeeDrops()).isEqualTo(MAX_XRP_IN_DROPS_BIG_INT);
+    assertThat(decomposedFees.openLedgerFeeDropsAsBigDecimal())
+      .isEqualTo(new BigDecimal(maxFees.bigIntegerValue()));
+  }
+
+  @Test
+  void buildWithEmptyMaxQueueSize() {
+    when(feeResultMock.currentQueueSize()).thenReturn(UnsignedInteger.ONE);
+    when(feeResultMock.maxQueueSize()).thenReturn(Optional.empty());
+
+    when(feeDropsMock.minimumFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.ONE).build());
+    when(feeDropsMock.medianFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.ONE).build());
+    when(feeDropsMock.openLedgerFee()).thenReturn(XrpCurrencyAmount.builder().value(UnsignedLong.ONE).build());
+
+    FeeUtils.DecomposedFees decomposedFees = FeeUtils.DecomposedFees.builder(feeResultMock);
+
+    assertThat(decomposedFees.adjustedMinimumFeeDrops()).isEqualTo(BigInteger.ONE);
+    assertThat(decomposedFees.adjustedMinimumFeeDropsAsBigDecimal()).isEqualTo(BigDecimal.ONE);
+    assertThat(decomposedFees.medianFeeDrops()).isEqualTo(BigInteger.ONE);
+    assertThat(decomposedFees.medianFeeDropsAsBigDecimal()).isEqualTo(BigDecimal.ONE);
+    assertThat(decomposedFees.openLedgerFeeDrops()).isEqualTo(BigInteger.ONE);
+    assertThat(decomposedFees.openLedgerFeeDropsAsBigDecimal()).isEqualTo(BigDecimal.ONE);
+  }
+
+  @Test
+  void buildWithNegativeQueuePercentage() {
+    when(feeResultMock.currentQueueSize()).thenReturn(UnsignedInteger.ONE);
+    when(feeResultMock.maxQueueSize()).thenReturn(Optional.empty());
+
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      FeeUtils.DecomposedFees.builder(feeDropsMock, BigDecimal.valueOf(-1));
+    });
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      FeeUtils.DecomposedFees.builder(feeDropsMock, BigDecimal.valueOf(1.1));
+    });
+  }
+
+}

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/fees/FeeUtilsTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/client/fees/FeeUtilsTest.java
@@ -230,6 +230,96 @@ public class FeeUtilsTest {
   }
 
   @Test
+  public void calculateFeeUsingXummTestValuesForLow() {
+    FeeResult feeResult = FeeResult.builder()
+      .currentLedgerSize(UnsignedInteger.valueOf(1))
+      .currentQueueSize(UnsignedInteger.valueOf(0))
+      .drops(
+        FeeDrops.builder()
+          .baseFee(XrpCurrencyAmount.ofDrops(10))
+          .medianFee(XrpCurrencyAmount.ofDrops(5000))
+          .minimumFee(XrpCurrencyAmount.ofDrops(10))
+          .openLedgerFee(XrpCurrencyAmount.ofDrops(5343))
+          .build()
+      )
+      .expectedLedgerSize(UnsignedInteger.valueOf(10))
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(26575101)))
+      .levels(
+        FeeLevels.builder()
+          .medianLevel(XrpCurrencyAmount.ofDrops(256000))
+          .minimumLevel(XrpCurrencyAmount.ofDrops(10))
+          .openLedgerLevel(XrpCurrencyAmount.ofDrops(67940792))
+          .referenceLevel(XrpCurrencyAmount.ofDrops(256))
+          .build()
+      )
+      .maxQueueSize(UnsignedInteger.valueOf(2000))
+      .status("success")
+      .build();
+
+    assertThat(calculateFeeDynamically(feeResult)).isEqualTo(XrpCurrencyAmount.ofDrops(15));
+  }
+
+  @Test
+  public void calculateFeeUsingXummTestValuesForMedium() {
+    FeeResult feeResult = FeeResult.builder()
+      .currentLedgerSize(UnsignedInteger.valueOf(1))
+      .currentQueueSize(UnsignedInteger.valueOf(1924))
+      .drops(
+        FeeDrops.builder()
+          .baseFee(XrpCurrencyAmount.ofDrops(10))
+          .medianFee(XrpCurrencyAmount.ofDrops(5000))
+          .minimumFee(XrpCurrencyAmount.ofDrops(10))
+          .openLedgerFee(XrpCurrencyAmount.ofDrops(5343))
+          .build()
+      )
+      .expectedLedgerSize(UnsignedInteger.valueOf(10))
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(26575101)))
+      .levels(
+        FeeLevels.builder()
+          .medianLevel(XrpCurrencyAmount.ofDrops(256000))
+          .minimumLevel(XrpCurrencyAmount.ofDrops(10))
+          .openLedgerLevel(XrpCurrencyAmount.ofDrops(67940792))
+          .referenceLevel(XrpCurrencyAmount.ofDrops(256))
+          .build()
+      )
+      .maxQueueSize(UnsignedInteger.valueOf(2000))
+      .status("success")
+      .build();
+
+    assertThat(calculateFeeDynamically(feeResult)).isEqualTo(XrpCurrencyAmount.ofDrops(225));
+  }
+
+  @Test
+  public void calculateFeeUsingXummTestValuesForHigh() {
+    FeeResult feeResult = FeeResult.builder()
+      .currentLedgerSize(UnsignedInteger.valueOf(1))
+      .currentQueueSize(UnsignedInteger.valueOf(2000))
+      .drops(
+        FeeDrops.builder()
+          .baseFee(XrpCurrencyAmount.ofDrops(10))
+          .medianFee(XrpCurrencyAmount.ofDrops(5000))
+          .minimumFee(XrpCurrencyAmount.ofDrops(10))
+          .openLedgerFee(XrpCurrencyAmount.ofDrops(5343))
+          .build()
+      )
+      .expectedLedgerSize(UnsignedInteger.valueOf(10))
+      .ledgerCurrentIndex(LedgerIndex.of(UnsignedInteger.valueOf(26575101)))
+      .levels(
+        FeeLevels.builder()
+          .medianLevel(XrpCurrencyAmount.ofDrops(256000))
+          .minimumLevel(XrpCurrencyAmount.ofDrops(10))
+          .openLedgerLevel(XrpCurrencyAmount.ofDrops(67940792))
+          .referenceLevel(XrpCurrencyAmount.ofDrops(256))
+          .build()
+      )
+      .maxQueueSize(UnsignedInteger.valueOf(2000))
+      .status("success")
+      .build();
+
+    assertThat(calculateFeeDynamically(feeResult)).isEqualTo(XrpCurrencyAmount.ofDrops(5877));
+  }
+
+  @Test
   void testQueueIsEmpty() {
     assertThrows(
       NullPointerException.class,

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmountTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmountTest.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.transactions;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -132,5 +132,12 @@ public class CurrencyAmountTest {
     assertThrows(NullPointerException.class, () ->
       issuedCurrencyAmount.map(($) -> new Object(), null)
     );
+  }
+
+  @Test
+  void testConstants() {
+    assertThat(CurrencyAmount.ONE_XRP_IN_DROPS).isEqualTo(1_000_000L);
+    assertThat(CurrencyAmount.MAX_XRP).isEqualTo(100_000_000_000L);
+    assertThat(CurrencyAmount.MAX_XRP_IN_DROPS).isEqualTo(100_000_000_000_000_000L);
   }
 }


### PR DESCRIPTION
1. Use `BigInteger` and `BigDecimal` instead of double for more precise arithmetic.
2. Replicate more faithfully the fee computation logic from [Xumm](https://github.com/XRPL-Labs/XUMM-App/blob/master/src/services/LedgerService.ts#L244).