### PR TITLE
Fix CI Builds

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,7 +6,7 @@ on:
     types: [assigned]
 jobs:
   build_java8:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
         uses: codecov/codecov-action@v1.0.15
 
   build_android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -Pandroid
 
   build_other_java:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     strategy:
       matrix:
         # test against each major Java version
@@ -73,7 +73,7 @@ jobs:
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true
 
   build_open_jdk_non_us:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       - uses: actions/checkout@v2
       # Set up Adopt OpenJDK Hotspot 16
@@ -95,7 +95,7 @@ jobs:
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DargLine="-Duser.language=de -Duser.country=DE"
 
   build_devnet_its:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v2
@@ -116,7 +116,7 @@ jobs:
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DuseDevnet
 
   build_testnet_its:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-21.10
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -116,7 +116,7 @@ jobs:
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DuseDevnet
 
   build_testnet_its:
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,6 @@
 name: xrpl4j-CI
 
+
 on:
   push:
   pull_request:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,7 +6,7 @@ on:
     types: [assigned]
 jobs:
   build_java8:
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
         uses: codecov/codecov-action@v1.0.15
 
   build_android:
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -Pandroid
 
   build_other_java:
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # test against each major Java version
@@ -73,7 +73,7 @@ jobs:
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true
 
   build_open_jdk_non_us:
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       # Set up Adopt OpenJDK Hotspot 16
@@ -95,7 +95,7 @@ jobs:
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DargLine="-Duser.language=de -Duser.country=DE"
 
   build_devnet_its:
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v2

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/NfTokenIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/NfTokenIT.java
@@ -35,14 +35,6 @@ import org.xrpl.xrpl4j.wallet.Wallet;
  */
 public class NfTokenIT extends AbstractIT {
 
-  @BeforeAll
-  protected static void initXrplEnvironment() {
-    xrplEnvironment = new CustomEnvironment(
-      HttpUrl.parse("http://xls20-sandbox.rippletest.net:51234"),
-      HttpUrl.parse("https://faucet-nft.ripple.com")
-    );
-  }
-
   @Test
   void mint() throws JsonRpcClientErrorException {
     Wallet wallet = createRandomAccount();

--- a/xrpl4j-integration-tests/src/test/resources/rippled/rippled.cfg
+++ b/xrpl4j-integration-tests/src/test/resources/rippled/rippled.cfg
@@ -385,7 +385,7 @@
 #
 #   [ips]
 #   192.168.0.1
-#   192.168.0.1 2459 
+#   192.168.0.1 2459
 #   r.ripple.com 51235
 #
 #
@@ -1275,3 +1275,6 @@ validators.txt
 account_reserve = 20000000   # 20 XRP
 owner_reserve = 5000000   # 5 XRP
 reference_fee = 10           # 10 drops
+
+[features]
+NonFungibleTokensV1_1


### PR DESCRIPTION
Our github actions pipeline runs several maven builds for different version of Java. Every build was running on the `ubuntu-latest`, however Github has recently updated it's "latest" version of ubuntu. I'm not totally sure why the builds fail in the latest ubuntu version, but pegging ubuntu to version 20.04 seems to fix the issue.

Additionally, this PR changes `NfTokenITs` to use the configured `XrplEnvironment` for all ITs instead of a `CustomEnvironment` pointed at NFT Devnet. NFT Devnet has been deprecated and has been experiencing issues lately, which exposed the fact that overwriting `AbstractIT.xrplEnvironment` in `NfTokenIT` will cause all ITs run after `NfTokenIT` to point to NFT devnet. Removing this logic in `NfTokenId` both fixes this problem and will help down the line when NFT Devnet is fully decommissioned. 