### PR TITLE
Releases/v2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.xrpl</groupId>
   <artifactId>xrpl4j-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.5.0</version>
+  <version>2.5.1-SNAPSHOT</version>
 
   <name>xrpl4j parent</name>
   <description>Parent project for xrpl4j modules.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.xrpl</groupId>
   <artifactId>xrpl4j-parent</artifactId>
   <packaging>pom</packaging>
-  <version>HEAD-SNAPSHOT</version>
+  <version>2.5.0</version>
 
   <name>xrpl4j parent</name>
   <description>Parent project for xrpl4j modules.</description>

--- a/xrpl4j-address-codec/pom.xml
+++ b/xrpl4j-address-codec/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xrpl4j-parent</artifactId>
     <groupId>org.xrpl</groupId>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-address-codec/pom.xml
+++ b/xrpl4j-address-codec/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xrpl4j-parent</artifactId>
     <groupId>org.xrpl</groupId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>2.5.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-binary-codec/pom.xml
+++ b/xrpl4j-binary-codec/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.xrpl</groupId>
     <artifactId>xrpl4j-parent</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>xrpl4j-binary-codec</artifactId>

--- a/xrpl4j-binary-codec/pom.xml
+++ b/xrpl4j-binary-codec/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.xrpl</groupId>
     <artifactId>xrpl4j-parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>2.5.0</version>
   </parent>
 
   <artifactId>xrpl4j-binary-codec</artifactId>

--- a/xrpl4j-bom/pom.xml
+++ b/xrpl4j-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xrpl4j-parent</artifactId>
     <groupId>org.xrpl</groupId>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-bom/pom.xml
+++ b/xrpl4j-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xrpl4j-parent</artifactId>
     <groupId>org.xrpl</groupId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>2.5.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-client/pom.xml
+++ b/xrpl4j-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xrpl4j-parent</artifactId>
     <groupId>org.xrpl</groupId>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-client/pom.xml
+++ b/xrpl4j-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xrpl4j-parent</artifactId>
     <groupId>org.xrpl</groupId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>2.5.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-crypto-parent/pom.xml
+++ b/xrpl4j-crypto-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xrpl</groupId>
     <artifactId>xrpl4j-parent</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/xrpl4j-crypto-parent/pom.xml
+++ b/xrpl4j-crypto-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xrpl</groupId>
     <artifactId>xrpl4j-parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>2.5.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/pom.xml
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xrpl</groupId>
     <artifactId>xrpl4j-crypto-parent</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/pom.xml
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-bouncycastle/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xrpl</groupId>
     <artifactId>xrpl4j-crypto-parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>2.5.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/pom.xml
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xrpl</groupId>
     <artifactId>xrpl4j-crypto-parent</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-crypto-parent/xrpl4j-crypto-core/pom.xml
+++ b/xrpl4j-crypto-parent/xrpl4j-crypto-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xrpl</groupId>
     <artifactId>xrpl4j-crypto-parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>2.5.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-integration-tests/pom.xml
+++ b/xrpl4j-integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xrpl4j-parent</artifactId>
     <groupId>org.xrpl</groupId>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-integration-tests/pom.xml
+++ b/xrpl4j-integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xrpl4j-parent</artifactId>
     <groupId>org.xrpl</groupId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>2.5.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-keypairs/pom.xml
+++ b/xrpl4j-keypairs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xrpl4j-parent</artifactId>
     <groupId>org.xrpl</groupId>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-keypairs/pom.xml
+++ b/xrpl4j-keypairs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xrpl4j-parent</artifactId>
     <groupId>org.xrpl</groupId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>2.5.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-model/pom.xml
+++ b/xrpl4j-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xrpl4j-parent</artifactId>
     <groupId>org.xrpl</groupId>
-    <version>2.5.0</version>
+    <version>2.5.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/xrpl4j-model/pom.xml
+++ b/xrpl4j-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>xrpl4j-parent</artifactId>
     <groupId>org.xrpl</groupId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>2.5.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Thanks for creating and maintaining this wonderful library.
The issue i'm having is that, some crypto exchanges like binance allocate some deposit tags to their customers, and this deposit tags are numbers higher than the maximum limit of UnsignedInteger currently specified by the xrpl4j library, thereby making it difficult to send fund to their wallet via the api.
In view of the above, i am pleading that the **UnsignedInteger field type specified in the library for destination tags should be changed to UnsignedLong**.
Thank you as i await your response / action.