### PR TITLE
Fix Flaky ITs

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/EscrowIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/EscrowIT.java
@@ -177,8 +177,8 @@ public class EscrowIT extends AbstractIT {
       .fee(XrpCurrencyAmount.ofXrp(new BigDecimal(1)))
       .amount(XrpCurrencyAmount.ofDrops(123456))
       .destination(receiverWallet.classicAddress())
-      .cancelAfter(instantToXrpTimestamp(getMinExpirationTime().plus(Duration.ofSeconds(5))))
-      .finishAfter(instantToXrpTimestamp(getMinExpirationTime().plus(Duration.ofSeconds(1))))
+      .cancelAfter(instantToXrpTimestamp(getMinExpirationTime().plus(Duration.ofSeconds(10))))
+      .finishAfter(instantToXrpTimestamp(getMinExpirationTime().plus(Duration.ofSeconds(5))))
       .signingPublicKey(senderWallet.publicKey())
       .build();
 

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/PaymentChannelIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/PaymentChannelIT.java
@@ -133,8 +133,7 @@ public class PaymentChannelIT extends AbstractIT {
     // Validate that the amount of the payment channel was deducted from the source
     // accounts XRP balance
     AccountInfoResult senderAccountInfoAfterCreate = this.scanForResult(
-      () -> this.getValidatedAccountInfo(sourceWallet.classicAddress()),
-      accountInfo -> accountInfo.ledgerIndexSafe().equals(senderAccountInfo.ledgerIndexSafe().plus(UnsignedInteger.ONE))
+      () -> this.getValidatedAccountInfo(sourceWallet.classicAddress())
     );
 
     assertThat(senderAccountInfoAfterCreate.accountData().balance())


### PR DESCRIPTION
Fixes two ITs that were intermittently failing in the testnet build.

* `EscrowIT.createAndCancelTimeBasedEscrow` was failing because the `EscrowCreate` transaction specified `CancelAfter` and `FinishAfter` with too little time between the parent ledger close time and the current time. Sometimes by the time the transaction was getting applied to the ledger, the parent close time was already greater than the `CancelAfter` or `FinishAfter` times in the transaction. To fix this I just added more seconds on to the queried parent close time to avoid hitting this race condition
* `PaymentChannelIT.createPaymentChannel` was failing because we were scanning for account info and making sure the ledger index of the response was exactly one more than the previously queried ledger index. This check was unnecessary and would cause the test to fail if we missed a ledger between querying the first time and when we first start scanning.