### PR TITLE
Backport account_tx IT fix to main

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountTransactionsIT.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.tests;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,6 +28,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import com.google.common.primitives.UnsignedInteger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
 import org.xrpl.xrpl4j.client.XrplClient;
 import org.xrpl.xrpl4j.model.client.accounts.AccountTransactionsRequestParams;
@@ -45,18 +47,29 @@ import java.util.concurrent.TimeUnit;
 
 public class AccountTransactionsIT {
 
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
   // an arbitrary address on xrpl mainnet that has a decent amount of transaction history
   public static final Address MAINNET_ADDRESS = Address.of("r9m6MwViR4GnUNqoGXGa8eroBrZ9FAPHFS");
 
   private final XrplClient mainnetClient = new MainnetEnvironment().getXrplClient();
 
   @Test
+  public void listTransactionsDefaultWithPagination() throws JsonRpcClientErrorException {
+    AccountTransactionsResult results = mainnetClient.accountTransactions(MAINNET_ADDRESS);
+
+    // The default value for reporting mode is 200; but clio it's 50. However, the important things to test here is
+    // that a marker exists, so we only assert on that value.
+    assertThat(results.marker()).isNotEmpty();
+  }
+
+  @Test
   @Timeout(30)
   public void listTransactionsPagination() throws JsonRpcClientErrorException {
-    final int expectedTransactions = 284;
+    final int expectedTransactions = 748;
     // known ledger index range for this account that is known to have exactly 748 transactions
     LedgerIndexBound minLedger = LedgerIndexBound.of(61400000);
-    LedgerIndexBound maxLedger = LedgerIndexBound.of(61437000);
+    LedgerIndexBound maxLedger = LedgerIndexBound.of(61487000);
     AccountTransactionsResult results = mainnetClient.accountTransactions(
       AccountTransactionsRequestParams.builder(minLedger, maxLedger)
         .account(MAINNET_ADDRESS)
@@ -66,20 +79,26 @@ public class AccountTransactionsIT {
     assertThat(results.marker()).isNotEmpty();
 
     int transactionsFound = results.transactions().size();
-    int pages = 1;
-    while (results.marker().isPresent()) {
-      results = mainnetClient.accountTransactions(AccountTransactionsRequestParams
-          .builder(minLedger, maxLedger)
+    int pages = 0;
+    while (results.marker().isPresent() &&
+      // Needed because clio is broken. See https://github.com/XRPLF/clio/issues/195#issuecomment-1247412892
+      results.transactions().size() > 0
+    ) {
+      results = mainnetClient.accountTransactions(AccountTransactionsRequestParams.builder(minLedger, maxLedger)
         .account(MAINNET_ADDRESS)
+        .limit(UnsignedInteger.valueOf(200L))
         .marker(results.marker().get())
         .build());
-      assertThat(results.transactions()).isNotEmpty();
       transactionsFound += results.transactions().size();
       pages++;
+      logger.info("Retrieved {} ledgers (marker={} page={})",
+        transactionsFound,
+        results.marker().map($ -> $.value()).orElseGet(() -> "n/a"),
+        pages
+      );
     }
 
     assertThat(transactionsFound).isEqualTo(expectedTransactions);
-    assertThat(pages).isEqualTo(2);
   }
 
   @Test

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IssuedCurrencyIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IssuedCurrencyIT.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
 import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
 import org.xrpl.xrpl4j.model.client.accounts.AccountCurrenciesRequestParams;
@@ -201,7 +202,8 @@ public class IssuedCurrencyIT extends AbstractIT {
     );
   }
 
-//  @Test
+  @Test
+  @Disabled
   public void sendMultiHopSameCurrencyPayment() throws JsonRpcClientErrorException {
     ///////////////////////////
     // Create two issuer wallets and three non-issuer wallets

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IssuedCurrencyIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IssuedCurrencyIT.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
 import org.xrpl.xrpl4j.model.client.accounts.AccountCurrenciesRequestParams;
@@ -200,7 +201,7 @@ public class IssuedCurrencyIT extends AbstractIT {
     );
   }
 
-  @Test
+//  @Test
   public void sendMultiHopSameCurrencyPayment() throws JsonRpcClientErrorException {
     ///////////////////////////
     // Create two issuer wallets and three non-issuer wallets


### PR DESCRIPTION
Backports the changes made to `AccountTransactionsIT` in #302 into `main` to prevent builds from failing on branches based off of `main`.