### PR TITLE
allow brokered mode without `brokerFee`

### DIFF
--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/NfTokenAcceptOffer.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/NfTokenAcceptOffer.java
@@ -92,14 +92,13 @@ public interface NfTokenAcceptOffer extends Transaction {
    * for direct mode and both are present for brokered mode.
    */
   @Value.Check
-  default void atleastOneOfferPresent() {
-    if (brokerFee().isPresent()) {
-      Preconditions.checkState( buyOffer().isPresent() && sellOffer().isPresent(),
-        "In brokered mode, you must specify both the SellOffer and the BuyOffer.");
-    } else {
-      Preconditions.checkState( (buyOffer().isPresent() || sellOffer().isPresent()) &&
-        !(buyOffer().isPresent() && sellOffer().isPresent()),
-        "In direct mode, you must specify either the SellOffer or the BuyOffer.");
+  default void brokerFeeNotPresentInDirectModeAndAtleastOneOfferPresent() {
+    Preconditions.checkState(buyOffer().isPresent() || sellOffer().isPresent(),
+      "One offer must be present.");
+
+    if ((buyOffer().isPresent() || sellOffer().isPresent()) &&
+      !(buyOffer().isPresent() && sellOffer().isPresent())) {
+      Preconditions.checkState(!brokerFee().isPresent(), "No BrokerFee needed in direct mode.");
     }
   }
 

--- a/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/NfTokenAcceptOffer.java
+++ b/xrpl4j-model/src/main/java/org/xrpl/xrpl4j/model/transactions/NfTokenAcceptOffer.java
@@ -94,7 +94,7 @@ public interface NfTokenAcceptOffer extends Transaction {
   @Value.Check
   default void brokerFeeNotPresentInDirectModeAndAtleastOneOfferPresent() {
     Preconditions.checkState(buyOffer().isPresent() || sellOffer().isPresent(),
-      "One offer must be present.");
+      "PLease specify one offer for direct mode and both offers for brokered mode.");
 
     if ((buyOffer().isPresent() || sellOffer().isPresent()) &&
       !(buyOffer().isPresent() && sellOffer().isPresent())) {

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/NfTokenAcceptOfferTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/NfTokenAcceptOfferTest.java
@@ -1,6 +1,7 @@
 package org.xrpl.xrpl4j.model.transactions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -9,15 +10,53 @@ import java.util.Optional;
 
 public class NfTokenAcceptOfferTest {
 
+  private final Address ADDRESS = Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
+  private final Hash256 offer = Hash256.of("000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65");
+
   @Test
   public void buildTx() {
-    Hash256 offer = Hash256.of("000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65");
     NfTokenAcceptOffer nfTokenAcceptOffer = NfTokenAcceptOffer.builder()
-      .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+      .account(ADDRESS)
       .fee(XrpCurrencyAmount.ofDrops(1))
       .buyOffer(offer)
       .build();
 
+    assertThat(offer.equals(nfTokenAcceptOffer.buyOffer()));
+    assertThat(nfTokenAcceptOffer.buyOffer()).isEqualTo(Optional.of(offer));
+    assertThat(nfTokenAcceptOffer.account().equals(ADDRESS));
+  }
+
+  @Test
+  public void directModeWithBrokerFee_throws() {
+    assertThatThrownBy(() -> NfTokenAcceptOffer.builder()
+      .account(ADDRESS)
+      .sellOffer(offer)
+      .brokerFee(XrpCurrencyAmount.ofDrops(1000))
+      .fee(XrpCurrencyAmount.ofDrops(100))
+      .build())
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("No BrokerFee needed in direct mode.");
+  }
+
+  @Test
+  public void brokeredModeWithAndWithoutFee() {
+    NfTokenAcceptOffer nfTokenAcceptOffer = NfTokenAcceptOffer.builder()
+      .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+      .fee(XrpCurrencyAmount.ofDrops(1))
+      .buyOffer(offer)
+      .sellOffer(offer)
+      .build();
+
+    assertThat(offer.equals(nfTokenAcceptOffer.buyOffer()));
+    assertThat(nfTokenAcceptOffer.buyOffer()).isEqualTo(Optional.of(offer));
+
+    nfTokenAcceptOffer = NfTokenAcceptOffer.builder()
+      .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+      .fee(XrpCurrencyAmount.ofDrops(1))
+      .buyOffer(offer)
+      .sellOffer(offer)
+      .brokerFee(XrpCurrencyAmount.ofDrops(10000))
+      .build();
     assertThat(offer.equals(nfTokenAcceptOffer.buyOffer()));
     assertThat(nfTokenAcceptOffer.buyOffer()).isEqualTo(Optional.of(offer));
   }

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/NfTokenAcceptOfferTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/NfTokenAcceptOfferTest.java
@@ -27,6 +27,17 @@ public class NfTokenAcceptOfferTest {
   }
 
   @Test
+  public void throwWhenNoOfferIsPresent() {
+    assertThatThrownBy(() -> NfTokenAcceptOffer.builder()
+      .account(address)
+      .brokerFee(XrpCurrencyAmount.ofDrops(1000))
+      .fee(XrpCurrencyAmount.ofDrops(100))
+      .build())
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("PLease specify one offer for direct mode and both offers for brokered mode.");
+  }
+
+  @Test
   public void directModeWithBrokerFee_throws() {
     assertThatThrownBy(() -> NfTokenAcceptOffer.builder()
       .account(address)

--- a/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/NfTokenAcceptOfferTest.java
+++ b/xrpl4j-model/src/test/java/org/xrpl/xrpl4j/model/transactions/NfTokenAcceptOfferTest.java
@@ -10,26 +10,26 @@ import java.util.Optional;
 
 public class NfTokenAcceptOfferTest {
 
-  private final Address ADDRESS = Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
+  private final Address address = Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn");
   private final Hash256 offer = Hash256.of("000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65");
 
   @Test
   public void buildTx() {
     NfTokenAcceptOffer nfTokenAcceptOffer = NfTokenAcceptOffer.builder()
-      .account(ADDRESS)
+      .account(address)
       .fee(XrpCurrencyAmount.ofDrops(1))
       .buyOffer(offer)
       .build();
 
     assertThat(offer.equals(nfTokenAcceptOffer.buyOffer()));
     assertThat(nfTokenAcceptOffer.buyOffer()).isEqualTo(Optional.of(offer));
-    assertThat(nfTokenAcceptOffer.account().equals(ADDRESS));
+    assertThat(nfTokenAcceptOffer.account().equals(address));
   }
 
   @Test
   public void directModeWithBrokerFee_throws() {
     assertThatThrownBy(() -> NfTokenAcceptOffer.builder()
-      .account(ADDRESS)
+      .account(address)
       .sellOffer(offer)
       .brokerFee(XrpCurrencyAmount.ofDrops(1000))
       .fee(XrpCurrencyAmount.ofDrops(100))


### PR DESCRIPTION
There is a possibility that brokered mode `NfTokenAcceptOffer` transactions are submitted without `brokerFee`. It was not allowed earlier and this PR fixes it.