### PR TITLE
Remove deprecated methods in org.xrpl.xrpl4j.codec.addresses package

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/AddressCodec.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/AddressCodec.java
@@ -47,51 +47,6 @@ public class AddressCodec {
   }
 
   /**
-   * Decodes a Base58Check encoded XRPL secret key seed value. Works for ed25519 and secp256k1 seeds.
-   *
-   * @param seed A Base58Check encoded XRPL keypair seed.
-   *
-   * @return The decoded seed, seed type, and algorithm used to encode the seed.
-   *
-   * @see "https://xrpl.org/cryptographic-keys.html#seed"
-   * @deprecated Prefer the variant in {@link SeedCodec} instead.
-   */
-  @Deprecated
-  public Decoded decodeSeed(final String seed) throws EncodingFormatException {
-    Objects.requireNonNull(seed);
-
-    return AddressBase58.decode(
-      seed,
-      Lists.newArrayList(KeyType.ED25519, KeyType.SECP256K1),
-      Lists.newArrayList(Version.ED25519_SEED, Version.FAMILY_SEED),
-      Optional.of(UnsignedInteger.valueOf(16))
-    );
-  }
-
-  /**
-   * Encodes a byte array to a Base58Check {@link String} using the given {@link KeyType}.
-   *
-   * @param entropy An {@link UnsignedByteArray} containing the seed entropy to encode.
-   * @param type    The cryptographic algorithm type to be encoded in the resulting seed.
-   *
-   * @return A Base58Check encoded XRPL keypair seed.
-   *
-   * @deprecated Prefer the variant in {@link SeedCodec} instead.
-   */
-  @Deprecated
-  public String encodeSeed(final UnsignedByteArray entropy, final KeyType type) {
-    Objects.requireNonNull(entropy);
-    Objects.requireNonNull(type);
-
-    if (entropy.getUnsignedBytes().size() != 16) {
-      throw new EncodeException("entropy must have length 16.");
-    }
-
-    Version version = type.equals(KeyType.ED25519) ? Version.ED25519_SEED : Version.FAMILY_SEED;
-    return AddressBase58.encode(entropy, Lists.newArrayList(version), UnsignedInteger.valueOf(16));
-  }
-
-  /**
    * Encode an XRPL AccountID to a Base58Check encoded {@link String}.
    *
    * @param accountId An {@link UnsignedByteArray} containing the AccountID to be encoded.
@@ -131,10 +86,7 @@ public class AddressCodec {
    * @param publicKey An {@link UnsignedByteArray} containing the public key to be encoded.
    *
    * @return The Base58 representation of publicKey.
-   *
-   * @deprecated This will be replaced by a PublicKeyCodec or KeyCodec.
    */
-  @Deprecated
   public String encodeNodePublicKey(final UnsignedByteArray publicKey) {
     Objects.requireNonNull(publicKey);
 
@@ -149,52 +101,13 @@ public class AddressCodec {
    * @return An {@link UnsignedByteArray} containing the decoded public key.
    *
    * @see "https://xrpl.org/base58-encodings.html"
-   * @deprecated This will be replaced by a PublicKeyCodec or KeyCodec.
    */
-  @Deprecated
   public UnsignedByteArray decodeNodePublicKey(final String publicKey) {
     Objects.requireNonNull(publicKey);
 
     return AddressBase58.decode(
       publicKey,
       Lists.newArrayList(Version.NODE_PUBLIC),
-      UnsignedInteger.valueOf(33)
-    ).bytes();
-  }
-
-  /**
-   * Encode an XRPL Account Public Key to a Base58Check encoded {@link String}.
-   *
-   * @param publicKey An {@link UnsignedByteArray} containing the public key to be encoded.
-   *
-   * @return The Base58 representation of publicKey.
-   *
-   * @deprecated This will be replaced by a PublicKeyCodec or KeyCodec.
-   */
-  @Deprecated
-  public String encodeAccountPublicKey(final UnsignedByteArray publicKey) {
-    Objects.requireNonNull(publicKey);
-
-    return AddressBase58.encode(publicKey, Lists.newArrayList(Version.ACCOUNT_PUBLIC_KEY), UnsignedInteger.valueOf(33));
-  }
-
-  /**
-   * Decode a Base58Check encoded XRPL Account Public Key.
-   *
-   * @param publicKey The Base58 encoded public key to be decoded.
-   *
-   * @return An {@link UnsignedByteArray} containing the decoded public key.
-   *
-   * @see "https://xrpl.org/base58-encodings.html"
-   * @deprecated This will be replaced by a PublicKeyCodec or KeyCodec.
-   */
-  @Deprecated
-  public UnsignedByteArray decodeAccountPublicKey(final String publicKey) {
-    Objects.requireNonNull(publicKey);
-
-    return AddressBase58.decode(
-      publicKey,
-      Lists.newArrayList(Version.ACCOUNT_PUBLIC_KEY),
       UnsignedInteger.valueOf(33)
     ).bytes();
   }
@@ -208,10 +121,7 @@ public class AddressCodec {
    *                       encoded for Mainnet.
    *
    * @return The X-Address representation of the classic address and destination tag.
-   *
-   * @deprecated X-Address support will be removed in a future version.
    */
-  @Deprecated
   public XAddress classicAddressToXAddress(
     final Address classicAddress,
     final UnsignedInteger tag,
@@ -231,10 +141,7 @@ public class AddressCodec {
    *                       encoded for Mainnet.
    *
    * @return The X-Address representation of the classic address, as an {@link XAddress}.
-   *
-   * @deprecated X-Address support will be removed in a future version.
    */
-  @Deprecated
   public XAddress classicAddressToXAddress(final Address classicAddress, final boolean test) {
     Objects.requireNonNull(classicAddress);
 
@@ -250,10 +157,7 @@ public class AddressCodec {
    *                       encoded for Mainnet.
    *
    * @return The X-Address representation of the classic address and destination tag, as an {@link XAddress}.
-   *
-   * @deprecated X-Address support will be removed in a future version.
    */
-  @Deprecated
   public XAddress classicAddressToXAddress(
     final Address classicAddress,
     final Optional<UnsignedInteger> tag,
@@ -318,10 +222,7 @@ public class AddressCodec {
    * @param xAddress The {@link XAddress} to be decoded.
    *
    * @return The {@link ClassicAddress} decoded from xAddress.
-   *
-   * @deprecated Prefer the variant in AddressService instead.
    */
-  @Deprecated
   public ClassicAddress xAddressToClassicAddress(final XAddress xAddress) {
     Objects.requireNonNull(xAddress);
 
@@ -403,10 +304,7 @@ public class AddressCodec {
    * @param xAddress A potentially valid {@link XAddress}.
    *
    * @return {@code true} if the given address is a valid X-Address, {@code false} if not.
-   *
-   * @deprecated Prefer the variant in AddressService instead.
    */
-  @Deprecated
   public boolean isValidXAddress(final XAddress xAddress) {
     try {
       decodeXAddress(xAddress);
@@ -423,10 +321,7 @@ public class AddressCodec {
    * @param address A potentially valid classic {@link Address}.
    *
    * @return {@code true} if the given address is a valid Classic Address, {@code false} if not.
-   *
-   * @deprecated Prefer the variant in AddressService instead.
    */
-  @Deprecated
   public boolean isValidClassicAddress(final Address address) {
     try {
       decodeAccountId(address);

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PublicKeyCodec.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PublicKeyCodec.java
@@ -24,7 +24,6 @@ public class PublicKeyCodec {
    *
    * @return The Base58 representation of publicKey.
    */
-  // TODO: Use PublicKey when the modules are rearrangd.
   public String encodeNodePublicKey(final UnsignedByteArray publicKey) {
     Objects.requireNonNull(publicKey);
     return AddressBase58.encode(publicKey, Lists.newArrayList(Version.NODE_PUBLIC), UnsignedInteger.valueOf(33));
@@ -39,7 +38,6 @@ public class PublicKeyCodec {
    *
    * @see "https://xrpl.org/base58-encodings.html"
    */
-  // TODO: Use PublicKey when the modules are rearrangd.
   public UnsignedByteArray decodeNodePublicKey(final String publicKey) {
     Objects.requireNonNull(publicKey);
 

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PublicKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PublicKey.java
@@ -14,6 +14,7 @@ import org.xrpl.xrpl4j.codec.addresses.AddressBase58;
 import org.xrpl.xrpl4j.codec.addresses.AddressCodec;
 import org.xrpl.xrpl4j.codec.addresses.Decoded;
 import org.xrpl.xrpl4j.codec.addresses.KeyType;
+import org.xrpl.xrpl4j.codec.addresses.PublicKeyCodec;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
 import org.xrpl.xrpl4j.codec.addresses.Version;
 import org.xrpl.xrpl4j.model.jackson.modules.PublicKeyDeserializer;
@@ -62,7 +63,7 @@ public interface PublicKey {
     }
     
     return PublicKey.builder()
-      .value(AddressCodec.getInstance().decodeAccountPublicKey(base58EncodedPublicKey))
+      .value(PublicKeyCodec.getInstance().decodeAccountPublicKey(base58EncodedPublicKey))
       .build();
   }
 
@@ -103,7 +104,7 @@ public interface PublicKey {
       return "";
     }
     
-    return AddressBase58.encode(value(), Lists.newArrayList(Version.ACCOUNT_PUBLIC_KEY), UnsignedInteger.valueOf(33));
+    return PublicKeyCodec.getInstance().encodeAccountPublicKey(this.value());
   }
 
   /**

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/AddressCodecTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/AddressCodecTest.java
@@ -21,12 +21,10 @@ package org.xrpl.xrpl4j.codec.addresses;
  */
 
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodeException;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodingFormatException;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.XAddress;
@@ -46,103 +44,6 @@ public class AddressCodecTest extends AbstractCodecTest {
   }
 
   @Test
-  public void decodeEd25519Seed() {
-    String seed = "sEdTM1uX8pu2do5XvTnutH6HsouMaM2";
-    Decoded decoded = addressCodec.decodeSeed(seed);
-    assertThat(decoded.bytes().hexValue()).isEqualTo("4C3A1D213FBDFB14C7C28D609469B341");
-    assertThat(decoded.type()).isNotEmpty().get().isEqualTo(KeyType.ED25519);
-    assertThat(decoded.version()).isEqualTo(Version.ED25519_SEED);
-  }
-
-  @Test
-  public void decodeSecp256k1Seed() {
-    String seed = "sn259rEFXrQrWyx3Q7XneWcwV6dfL";
-    Decoded decoded = addressCodec.decodeSeed(seed);
-    assertThat(decoded.bytes().hexValue()).isEqualTo("CF2DE378FBDD7E2EE87D486DFB5A7BFF");
-    assertThat(decoded.type()).isNotEmpty().get().isEqualTo(KeyType.SECP256K1);
-    assertThat(decoded.version()).isEqualTo(Version.FAMILY_SEED);
-  }
-
-  @Test
-  public void encodeSecp256k1Seed() {
-    String encoded = addressCodec.encodeSeed(
-      unsignedByteArrayFromHex("CF2DE378FBDD7E2EE87D486DFB5A7BFF"),
-      KeyType.SECP256K1
-    );
-
-    assertThat(encoded).isEqualTo("sn259rEFXrQrWyx3Q7XneWcwV6dfL");
-  }
-
-  @Test
-  public void encodeLowSecp256k1Seed() {
-    String encoded = addressCodec.encodeSeed(
-      unsignedByteArrayFromHex("00000000000000000000000000000000"),
-      KeyType.SECP256K1
-    );
-
-    assertThat(encoded).isEqualTo("sp6JS7f14BuwFY8Mw6bTtLKWauoUs");
-  }
-
-  @Test
-  public void encodeHighSecp256k1Seed() {
-    String encoded = addressCodec.encodeSeed(
-      unsignedByteArrayFromHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
-      KeyType.SECP256K1
-    );
-
-    assertThat(encoded).isEqualTo("saGwBRReqUNKuWNLpUAq8i8NkXEPN");
-  }
-
-  @Test
-  public void encodeEd25519Seed() {
-    String encoded = addressCodec.encodeSeed(
-      unsignedByteArrayFromHex("4C3A1D213FBDFB14C7C28D609469B341"),
-      KeyType.ED25519
-    );
-
-    assertThat(encoded).isEqualTo("sEdTM1uX8pu2do5XvTnutH6HsouMaM2");
-  }
-
-  @Test
-  public void encodeLowEd25519Seed() {
-    String encoded = addressCodec.encodeSeed(
-      unsignedByteArrayFromHex("00000000000000000000000000000000"),
-      KeyType.ED25519
-    );
-
-    assertThat(encoded).isEqualTo("sEdSJHS4oiAdz7w2X2ni1gFiqtbJHqE");
-  }
-
-  @Test
-  public void encodeHighEd25519Seed() {
-    String encoded = addressCodec.encodeSeed(
-      unsignedByteArrayFromHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
-      KeyType.ED25519
-    );
-
-    assertThat(encoded).isEqualTo("sEdV19BLfeQeKdEXyYA4NhjPJe6XBfG");
-  }
-
-  @Test
-  public void encodeSeedWithFewerThanSixteenBytes() {
-    assertThrows(
-      EncodeException.class,
-      () -> addressCodec.encodeSeed(unsignedByteArrayFromHex("CF2DE378FBDD7E2EE87D486DFB5A7B"), KeyType.SECP256K1),
-      "entropy must have length 16."
-    );
-  }
-
-  @Test
-  public void encodeSeedWithGreaterThanSixteenBytes() {
-    assertThrows(
-      EncodeException.class,
-      () -> addressCodec
-        .encodeSeed(unsignedByteArrayFromHex("CF2DE378FBDD7E2EE87D486DFB5A7BFFFF"), KeyType.SECP256K1),
-      "entropy must have length 16."
-    );
-  }
-
-  @Test
   public void encodeDecodeAccountId() {
     testEncodeDecode(
       accountId -> addressCodec.encodeAccountId(accountId).value(),
@@ -159,16 +60,6 @@ public class AddressCodecTest extends AbstractCodecTest {
       nodePublic -> addressCodec.decodeNodePublicKey(nodePublic),
       unsignedByteArrayFromHex("0388E5BA87A000CB807240DF8C848EB0B5FFA5C8E5A521BC8E105C0F0A44217828"),
       "n9MXXueo837zYH36DvMc13BwHcqtfAWNJY5czWVbp7uYTj7x17TH"
-    );
-  }
-
-  @Test
-  public void encodeDecodeAccountPublicKey() {
-    testEncodeDecode(
-      publicKey -> addressCodec.encodeAccountPublicKey(publicKey),
-      publicKey -> addressCodec.decodeAccountPublicKey(publicKey),
-      unsignedByteArrayFromHex("023693F15967AE357D0327974AD46FE3C127113B1110D6044FD41E723689F81CC6"),
-      "aB44YfzW24VDEJQ2UuLPV2PvqcPCSoLnL7y5M1EzhdW4LnK5xMS3"
     );
   }
 


### PR DESCRIPTION
Partially fixes #366 by removing deprecated methods in `AddressCodec`