### PR TITLE
Fix NFT Amounts 

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/client/nft/BuyOffer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/client/nft/BuyOffer.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.flags.NfTokenOfferFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.CurrencyAmount;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
@@ -48,12 +49,12 @@ public interface BuyOffer {
   }
 
   /**
-   * The amount offered to buy the NFT for {@link XrpCurrencyAmount}.
+   * The amount offered to buy the NFT.
    *
-   * @return The {@link XrpCurrencyAmount}.
+   * @return The {@link CurrencyAmount}.
    */
   @JsonProperty("Amount")
-  XrpCurrencyAmount amount();
+  CurrencyAmount amount();
 
   /**
    * A set of boolean {@link NfTokenOfferFlags} containing options

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/client/nft/SellOffer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/client/nft/SellOffer.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.flags.NfTokenOfferFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.CurrencyAmount;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
@@ -48,12 +49,12 @@ public interface SellOffer {
   }
 
   /**
-   * The amount offered to buy the NFT for {@link XrpCurrencyAmount}.
+   * The amount offered to sell the NFT.
    *
-   * @return The {@link XrpCurrencyAmount}.
+   * @return The {@link CurrencyAmount}.
    */
   @JsonProperty("Amount")
-  XrpCurrencyAmount amount();
+  CurrencyAmount amount();
 
   /**
    * A set of boolean {@link NfTokenOfferFlags} containing options

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/client/nft/SellOffer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/client/nft/SellOffer.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.client.nft;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,11 +28,9 @@ import org.xrpl.xrpl4j.model.flags.NfTokenOfferFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.CurrencyAmount;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
-import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
 /**
- * An Offer returned in an {@link SellOffer} list.
- * This offer is related to NfTokens.
+ * An Offer returned in an {@link SellOffer} list. This offer is related to NfTokens.
  */
 @Value.Immutable
 @JsonSerialize(as = ImmutableSellOffer.class)
@@ -57,8 +55,7 @@ public interface SellOffer {
   CurrencyAmount amount();
 
   /**
-   * A set of boolean {@link NfTokenOfferFlags} containing options
-   * enabled for this object.
+   * A set of boolean {@link NfTokenOfferFlags} containing options enabled for this object.
    *
    * @return The {@link NfTokenOfferFlags} for this object.
    */

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/ledger/NfTokenOfferObject.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/ledger/NfTokenOfferObject.java
@@ -27,6 +27,7 @@ import com.google.common.primitives.UnsignedInteger;
 import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.flags.NfTokenOfferFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.CurrencyAmount;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.NfTokenId;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
@@ -63,12 +64,12 @@ public interface NfTokenOfferObject extends LedgerObject {
   }
 
   /**
-   * The amount of XRP, in drops, expected or offered for the token.
+   * The amount expected or offered for the token.
    *
-   * @return The {@link XrpCurrencyAmount}.
+   * @return The {@link CurrencyAmount}.
    */
   @JsonProperty("Amount")
-  XrpCurrencyAmount amount();
+  CurrencyAmount amount();
 
   /**
    * {@link Address} of the source account that created and owns the offer.

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/metadata/MetaNfTokenOfferObject.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/metadata/MetaNfTokenOfferObject.java
@@ -30,6 +30,7 @@ import org.xrpl.xrpl4j.model.flags.NfTokenOfferFlags;
 import org.xrpl.xrpl4j.model.ledger.ImmutableNfTokenOfferObject;
 import org.xrpl.xrpl4j.model.ledger.LedgerObject;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.CurrencyAmount;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.NfTokenId;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
@@ -46,12 +47,12 @@ import java.util.Optional;
 public interface MetaNfTokenOfferObject extends MetaLedgerObject {
 
   /**
-   * The amount of XRP, in drops, expected or offered for the token.
+   * The amount expected or offered for the token.
    *
-   * @return The {@link XrpCurrencyAmount}.
+   * @return The {@link CurrencyAmount}.
    */
   @JsonProperty("Amount")
-  Optional<XrpCurrencyAmount> amount();
+  Optional<CurrencyAmount> amount();
 
   /**
    * {@link Address} of the source account that created and owns the offer.

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NfTokenOfferObjectJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NfTokenOfferObjectJsonTests.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.client.nft;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,14 +29,14 @@ import org.xrpl.xrpl4j.model.flags.NfTokenOfferFlags;
 import org.xrpl.xrpl4j.model.ledger.NfTokenOfferObject;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;
 import org.xrpl.xrpl4j.model.transactions.NfTokenId;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
-public class NfTokenOfferObjectJsonTests  extends AbstractJsonTest {
+public class NfTokenOfferObjectJsonTests extends AbstractJsonTest {
 
   @Test
-  public void testJson() throws JsonProcessingException, JSONException {
-
+  public void testJsonWithXrpAmount() throws JsonProcessingException, JSONException {
     NfTokenOfferObject object = NfTokenOfferObject.builder()
       .amount(XrpCurrencyAmount.ofDrops(10000))
       .destination(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
@@ -50,6 +50,42 @@ public class NfTokenOfferObjectJsonTests  extends AbstractJsonTest {
     String json = "{\n" +
       "    \"Flags\": 1,\n" +
       "    \"Amount\": \"10000\",\n" +
+      "    \"Owner\": \"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW\",\n" +
+      "    \"NFTokenID\": \"000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65\",\n" +
+      "    \"Destination\": \"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn\",\n" +
+      "    \"PreviousTxnID\": \"E3FE6EA3D48F0C2B639448020EA4F03D4F4F8FFDB243A852A0F59177921B4879\",\n" +
+      "    \"PreviousTxnLgrSeq\": 14090896,\n" +
+      "    \"LedgerEntryType\": \"NFTokenOffer\"\n" +
+      "}";
+
+    assertCanSerializeAndDeserialize(object, json);
+  }
+
+  @Test
+  public void testJsonWithIssuedCurrencyAmount() throws JsonProcessingException, JSONException {
+    NfTokenOfferObject object = NfTokenOfferObject.builder()
+      .amount(
+        IssuedCurrencyAmount.builder()
+          .currency("USD")
+          .issuer(Address.of("rsjYGpMWQeNBXbUTkVz4ZKzHefgZSr6rys"))
+          .value("10")
+          .build()
+      )
+      .destination(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+      .owner(Address.of("rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"))
+      .previousTransactionId(Hash256.of("E3FE6EA3D48F0C2B639448020EA4F03D4F4F8FFDB243A852A0F59177921B4879"))
+      .previousTransactionLedgerSequence(UnsignedInteger.valueOf(14090896))
+      .nfTokenId(NfTokenId.of("000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65"))
+      .flags(NfTokenOfferFlags.BUY_TOKEN)
+      .build();
+
+    String json = "{\n" +
+      "    \"Flags\": 1,\n" +
+      "    \"Amount\": {" +
+      "       \"currency\": \"USD\",\n" +
+      "       \"issuer\": \"rsjYGpMWQeNBXbUTkVz4ZKzHefgZSr6rys\"," +
+      "       \"value\": \"10\"" +
+      "    },\n" +
       "    \"Owner\": \"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW\",\n" +
       "    \"NFTokenID\": \"000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65\",\n" +
       "    \"Destination\": \"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn\",\n" +

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NfTokenSellOffersResultTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NfTokenSellOffersResultTest.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.client.nft;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,6 +27,7 @@ import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.NfTokenOfferFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;
 import org.xrpl.xrpl4j.model.transactions.NfTokenId;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
@@ -36,7 +37,7 @@ import java.util.List;
 public class NfTokenSellOffersResultTest extends AbstractJsonTest {
 
   @Test
-  public void test() throws JsonProcessingException, JSONException {
+  public void testWithXrpAmount() throws JsonProcessingException, JSONException {
     SellOffer sellOffer = SellOffer.builder()
       .amount(XrpCurrencyAmount.ofDrops(1000))
       .owner(Address.of("rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"))
@@ -55,6 +56,47 @@ public class NfTokenSellOffersResultTest extends AbstractJsonTest {
     String offer = "{\n" +
       "    \"Flags\": 2,\n" +
       "    \"Amount\": \"1000\",\n" +
+      "    \"owner\": \"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW\",\n" +
+      "    \"nft_offer_index\": \"000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007\"\n" +
+      "}";
+
+    String json = "{\n" +
+      "        \"nft_id\": \"000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007\",\n" +
+      "        \"offers\": [" + offer + "]\n" +
+      "}";
+
+    assertCanSerializeAndDeserialize(params, json);
+  }
+
+  @Test
+  public void testWithIssuedCurrencyAmount() throws JsonProcessingException, JSONException {
+    SellOffer sellOffer = SellOffer.builder()
+      .amount(IssuedCurrencyAmount.builder()
+        .issuer(Address.of("rsjYGpMWQeNBXbUTkVz4ZKzHefgZSr6rys"))
+        .currency("USD")
+        .value("100")
+        .build()
+      )
+      .owner(Address.of("rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"))
+      .flags(NfTokenOfferFlags.AUTHORIZED)
+      .nftOfferIndex(Hash256.of("000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007"))
+      .build();
+
+    List<SellOffer> list = new ArrayList<>();
+    list.add(sellOffer);
+
+    NftSellOffersResult params = NftSellOffersResult.builder()
+      .nfTokenId(NfTokenId.of("000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007"))
+      .offers(list)
+      .build();
+
+    String offer = "{\n" +
+      "    \"Flags\": 2,\n" +
+      "    \"Amount\": {\n" +
+      "      \"issuer\": \"rsjYGpMWQeNBXbUTkVz4ZKzHefgZSr6rys\",\n" +
+      "      \"currency\": \"USD\",\n" +
+      "      \"value\": \"100\"\n" +
+      "    },\n" +
       "    \"owner\": \"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW\",\n" +
       "    \"nft_offer_index\": \"000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007\"\n" +
       "}";

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NfTokenSellOffersResultTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NfTokenSellOffersResultTest.java
@@ -37,7 +37,6 @@ public class NfTokenSellOffersResultTest extends AbstractJsonTest {
 
   @Test
   public void test() throws JsonProcessingException, JSONException {
-
     SellOffer sellOffer = SellOffer.builder()
       .amount(XrpCurrencyAmount.ofDrops(1000))
       .owner(Address.of("rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"))

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NftBuyOffersRequestParamsTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NftBuyOffersRequestParamsTest.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.client.nft;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,21 +21,40 @@ package org.xrpl.xrpl4j.model.client.nft;
  */
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
+import org.xrpl.xrpl4j.model.transactions.Marker;
 import org.xrpl.xrpl4j.model.transactions.NfTokenId;
 
 public class NftBuyOffersRequestParamsTest extends AbstractJsonTest {
 
   @Test
-  public void test() throws JsonProcessingException, JSONException {
+  public void testWithRequiredValue() throws JsonProcessingException, JSONException {
     NftBuyOffersRequestParams params = NftBuyOffersRequestParams.builder()
       .nfTokenId(NfTokenId.of("000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007"))
       .build();
 
     String json = "{\n" +
       "        \"nft_id\": \"000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007\"\n" +
+      "    }";
+
+    assertCanSerializeAndDeserialize(params, json);
+  }
+
+  @Test
+  public void testWithAllValues() throws JsonProcessingException, JSONException {
+    NftBuyOffersRequestParams params = NftBuyOffersRequestParams.builder()
+      .nfTokenId(NfTokenId.of("000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007"))
+      .limit(UnsignedInteger.valueOf(10L))
+      .marker(Marker.of("123"))
+      .build();
+
+    String json = "{\n" +
+      "        \"nft_id\": \"000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007\",\n" +
+      "        \"limit\": 10,\n" +
+      "        \"marker\": \"123\"\n" +
       "    }";
 
     assertCanSerializeAndDeserialize(params, json);

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NftBuyOffersResultTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NftBuyOffersResultTest.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.client.nft;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,6 +27,7 @@ import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.NfTokenOfferFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;
 import org.xrpl.xrpl4j.model.transactions.NfTokenId;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
@@ -36,7 +37,7 @@ import java.util.List;
 public class NftBuyOffersResultTest extends AbstractJsonTest {
 
   @Test
-  public void test() throws JsonProcessingException, JSONException {
+  public void testWithXrpCurrencyAmount() throws JsonProcessingException, JSONException {
 
     BuyOffer buyOffer = BuyOffer.builder()
       .amount(XrpCurrencyAmount.ofDrops(1000))
@@ -56,6 +57,48 @@ public class NftBuyOffersResultTest extends AbstractJsonTest {
     String offer = "{\n" +
       "    \"Flags\": 1,\n" +
       "    \"Amount\": \"1000\",\n" +
+      "    \"owner\": \"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW\",\n" +
+      "    \"nft_offer_index\": \"000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007\"\n" +
+      "}";
+
+    String json = "{\n" +
+      "        \"nft_id\": \"000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007\",\n" +
+      "        \"offers\": [" + offer + "]\n" +
+      "}";
+
+    assertCanSerializeAndDeserialize(params, json);
+  }
+
+  @Test
+  public void testWithIssuedCurrencyAmount() throws JsonProcessingException, JSONException {
+
+    BuyOffer buyOffer = BuyOffer.builder()
+      .amount(IssuedCurrencyAmount.builder()
+        .issuer(Address.of("rsjYGpMWQeNBXbUTkVz4ZKzHefgZSr6rys"))
+        .currency("USD")
+        .value("100")
+        .build()
+      )
+      .owner(Address.of("rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"))
+      .flags(NfTokenOfferFlags.BUY_TOKEN)
+      .nftOfferIndex(Hash256.of("000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007"))
+      .build();
+
+    List<BuyOffer> list = new ArrayList<>();
+    list.add(buyOffer);
+
+    NftBuyOffersResult params = NftBuyOffersResult.builder()
+      .nfTokenId(NfTokenId.of("000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007"))
+      .offers(list)
+      .build();
+
+    String offer = "{\n" +
+      "    \"Flags\": 1,\n" +
+      "    \"Amount\": {\n" +
+      "      \"issuer\": \"rsjYGpMWQeNBXbUTkVz4ZKzHefgZSr6rys\",\n" +
+      "      \"currency\": \"USD\",\n" +
+      "      \"value\": \"100\"\n" +
+      "    },\n" +
       "    \"owner\": \"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW\",\n" +
       "    \"nft_offer_index\": \"000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007\"\n" +
       "}";

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NftSellOffersRequestParamsTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NftSellOffersRequestParamsTest.java
@@ -53,7 +53,7 @@ public class NftSellOffersRequestParamsTest extends AbstractJsonTest {
 
     String json = "{\n" +
       "        \"nft_id\": \"000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007\",\n" +
-      "        \"limit\": \"10\",\n" +
+      "        \"limit\": 10,\n" +
       "        \"marker\": \"123\"\n" +
       "    }";
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NftSellOffersRequestParamsTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NftSellOffersRequestParamsTest.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.client.nft;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,21 +21,40 @@ package org.xrpl.xrpl4j.model.client.nft;
  */
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
+import org.xrpl.xrpl4j.model.transactions.Marker;
 import org.xrpl.xrpl4j.model.transactions.NfTokenId;
 
 public class NftSellOffersRequestParamsTest extends AbstractJsonTest {
 
   @Test
-  public void test() throws JsonProcessingException, JSONException {
+  public void testWithRequiredValue() throws JsonProcessingException, JSONException {
     NftSellOffersRequestParams params = NftSellOffersRequestParams.builder()
       .nfTokenId(NfTokenId.of("000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007"))
       .build();
 
     String json = "{\n" +
       "        \"nft_id\": \"000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007\"\n" +
+      "    }";
+
+    assertCanSerializeAndDeserialize(params, json);
+  }
+
+  @Test
+  public void testWithAllValues() throws JsonProcessingException, JSONException {
+    NftSellOffersRequestParams params = NftSellOffersRequestParams.builder()
+      .nfTokenId(NfTokenId.of("000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007"))
+      .limit(UnsignedInteger.valueOf(10L))
+      .marker(Marker.of("123"))
+      .build();
+
+    String json = "{\n" +
+      "        \"nft_id\": \"000100001E962F495F07A990F4ED55ACCFEEF365DBAA76B6A048C0A200000007\",\n" +
+      "        \"limit\": \"10\",\n" +
+      "        \"marker\": \"123\"\n" +
       "    }";
 
     assertCanSerializeAndDeserialize(params, json);

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/TransactionMetadataTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/TransactionMetadataTest.java
@@ -515,78 +515,78 @@ class TransactionMetadataTest {
 
   @Test
   void testMetadataWithNfTokenOfferDeletedNode() throws JsonProcessingException {
-    String json = "{\n"
-      + "  \"AffectedNodes\": [\n"
-      + "    {\n"
-      + "      \"ModifiedNode\": {\n"
-      + "        \"FinalFields\": {\n"
-      + "          \"Flags\": 0,\n"
-      + "          \"IndexPrevious\": \"1\",\n"
-      + "          \"Owner\": \"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n"
-      + "          \"RootIndex\": \"DB2B7599894EAE13B565B539990BEADBE6F2BED04A0ADCD89DC4BB68C09CF06C\"\n"
-      + "        },\n"
-      + "        \"LedgerEntryType\": \"DirectoryNode\",\n"
-      + "        \"LedgerIndex\": \"0BF5AFC91640BE6B1F595949A57FA9D113D013FEB0C19DFFCFFC521A2D0590CD\"\n"
-      + "      }\n"
-      + "    },\n"
-      + "    {\n"
-      + "      \"DeletedNode\": {\n"
-      + "        \"FinalFields\": {\n"
-      + "          \"Amount\": {\n"
-      + "            \"currency\": \"534F4C4F00000000000000000000000000000000\",\n"
-      + "            \"issuer\": \"rHZwvHEs56GCmHupwjA4RY7oPA3EoAJWuN\",\n"
-      + "            \"value\": \"0.4\"\n"
-      + "          },\n"
-      + "          \"Flags\": 1,\n"
-      + "          \"NFTokenID\": \"00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD\",\n"
-      + "          \"NFTokenOfferNode\": \"0\",\n"
-      + "          \"Owner\": \"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n"
-      + "          \"OwnerNode\": \"2\",\n"
-      + "          \"PreviousTxnID\": \"78D3B7A4B07BFC1F5D7EBD9844B25209F3D5885F347EBA0868FEF2672A91F9DF\",\n"
-      + "          \"PreviousTxnLgrSeq\": 39480038\n"
-      + "        },\n"
-      + "        \"LedgerEntryType\": \"NFTokenOffer\",\n"
-      + "        \"LedgerIndex\": \"0F512CD1108EF19E3662FB0F830C803853DCBAE8B5FEF2A46E2A99ACCE1E8177\"\n"
-      + "      }\n"
-      + "    },\n"
-      + "    {\n"
-      + "      \"ModifiedNode\": {\n"
-      + "        \"FinalFields\": {\n"
-      + "          \"Flags\": 2,\n"
-      + "          \"NFTokenID\": \"00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD\",\n"
-      + "          \"RootIndex\": \"CF89EB7D051F954EB3FCE9115D5532BA2BF39F1311BB69F2633C002A87972B71\"\n"
-      + "        },\n"
-      + "        \"LedgerEntryType\": \"DirectoryNode\",\n"
-      + "        \"LedgerIndex\": \"CF89EB7D051F954EB3FCE9115D5532BA2BF39F1311BB69F2633C002A87972B71\"\n"
-      + "      }\n"
-      + "    },\n"
-      + "    {\n"
-      + "      \"ModifiedNode\": {\n"
-      + "        \"FinalFields\": {\n"
-      + "          \"Account\": \"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n"
-      + "          \"Balance\": \"953788095\",\n"
-      + "          \"BurnedNFTokens\": 126,\n"
-      + "          \"EmailHash\": \"1D1382344586ECFF844DACFF698C2EFB\",\n"
-      + "          \"Flags\": 0,\n"
-      + "          \"MintedNFTokens\": 254,\n"
-      + "          \"OwnerCount\": 82,\n"
-      + "          \"Sequence\": 35260003\n"
-      + "        },\n"
-      + "        \"LedgerEntryType\": \"AccountRoot\",\n"
-      + "        \"LedgerIndex\": \"D6C4EE995A40D6A22172016806CE813DE1578B11158B4EAA5115C563B4DC4B29\",\n"
-      + "        \"PreviousFields\": {\n"
-      + "          \"Balance\": \"953788294\",\n"
-      + "          \"OwnerCount\": 83,\n"
-      + "          \"Sequence\": 35260002\n"
-      + "        },\n"
-      + "        \"PreviousTxnID\": \"A39E1C58CC442D99123D6EA0BA3E25995BC6221D98F9A191FAC04FDDC583BF63\",\n"
-      + "        \"PreviousTxnLgrSeq\": 39480040\n"
-      + "      }\n"
-      + "    }\n"
-      + "  ],\n"
-      + "  \"TransactionIndex\": 1,\n"
-      + "  \"TransactionResult\": \"tesSUCCESS\"\n"
-      + "}";
+    String json = "{\n" +
+      "  \"AffectedNodes\": [\n" +
+      "    {\n" +
+      "      \"ModifiedNode\": {\n" +
+      "        \"FinalFields\": {\n" +
+      "          \"Flags\": 0,\n" +
+      "          \"IndexPrevious\": \"1\",\n" +
+      "          \"Owner\": \"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n" +
+      "          \"RootIndex\": \"DB2B7599894EAE13B565B539990BEADBE6F2BED04A0ADCD89DC4BB68C09CF06C\"\n" +
+      "        },\n" +
+      "        \"LedgerEntryType\": \"DirectoryNode\",\n" +
+      "        \"LedgerIndex\": \"0BF5AFC91640BE6B1F595949A57FA9D113D013FEB0C19DFFCFFC521A2D0590CD\"\n" +
+      "      }\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"DeletedNode\": {\n" +
+      "        \"FinalFields\": {\n" +
+      "          \"Amount\": {\n" +
+      "            \"currency\": \"534F4C4F00000000000000000000000000000000\",\n" +
+      "            \"issuer\": \"rHZwvHEs56GCmHupwjA4RY7oPA3EoAJWuN\",\n" +
+      "            \"value\": \"0.4\"\n" +
+      "          },\n" +
+      "          \"Flags\": 1,\n" +
+      "          \"NFTokenID\": \"00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD\",\n" +
+      "          \"NFTokenOfferNode\": \"0\",\n" +
+      "          \"Owner\": \"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n" +
+      "          \"OwnerNode\": \"2\",\n" +
+      "          \"PreviousTxnID\": \"78D3B7A4B07BFC1F5D7EBD9844B25209F3D5885F347EBA0868FEF2672A91F9DF\",\n" +
+      "          \"PreviousTxnLgrSeq\": 39480038\n" +
+      "        },\n" +
+      "        \"LedgerEntryType\": \"NFTokenOffer\",\n" +
+      "        \"LedgerIndex\": \"0F512CD1108EF19E3662FB0F830C803853DCBAE8B5FEF2A46E2A99ACCE1E8177\"\n" +
+      "      }\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"ModifiedNode\": {\n" +
+      "        \"FinalFields\": {\n" +
+      "          \"Flags\": 2,\n" +
+      "          \"NFTokenID\": \"00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD\",\n" +
+      "          \"RootIndex\": \"CF89EB7D051F954EB3FCE9115D5532BA2BF39F1311BB69F2633C002A87972B71\"\n" +
+      "        },\n" +
+      "        \"LedgerEntryType\": \"DirectoryNode\",\n" +
+      "        \"LedgerIndex\": \"CF89EB7D051F954EB3FCE9115D5532BA2BF39F1311BB69F2633C002A87972B71\"\n" +
+      "      }\n" +
+      "    },\n" +
+      "    {\n" +
+      "      \"ModifiedNode\": {\n" +
+      "        \"FinalFields\": {\n" +
+      "          \"Account\": \"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n" +
+      "          \"Balance\": \"953788095\",\n" +
+      "          \"BurnedNFTokens\": 126,\n" +
+      "          \"EmailHash\": \"1D1382344586ECFF844DACFF698C2EFB\",\n" +
+      "          \"Flags\": 0,\n" +
+      "          \"MintedNFTokens\": 254,\n" +
+      "          \"OwnerCount\": 82,\n" +
+      "          \"Sequence\": 35260003\n" +
+      "        },\n" +
+      "        \"LedgerEntryType\": \"AccountRoot\",\n" +
+      "        \"LedgerIndex\": \"D6C4EE995A40D6A22172016806CE813DE1578B11158B4EAA5115C563B4DC4B29\",\n" +
+      "        \"PreviousFields\": {\n" +
+      "          \"Balance\": \"953788294\",\n" +
+      "          \"OwnerCount\": 83,\n" +
+      "          \"Sequence\": 35260002\n" +
+      "        },\n" +
+      "        \"PreviousTxnID\": \"A39E1C58CC442D99123D6EA0BA3E25995BC6221D98F9A191FAC04FDDC583BF63\",\n" +
+      "        \"PreviousTxnLgrSeq\": 39480040\n" +
+      "      }\n" +
+      "    }\n" +
+      "  ],\n" +
+      "  \"TransactionIndex\": 1,\n" +
+      "  \"TransactionResult\": \"tesSUCCESS\"\n" +
+      "}";
 
     TransactionMetadata transactionMetadata = objectMapper.readValue(json, TransactionMetadata.class);
     AffectedNode nftDeletedNode = transactionMetadata.affectedNodes().get(1);

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/TransactionMetadataTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/TransactionMetadataTest.java
@@ -1,25 +1,32 @@
 package org.xrpl.xrpl4j.model.transactions;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.UnsignedInteger;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.flags.NfTokenOfferFlags;
 import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.transactions.metadata.AffectedNode;
 import org.xrpl.xrpl4j.model.transactions.metadata.CreatedNode;
 import org.xrpl.xrpl4j.model.transactions.metadata.DeletedNode;
 import org.xrpl.xrpl4j.model.transactions.metadata.ImmutableCreatedNode;
 import org.xrpl.xrpl4j.model.transactions.metadata.ImmutableDeletedNode;
+import org.xrpl.xrpl4j.model.transactions.metadata.ImmutableMetaNfTokenOfferObject;
 import org.xrpl.xrpl4j.model.transactions.metadata.ImmutableModifiedNode;
 import org.xrpl.xrpl4j.model.transactions.metadata.MetaAccountRootObject;
 import org.xrpl.xrpl4j.model.transactions.metadata.MetaCheckObject;
 import org.xrpl.xrpl4j.model.transactions.metadata.MetaDepositPreAuthObject;
 import org.xrpl.xrpl4j.model.transactions.metadata.MetaEscrowObject;
+import org.xrpl.xrpl4j.model.transactions.metadata.MetaLedgerEntryType;
 import org.xrpl.xrpl4j.model.transactions.metadata.MetaLedgerObject;
 import org.xrpl.xrpl4j.model.transactions.metadata.MetaNfTokenOfferObject;
 import org.xrpl.xrpl4j.model.transactions.metadata.MetaNfTokenPageObject;
@@ -51,7 +58,7 @@ class TransactionMetadataTest {
   ObjectMapper objectMapper = ObjectMapperFactory.create();
 
   @Test
-  void deserializeMetadataFromXrplOrg() throws JsonProcessingException {
+  void deserializeMetadataFromXrplOrg() {
     String json = "{\n" +
       "  \"AffectedNodes\": [\n" +
       "    {\n" +
@@ -503,8 +510,110 @@ class TransactionMetadataTest {
       "  }\n" +
       "}";
 
+    assertThatNoException().isThrownBy(() -> objectMapper.readValue(json, TransactionMetadata.class));
+  }
+
+  @Test
+  void testMetadataWithNfTokenOfferDeletedNode() throws JsonProcessingException {
+    String json = "{\n"
+      + "  \"AffectedNodes\": [\n"
+      + "    {\n"
+      + "      \"ModifiedNode\": {\n"
+      + "        \"FinalFields\": {\n"
+      + "          \"Flags\": 0,\n"
+      + "          \"IndexPrevious\": \"1\",\n"
+      + "          \"Owner\": \"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n"
+      + "          \"RootIndex\": \"DB2B7599894EAE13B565B539990BEADBE6F2BED04A0ADCD89DC4BB68C09CF06C\"\n"
+      + "        },\n"
+      + "        \"LedgerEntryType\": \"DirectoryNode\",\n"
+      + "        \"LedgerIndex\": \"0BF5AFC91640BE6B1F595949A57FA9D113D013FEB0C19DFFCFFC521A2D0590CD\"\n"
+      + "      }\n"
+      + "    },\n"
+      + "    {\n"
+      + "      \"DeletedNode\": {\n"
+      + "        \"FinalFields\": {\n"
+      + "          \"Amount\": {\n"
+      + "            \"currency\": \"534F4C4F00000000000000000000000000000000\",\n"
+      + "            \"issuer\": \"rHZwvHEs56GCmHupwjA4RY7oPA3EoAJWuN\",\n"
+      + "            \"value\": \"0.4\"\n"
+      + "          },\n"
+      + "          \"Flags\": 1,\n"
+      + "          \"NFTokenID\": \"00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD\",\n"
+      + "          \"NFTokenOfferNode\": \"0\",\n"
+      + "          \"Owner\": \"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n"
+      + "          \"OwnerNode\": \"2\",\n"
+      + "          \"PreviousTxnID\": \"78D3B7A4B07BFC1F5D7EBD9844B25209F3D5885F347EBA0868FEF2672A91F9DF\",\n"
+      + "          \"PreviousTxnLgrSeq\": 39480038\n"
+      + "        },\n"
+      + "        \"LedgerEntryType\": \"NFTokenOffer\",\n"
+      + "        \"LedgerIndex\": \"0F512CD1108EF19E3662FB0F830C803853DCBAE8B5FEF2A46E2A99ACCE1E8177\"\n"
+      + "      }\n"
+      + "    },\n"
+      + "    {\n"
+      + "      \"ModifiedNode\": {\n"
+      + "        \"FinalFields\": {\n"
+      + "          \"Flags\": 2,\n"
+      + "          \"NFTokenID\": \"00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD\",\n"
+      + "          \"RootIndex\": \"CF89EB7D051F954EB3FCE9115D5532BA2BF39F1311BB69F2633C002A87972B71\"\n"
+      + "        },\n"
+      + "        \"LedgerEntryType\": \"DirectoryNode\",\n"
+      + "        \"LedgerIndex\": \"CF89EB7D051F954EB3FCE9115D5532BA2BF39F1311BB69F2633C002A87972B71\"\n"
+      + "      }\n"
+      + "    },\n"
+      + "    {\n"
+      + "      \"ModifiedNode\": {\n"
+      + "        \"FinalFields\": {\n"
+      + "          \"Account\": \"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n"
+      + "          \"Balance\": \"953788095\",\n"
+      + "          \"BurnedNFTokens\": 126,\n"
+      + "          \"EmailHash\": \"1D1382344586ECFF844DACFF698C2EFB\",\n"
+      + "          \"Flags\": 0,\n"
+      + "          \"MintedNFTokens\": 254,\n"
+      + "          \"OwnerCount\": 82,\n"
+      + "          \"Sequence\": 35260003\n"
+      + "        },\n"
+      + "        \"LedgerEntryType\": \"AccountRoot\",\n"
+      + "        \"LedgerIndex\": \"D6C4EE995A40D6A22172016806CE813DE1578B11158B4EAA5115C563B4DC4B29\",\n"
+      + "        \"PreviousFields\": {\n"
+      + "          \"Balance\": \"953788294\",\n"
+      + "          \"OwnerCount\": 83,\n"
+      + "          \"Sequence\": 35260002\n"
+      + "        },\n"
+      + "        \"PreviousTxnID\": \"A39E1C58CC442D99123D6EA0BA3E25995BC6221D98F9A191FAC04FDDC583BF63\",\n"
+      + "        \"PreviousTxnLgrSeq\": 39480040\n"
+      + "      }\n"
+      + "    }\n"
+      + "  ],\n"
+      + "  \"TransactionIndex\": 1,\n"
+      + "  \"TransactionResult\": \"tesSUCCESS\"\n"
+      + "}";
+
     TransactionMetadata transactionMetadata = objectMapper.readValue(json, TransactionMetadata.class);
-    System.out.println(transactionMetadata);
+    AffectedNode nftDeletedNode = transactionMetadata.affectedNodes().get(1);
+    AffectedNode expectedNode = ImmutableDeletedNode.builder()
+      .ledgerEntryType(MetaLedgerEntryType.NFTOKEN_OFFER)
+      .ledgerIndex(Hash256.of("0F512CD1108EF19E3662FB0F830C803853DCBAE8B5FEF2A46E2A99ACCE1E8177"))
+      .finalFields(
+        ImmutableMetaNfTokenOfferObject.builder()
+          .amount(
+            IssuedCurrencyAmount.builder()
+              .currency("534F4C4F00000000000000000000000000000000")
+              .issuer(Address.of("rHZwvHEs56GCmHupwjA4RY7oPA3EoAJWuN"))
+              .value("0.4")
+              .build()
+          )
+          .flags(NfTokenOfferFlags.BUY_TOKEN)
+          .nfTokenId(NfTokenId.of("00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD"))
+          .owner(Address.of("rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu"))
+          .ownerNode("2")
+          .previousTransactionId(Hash256.of("78D3B7A4B07BFC1F5D7EBD9844B25209F3D5885F347EBA0868FEF2672A91F9DF"))
+          .previousTransactionLedgerSequence(LedgerIndex.of(UnsignedInteger.valueOf(39480038)))
+          .offerNode("0")
+          .build()
+      )
+      .build();
+
+    assertThat(nftDeletedNode).isEqualTo(expectedNode);
   }
 
   /**

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/metadata/MetaNfTokenOfferObjectTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/metadata/MetaNfTokenOfferObjectTest.java
@@ -24,6 +24,7 @@ class MetaNfTokenOfferObjectTest extends AbstractJsonTest {
       .previousTransactionLedgerSequence(LedgerIndex.of(UnsignedInteger.valueOf(39480038)))
       .nfTokenId(NfTokenId.of("00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD"))
       .ownerNode("2")
+      .offerNode("0")
       .flags(NfTokenOfferFlags.BUY_TOKEN)
       .build();
 
@@ -56,6 +57,7 @@ class MetaNfTokenOfferObjectTest extends AbstractJsonTest {
       .previousTransactionLedgerSequence(LedgerIndex.of(UnsignedInteger.valueOf(39480038)))
       .nfTokenId(NfTokenId.of("00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD"))
       .ownerNode("2")
+      .offerNode("0")
       .flags(NfTokenOfferFlags.BUY_TOKEN)
       .build();
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/metadata/MetaNfTokenOfferObjectTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/metadata/MetaNfTokenOfferObjectTest.java
@@ -1,0 +1,78 @@
+package org.xrpl.xrpl4j.model.transactions.metadata;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.primitives.UnsignedInteger;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.AbstractJsonTest;
+import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
+import org.xrpl.xrpl4j.model.flags.NfTokenOfferFlags;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;
+import org.xrpl.xrpl4j.model.transactions.NfTokenId;
+import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
+
+class MetaNfTokenOfferObjectTest extends AbstractJsonTest {
+
+  @Test
+  public void testJsonWithXrpAmount() throws JsonProcessingException, JSONException {
+    MetaNfTokenOfferObject object = ImmutableMetaNfTokenOfferObject.builder()
+      .amount(XrpCurrencyAmount.ofDrops(10000))
+      .owner(Address.of("rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu"))
+      .previousTransactionId(Hash256.of("78D3B7A4B07BFC1F5D7EBD9844B25209F3D5885F347EBA0868FEF2672A91F9DF"))
+      .previousTransactionLedgerSequence(LedgerIndex.of(UnsignedInteger.valueOf(39480038)))
+      .nfTokenId(NfTokenId.of("00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD"))
+      .ownerNode("2")
+      .flags(NfTokenOfferFlags.BUY_TOKEN)
+      .build();
+
+    String json = "{\n"
+      + "\"Amount\": \"10000\",\n"
+      + "\"Flags\":1,\n"
+      + "\"NFTokenID\":\"00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD\",\n"
+      + "\"Owner\":\"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n"
+      + "\"OwnerNode\":\"2\",\n"
+      + "\"PreviousTxnID\":\"78D3B7A4B07BFC1F5D7EBD9844B25209F3D5885F347EBA0868FEF2672A91F9DF\",\n"
+      + "\"PreviousTxnLgrSeq\":39480038\n"
+      + "}";
+
+    assertCanSerializeAndDeserialize(object, json, MetaNfTokenOfferObject.class);
+  }
+
+  @Test
+  public void testJsonWithIssuedCurrencyAmount() throws JsonProcessingException, JSONException {
+    MetaNfTokenOfferObject object = ImmutableMetaNfTokenOfferObject.builder()
+      .amount(
+        IssuedCurrencyAmount.builder()
+          .currency("534F4C4F00000000000000000000000000000000")
+          .issuer(Address.of("rHZwvHEs56GCmHupwjA4RY7oPA3EoAJWuN"))
+          .value("0.4")
+          .build()
+      )
+      .owner(Address.of("rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu"))
+      .previousTransactionId(Hash256.of("78D3B7A4B07BFC1F5D7EBD9844B25209F3D5885F347EBA0868FEF2672A91F9DF"))
+      .previousTransactionLedgerSequence(LedgerIndex.of(UnsignedInteger.valueOf(39480038)))
+      .nfTokenId(NfTokenId.of("00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD"))
+      .ownerNode("2")
+      .flags(NfTokenOfferFlags.BUY_TOKEN)
+      .build();
+
+    String json = "{\n"
+      + "\"Amount\": {\n"
+      + "   \"currency\":\"534F4C4F00000000000000000000000000000000\",\n"
+      + "   \"issuer\":\"rHZwvHEs56GCmHupwjA4RY7oPA3EoAJWuN\",\n"
+      + "   \"value\":\"0.4\"\n"
+      + "},\n"
+      + "\"Flags\":1,\n"
+      + "\"NFTokenID\":\"00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD\",\n"
+      + "\"Owner\":\"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n"
+      + "\"OwnerNode\":\"2\",\n"
+      + "\"PreviousTxnID\":\"78D3B7A4B07BFC1F5D7EBD9844B25209F3D5885F347EBA0868FEF2672A91F9DF\",\n"
+      + "\"PreviousTxnLgrSeq\":39480038\n"
+      + "}";
+
+    assertCanSerializeAndDeserialize(object, json, MetaNfTokenOfferObject.class);
+  }
+
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/metadata/MetaNfTokenOfferObjectTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/metadata/MetaNfTokenOfferObjectTest.java
@@ -27,15 +27,16 @@ class MetaNfTokenOfferObjectTest extends AbstractJsonTest {
       .flags(NfTokenOfferFlags.BUY_TOKEN)
       .build();
 
-    String json = "{\n"
-      + "\"Amount\": \"10000\",\n"
-      + "\"Flags\":1,\n"
-      + "\"NFTokenID\":\"00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD\",\n"
-      + "\"Owner\":\"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n"
-      + "\"OwnerNode\":\"2\",\n"
-      + "\"PreviousTxnID\":\"78D3B7A4B07BFC1F5D7EBD9844B25209F3D5885F347EBA0868FEF2672A91F9DF\",\n"
-      + "\"PreviousTxnLgrSeq\":39480038\n"
-      + "}";
+    String json = "{\n" +
+      "          \"Amount\": \"10000\",\n" +
+      "          \"Flags\": 1,\n" +
+      "          \"NFTokenID\": \"00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD\",\n" +
+      "          \"NFTokenOfferNode\": \"0\",\n" +
+      "          \"Owner\": \"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n" +
+      "          \"OwnerNode\": \"2\",\n" +
+      "          \"PreviousTxnID\": \"78D3B7A4B07BFC1F5D7EBD9844B25209F3D5885F347EBA0868FEF2672A91F9DF\",\n" +
+      "          \"PreviousTxnLgrSeq\": 39480038\n" +
+      "        }";
 
     assertCanSerializeAndDeserialize(object, json, MetaNfTokenOfferObject.class);
   }
@@ -58,19 +59,20 @@ class MetaNfTokenOfferObjectTest extends AbstractJsonTest {
       .flags(NfTokenOfferFlags.BUY_TOKEN)
       .build();
 
-    String json = "{\n"
-      + "\"Amount\": {\n"
-      + "   \"currency\":\"534F4C4F00000000000000000000000000000000\",\n"
-      + "   \"issuer\":\"rHZwvHEs56GCmHupwjA4RY7oPA3EoAJWuN\",\n"
-      + "   \"value\":\"0.4\"\n"
-      + "},\n"
-      + "\"Flags\":1,\n"
-      + "\"NFTokenID\":\"00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD\",\n"
-      + "\"Owner\":\"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n"
-      + "\"OwnerNode\":\"2\",\n"
-      + "\"PreviousTxnID\":\"78D3B7A4B07BFC1F5D7EBD9844B25209F3D5885F347EBA0868FEF2672A91F9DF\",\n"
-      + "\"PreviousTxnLgrSeq\":39480038\n"
-      + "}";
+    String json = "{\n" +
+      "          \"Amount\": {\n" +
+      "            \"currency\": \"534F4C4F00000000000000000000000000000000\",\n" +
+      "            \"issuer\": \"rHZwvHEs56GCmHupwjA4RY7oPA3EoAJWuN\",\n" +
+      "            \"value\": \"0.4\"\n" +
+      "          },\n" +
+      "          \"Flags\": 1,\n" +
+      "          \"NFTokenID\": \"00080BB86F12FFF50C3C44827709AA868A910613902F810FA11F9798000000FD\",\n" +
+      "          \"NFTokenOfferNode\": \"0\",\n" +
+      "          \"Owner\": \"rB3JmRd5m292YjCsCr65tc8dwZz2WN7HQu\",\n" +
+      "          \"OwnerNode\": \"2\",\n" +
+      "          \"PreviousTxnID\": \"78D3B7A4B07BFC1F5D7EBD9844B25209F3D5885F347EBA0868FEF2672A91F9DF\",\n" +
+      "          \"PreviousTxnLgrSeq\": 39480038\n" +
+      "        }";
 
     assertCanSerializeAndDeserialize(object, json, MetaNfTokenOfferObject.class);
   }


### PR DESCRIPTION
Fixes #450 

Some of the `amount` fields in NFT related objects were typed as `XrpCurrencyAmount`s, when they should have been `CurrencyAmount`. This was noticed because parsing transaction metadata with an `AffectedNode` for `NFTokenOffer` objects would throw an exception. This is because xrpl4j could not deserialize to a `MetaNfTokenOfferObject` because the `amount` field could not be deserialized correctly. 

This PR changes the `amount` field in `SellOffer`, `BuyOffer`, `NfTokenOfferObject` and `MetaNfTokenOfferObject` from `XrpCurrencyAmount` to `CurrencyAmount`.