### PR TITLE
Fixes #446 (Consistent secp256k1 Curve)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
-        <version>1.74</version>
+        <version>1.75</version>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.crypto.keys.bc;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,6 @@ package org.xrpl.xrpl4j.crypto.keys.bc;
  */
 
 import static org.xrpl.xrpl4j.codec.addresses.KeyType.ED25519;
-import static org.xrpl.xrpl4j.crypto.signing.bc.Secp256k1.EC_DOMAIN_PARAMETERS;
 
 import com.google.common.base.Preconditions;
 import com.google.common.io.BaseEncoding;
@@ -51,7 +50,7 @@ public final class BcKeyUtils {
 
   private static final String SECP256K1 = "secp256k1";
   private static final ECNamedCurveParameterSpec EC_PARAMS = ECNamedCurveTable.getParameterSpec(SECP256K1);
-  static final ECDomainParameters PARAMS =
+  public static final ECDomainParameters PARAMS =
     new ECDomainParameters(
       EC_PARAMS.getCurve(),
       EC_PARAMS.getG(),
@@ -168,7 +167,7 @@ public final class BcKeyUtils {
    */
   public static ECPublicKeyParameters toPublicKey(final ECPrivateKeyParameters ecPrivateKeyParameters) {
     Objects.requireNonNull(ecPrivateKeyParameters);
-    ECPoint ecPoint = EC_DOMAIN_PARAMETERS.getG().multiply(ecPrivateKeyParameters.getD());
+    ECPoint ecPoint = BcKeyUtils.PARAMS.getG().multiply(ecPrivateKeyParameters.getD());
     return new ECPublicKeyParameters(ecPoint, PARAMS);
   }
 
@@ -237,6 +236,6 @@ public final class BcKeyUtils {
     final BigInteger privateKeyInt = new BigInteger(
       BaseEncoding.base16().encode(privateKey.value().toByteArray()), 16
     );
-    return new ECPrivateKeyParameters(privateKeyInt, EC_DOMAIN_PARAMETERS);
+    return new ECPrivateKeyParameters(privateKeyInt, BcKeyUtils.PARAMS);
   }
 }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/BcSignatureService.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/BcSignatureService.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.crypto.signing.bc;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -129,13 +129,13 @@ public class BcSignatureService extends AbstractSignatureService<PrivateKey> imp
     final UnsignedByteArray messageHash = HashingUtils.sha512Half(transactionBytes);
 
     final BigInteger privateKeyInt = new BigInteger(privateKey.value().toByteArray());
-    final ECPrivateKeyParameters parameters = new ECPrivateKeyParameters(privateKeyInt, Secp256k1.EC_DOMAIN_PARAMETERS);
+    final ECPrivateKeyParameters parameters = new ECPrivateKeyParameters(privateKeyInt, BcKeyUtils.PARAMS);
 
     ecdsaSigner.init(true, parameters);
     final BigInteger[] signatures = ecdsaSigner.generateSignature(messageHash.toByteArray());
     final BigInteger r = signatures[0];
     BigInteger s = signatures[1];
-    final BigInteger otherS = Secp256k1.EC_DOMAIN_PARAMETERS.getN().subtract(s);
+    final BigInteger otherS = BcKeyUtils.PARAMS.getN().subtract(s);
     if (s.compareTo(otherS) > 0) {
       s = otherS;
     }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/EcDsaSignature.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/EcDsaSignature.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.crypto.signing.bc;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,6 +27,7 @@ import org.bouncycastle.asn1.DERSequenceGenerator;
 import org.bouncycastle.asn1.DLSequence;
 import org.immutables.value.Value;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
+import org.xrpl.xrpl4j.crypto.keys.bc.BcKeyUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -164,7 +165,7 @@ public interface EcDsaSignature {
     BigInteger r = new BigInteger(1, rBytes);
     BigInteger s = new BigInteger(1, sBytes);
 
-    BigInteger order = Secp256k1.EC_DOMAIN_PARAMETERS.getN();
+    BigInteger order = BcKeyUtils.PARAMS.getN();
 
     Preconditions.checkArgument(r.compareTo(order) <= -1 && s.compareTo(order) <= -1, "r or s greater than modulus");
     Preconditions.checkArgument(order.subtract(s).compareTo(s) > -1);

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/Secp256k1.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/Secp256k1.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.crypto.signing.bc;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,13 +23,30 @@ package org.xrpl.xrpl4j.crypto.signing.bc;
 import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.params.ECDomainParameters;
+import org.xrpl.xrpl4j.crypto.keys.bc.BcKeyUtils;
 
 /**
  * Static constants for Secp256k1 operations.
+ *
+ * @deprecated This interface is deprecated in-favor of {@link BcKeyUtils#PARAMS}.
  */
+@Deprecated
 public interface Secp256k1 {
 
+  /**
+   * Elliptic Curve parameters for the curve named `secp256k1`.
+   *
+   * @deprecated This interface is deprecated in-favor of {@link BcKeyUtils#PARAMS}.
+   */
+  @Deprecated
   X9ECParameters EC_PARAMETERS = SECNamedCurves.getByName("secp256k1");
+
+  /**
+   * Elliptic Curve domain parameters for the curve named `secp256k1`.
+   *
+   * @deprecated This interface is deprecated in-favor of {@link BcKeyUtils#PARAMS}.
+   */
+  @Deprecated
   ECDomainParameters EC_DOMAIN_PARAMETERS = new ECDomainParameters(
     EC_PARAMETERS.getCurve(),
     EC_PARAMETERS.getG(),

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtilsTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtilsTest.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.crypto.keys.bc;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.codec.addresses.Base58;
 import org.xrpl.xrpl4j.crypto.keys.PrivateKey;
 import org.xrpl.xrpl4j.crypto.keys.PublicKey;
-import org.xrpl.xrpl4j.crypto.signing.bc.Secp256k1;
 
 import java.math.BigInteger;
 
@@ -104,7 +103,7 @@ class BcKeyUtilsTest {
     ECPrivateKeyParameters ecPrivateKeyParameters = new ECPrivateKeyParameters(
       EC_PRIVATE_KEY_BIGINTEGER, BcKeyUtils.PARAMS
     );
-    ECPoint ecPoint = Secp256k1.EC_DOMAIN_PARAMETERS.getG().multiply(ecPrivateKeyParameters.getD());
+    ECPoint ecPoint = BcKeyUtils.PARAMS.getG().multiply(ecPrivateKeyParameters.getD());
     ECPublicKeyParameters ecPublicKeyParameters = new ECPublicKeyParameters(ecPoint, BcKeyUtils.PARAMS);
 
     PublicKey publicKey = BcKeyUtils.toPublicKey(ecPublicKeyParameters);


### PR DESCRIPTION
* Use `BcKeyUtils` values everywhere.
* Deprecate unused interface that is public.