### PR TITLE
Set UnlModify.account to ACCOUNT_ZERO to avoid deserialization issues

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/LedgerResultIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/LedgerResultIT.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.tests;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,13 +30,19 @@ import org.xrpl.xrpl4j.model.client.common.LedgerSpecifier;
 import org.xrpl.xrpl4j.model.client.ledger.LedgerRequestParams;
 import org.xrpl.xrpl4j.model.client.ledger.LedgerResult;
 import org.xrpl.xrpl4j.model.client.transactions.TransactionResult;
+import org.xrpl.xrpl4j.model.transactions.Transaction;
+import org.xrpl.xrpl4j.model.transactions.UnlModify;
 import org.xrpl.xrpl4j.tests.environment.MainnetEnvironment;
+
+import java.util.Optional;
 
 /**
  * These tests ensure {@link LedgerResult}s can be constructed from all of the different JSON responses
  * rippled sends back.
  */
 public class LedgerResultIT extends AbstractIT {
+
+  final XrplClient mainnetClient = new MainnetEnvironment().getXrplClient();
 
   @Test
   void getValidatedLedgerResult() throws JsonRpcClientErrorException {
@@ -95,8 +101,6 @@ public class LedgerResultIT extends AbstractIT {
 
   @Test
   void getLedgerResult() throws JsonRpcClientErrorException {
-
-    final XrplClient mainnetClient = new MainnetEnvironment().getXrplClient();
     final LedgerResult ledgerResult = mainnetClient.ledger(LedgerRequestParams.builder()
       .ledgerSpecifier(LedgerSpecifier.VALIDATED)
       .transactions(true)
@@ -113,5 +117,28 @@ public class LedgerResultIT extends AbstractIT {
     );
     assertThat(ledgerResult.ledger().closeTimeHuman()).isNotEmpty();
     assertThat(ledgerResult.ledger().parentCloseTime()).isNotEmpty();
+  }
+
+  /**
+   * This test ensures that <a href="https://github.com/XRPLF/xrpl4j/issues/288">xrpl4j-228</a> has been fixed.
+   * This issue states that {@link LedgerResult}s which contain {@link org.xrpl.xrpl4j.model.transactions.UnlModify}
+   * transactions fail to get deserialized and therefore calls to {@link XrplClient#ledger(LedgerRequestParams)}
+   * fail. This test queries the ledgers found in the issue make sure xrpl4j can deserialize those ledgers.
+   */
+  @Test
+  void getLedgerResultWithTransactionsForLedgerWithUnlModify() throws JsonRpcClientErrorException {
+    LedgerResult ledgerResult = mainnetClient.ledger(
+      LedgerRequestParams.builder()
+        .ledgerSpecifier(LedgerSpecifier.of(73151744))
+        .transactions(true)
+        .build()
+    );
+
+    Optional<? extends Transaction> foundUnlModify = ledgerResult.ledger().transactions().stream()
+      .map(TransactionResult::transaction)
+      .filter(transaction -> UnlModify.class.isAssignableFrom(transaction.getClass()))
+      .findFirst();
+
+    assertThat(foundUnlModify).isNotEmpty().get().extracting("account").isEqualTo(UnlModify.ACCOUNT_ZERO);
   }
 }

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/LedgerResultIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/LedgerResultIT.java
@@ -120,7 +120,7 @@ public class LedgerResultIT extends AbstractIT {
   }
 
   /**
-   * This test ensures that <a href="https://github.com/XRPLF/xrpl4j/issues/288">xrpl4j-228</a> has been fixed.
+   * This test ensures that <a href="https://github.com/XRPLF/xrpl4j/issues/288">xrpl4j-288</a> has been fixed.
    * This issue states that {@link LedgerResult}s which contain {@link org.xrpl.xrpl4j.model.transactions.UnlModify}
    * transactions fail to get deserialized and therefore calls to {@link XrplClient#ledger(LedgerRequestParams)}
    * fail. This test queries the ledgers found in the issue make sure xrpl4j can deserialize those ledgers.

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/UnlModify.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/UnlModify.java
@@ -18,6 +18,8 @@ import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 @JsonDeserialize(as = ImmutableUnlModify.class)
 public interface UnlModify extends Transaction {
 
+  Address ACCOUNT_ZERO = Address.of("rrrrrrrrrrrrrrrrrrrrrhoLvTp");
+
   /**
    * Construct a builder for this class.
    *
@@ -27,6 +29,23 @@ public interface UnlModify extends Transaction {
     return ImmutableUnlModify.builder();
   }
 
+
+  /**
+   * This field is overridden in this class because of a bug in rippled that causes this field to be missing
+   * in API responses. In other pseudo-transactions such as {@link SetFee} and {@link EnableAmendment}, the rippled
+   * API sets the {@code account} field to a special XRPL address called ACCOUNT_ZERO, which is the base58
+   * encoding of the number zero. Because rippled does not set the {@code account} field of the {@link UnlModify}
+   * pseudo-transaction, this override will always set the field to ACCOUNT_ZERO to avoid deserialization issues
+   * and to be consistent with other pseudo-transactions.
+   *
+   * @return Always returns ACCOUNT_ZERO, which is the base58 encoding of the number zero.
+   */
+  @Override
+  @JsonProperty("Account")
+  @Value.Derived
+  default Address account() {
+    return ACCOUNT_ZERO;
+  }
 
   /**
    * The {@link org.xrpl.xrpl4j.model.client.common.LedgerIndex} where this pseudo-transaction appears.

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/UnlModifyTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/UnlModifyTest.java
@@ -13,7 +13,6 @@ public class UnlModifyTest {
   public void testBuilder() {
     String validator = "EDB6FC8E803EE8EDC2793F1EC917B2EE41D35255618DEB91D3F9B1FC89B75D4539";
     UnlModify unlModify = UnlModify.builder()
-      .account(Address.of("rrrrrrrrrrrrrrrrrrrrrhoLvTp"))
       .fee(XrpCurrencyAmount.ofDrops(12))
       .sequence(UnsignedInteger.valueOf(2470665))
       .signingPublicKey("")
@@ -23,7 +22,7 @@ public class UnlModifyTest {
       .build();
 
     assertThat(unlModify.transactionType()).isEqualTo(TransactionType.UNL_MODIFY);
-    assertThat(unlModify.account()).isEqualTo(Address.of("rrrrrrrrrrrrrrrrrrrrrhoLvTp"));
+    assertThat(unlModify.account()).isEqualTo(UnlModify.ACCOUNT_ZERO);
     assertThat(unlModify.fee().value()).isEqualTo(UnsignedLong.valueOf(12));
     assertThat(unlModify.sequence()).isEqualTo(UnsignedInteger.valueOf(2470665));
     assertThat(unlModify.ledgerSequence()).isEqualTo(LedgerIndex.of(UnsignedInteger.valueOf(67850752)));

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/UnlModifyJsonTests.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/json/UnlModifyJsonTests.java
@@ -15,7 +15,6 @@ public class UnlModifyJsonTests  extends AbstractJsonTest {
   @Test
   public void testJson() throws JsonProcessingException, JSONException {
     UnlModify unlModify = UnlModify.builder()
-      .account(Address.of("rrrrrrrrrrrrrrrrrrrrrhoLvTp"))
       .fee(XrpCurrencyAmount.ofDrops(12))
       .sequence(UnsignedInteger.valueOf(2470665))
       .signingPublicKey("")
@@ -25,7 +24,7 @@ public class UnlModifyJsonTests  extends AbstractJsonTest {
       .build();
 
     String json = "{" +
-      "\"Account\":\"rrrrrrrrrrrrrrrrrrrrrhoLvTp\"," +
+      "\"Account\":\"" + UnlModify.ACCOUNT_ZERO + "\"," +
       "\"Fee\":\"12\"," +
       "\"LedgerSequence\":67850752," +
       "\"Sequence\":2470665," +


### PR DESCRIPTION
Fixes #288 by setting `UnlModify.account` to ACCOUNT_ZERO (base58 encoding of `0`) as a `@Value.Derived` field so that deserializing from JSON doesn't break.