### PR TITLE
instead of `Thread.sleep`, use scanForResult to get correct results

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IsFinalIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IsFinalIT.java
@@ -15,6 +15,8 @@ import org.xrpl.xrpl4j.model.client.fees.FeeResult;
 import org.xrpl.xrpl4j.model.client.fees.FeeUtils;
 import org.xrpl.xrpl4j.model.client.ledger.LedgerRequestParams;
 import org.xrpl.xrpl4j.model.client.transactions.SubmitResult;
+import org.xrpl.xrpl4j.model.immutables.FluentCompareTo;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.ImmutablePayment;
 import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;
 import org.xrpl.xrpl4j.model.transactions.Payment;
@@ -61,25 +63,30 @@ public class IsFinalIT extends AbstractIT {
   }
 
   @Test
-  public void simpleIsFinalTest() throws JsonRpcClientErrorException, InterruptedException {
+  public void simpleIsFinalTest() throws JsonRpcClientErrorException {
 
     Payment builtPayment = payment.build();
     SubmitResult response = xrplClient.submit(wallet, builtPayment);
     assertThat(response.result()).isEqualTo("tesSUCCESS");
+    Hash256 txHash = response.transactionResult().hash();
 
     assertThat(
       xrplClient.isFinal(
-        response.transactionResult().hash(),
+        txHash,
         response.validatedLedgerIndex(),
         lastLedgerSequence,
         accountInfo.accountData().sequence(),
         wallet.classicAddress()
       ).finalityStatus()
     ).isEqualTo(FinalityStatus.NOT_FINAL);
-    Thread.sleep(4000);
+
+    this.scanForResult(
+      () -> getValidatedTransaction(txHash, Payment.class)
+    );
+
     assertThat(
       xrplClient.isFinal(
-        response.transactionResult().hash(),
+        txHash,
         response.validatedLedgerIndex(),
         lastLedgerSequence,
         accountInfo.accountData().sequence(),
@@ -89,27 +96,33 @@ public class IsFinalIT extends AbstractIT {
   }
 
   @Test
-  public void isFinalExpiredTxTest() throws JsonRpcClientErrorException, InterruptedException {
+  public void isFinalExpiredTxTest() throws JsonRpcClientErrorException {
 
     Payment builtPayment = payment
       .sequence(accountInfo.accountData().sequence().minus(UnsignedInteger.ONE))
       .build();
     SubmitResult response = xrplClient.submit(wallet, builtPayment);
+    Hash256 txHash = response.transactionResult().hash();
 
     assertThat(
       xrplClient.isFinal(
-        response.transactionResult().hash(),
+        txHash,
         response.validatedLedgerIndex(),
         lastLedgerSequence.minus(UnsignedInteger.ONE),
         accountInfo.accountData().sequence(),
         wallet.classicAddress()
       ).finalityStatus()
     ).isEqualTo(FinalityStatus.NOT_FINAL);
-    Thread.sleep(1000);
+
+    this.scanForResult(
+      () -> this.getValidatedLedger(),
+      ledger -> FluentCompareTo.is(ledger.ledgerIndexSafe().unsignedIntegerValue())
+        .greaterThan(lastLedgerSequence.minus(UnsignedInteger.ONE))
+    );
 
     assertThat(
       xrplClient.isFinal(
-        response.transactionResult().hash(),
+        txHash,
         response.validatedLedgerIndex(),
         lastLedgerSequence.minus(UnsignedInteger.ONE),
         accountInfo.accountData().sequence(),
@@ -119,29 +132,32 @@ public class IsFinalIT extends AbstractIT {
   }
 
   @Test
-  public void isFinalNoTrustlineIouPayment_ValidatedFailureResponse()
-    throws JsonRpcClientErrorException, InterruptedException {
+  public void isFinalNoTrustlineIouPayment_ValidatedFailureResponse() throws JsonRpcClientErrorException {
 
     Payment builtPayment = payment
       .amount(IssuedCurrencyAmount.builder().currency("USD").issuer(
         wallet.classicAddress()).value("500").build()
       ).build();
     SubmitResult response = xrplClient.submit(wallet, builtPayment);
+    Hash256 txHash = response.transactionResult().hash();
 
     assertThat(
       xrplClient.isFinal(
-        response.transactionResult().hash(),
+        txHash,
         response.validatedLedgerIndex(),
         lastLedgerSequence,
         accountInfo.accountData().sequence(),
         wallet.classicAddress()
       ).finalityStatus()
     ).isEqualTo(FinalityStatus.NOT_FINAL);
-    Thread.sleep(1000);
+
+    this.scanForResult(
+      () -> getValidatedTransaction(txHash, Payment.class)
+    );
 
     assertThat(
       xrplClient.isFinal(
-        response.transactionResult().hash(),
+        txHash,
         response.validatedLedgerIndex(),
         lastLedgerSequence,
         accountInfo.accountData().sequence(),


### PR DESCRIPTION
Fixes #298 