### PR TITLE
Use codecov token in CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3.1.0
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
   build_android:


### PR DESCRIPTION
Uses a repository secret to add a codecov token to our CI pipeline. Without this token, codecov uses its generic GH token which often gets rate limited and fails our builds. This should prevent that.