### PR TITLE
Add Zero AccountSetFlag

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/AccountSet.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/AccountSet.java
@@ -205,7 +205,11 @@ public interface AccountSet extends Transaction {
    * </ul>
    */
   enum AccountSetFlag {
-
+    /**
+     * This flag will do nothing but exists to accurately deserialize AccountSet transactions whose {@code SetFlag}
+     * or {@code ClearFlag} fields are zero.
+     */
+    NONE(0),
     /**
      * Require a destination tag to send transactions to this account.
      */
@@ -274,7 +278,7 @@ public interface AccountSet extends Transaction {
      */
     DISALLOW_INCOMING_TRUSTLINE(15);
 
-    int value;
+    final int value;
 
     AccountSetFlag(int value) {
       this.value = value;

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/AccountSetJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/AccountSetJsonTests.java
@@ -153,4 +153,42 @@ public class AccountSetJsonTests extends AbstractJsonTest {
 
     assertCanSerializeAndDeserialize(accountSet, json);
   }
+
+  @Test
+  void testJsonWithZeroClearFlagAndSetFlag() throws JSONException, JsonProcessingException {
+    AccountSet accountSet = AccountSet.builder()
+      .account(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+      .fee(XrpCurrencyAmount.ofDrops(12))
+      .sequence(UnsignedInteger.valueOf(5))
+      .domain("6578616D706C652E636F6D")
+      .setFlag(AccountSetFlag.NONE)
+      .messageKey("03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB")
+      .transferRate(UnsignedInteger.valueOf(1000000001))
+      .tickSize(UnsignedInteger.valueOf(15))
+      .clearFlag(AccountSetFlag.NONE)
+      .emailHash("f9879d71855b5ff21e4963273a886bfc")
+      .signingPublicKey(
+        PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
+      )
+      .mintAccount(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+      .build();
+
+    String json = "{\n" +
+      "    \"TransactionType\":\"AccountSet\",\n" +
+      "    \"Account\":\"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn\",\n" +
+      "    \"Fee\":\"12\",\n" +
+      "    \"Sequence\":5,\n" +
+      "    \"Domain\":\"6578616D706C652E636F6D\",\n" +
+      "    \"SetFlag\":0,\n" +
+      "    \"MessageKey\":\"03AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB\",\n" +
+      "    \"TransferRate\":1000000001,\n" +
+      "    \"TickSize\":15,\n" +
+      "    \"ClearFlag\":0,\n" +
+      "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+      "    \"NFTokenMinter\" : \"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn\",\n" +
+      "    \"EmailHash\":\"f9879d71855b5ff21e4963273a886bfc\"\n" +
+      "}";
+
+    assertCanSerializeAndDeserialize(accountSet, json);
+  }
 }


### PR DESCRIPTION
Ledger 39597277 on testnet contains an AccountSet transaction where `ClearFlag` is `0`. `AccountSetFlag` does not have an enum value for `0`, so the `AccountSet` transaction failed to get deserialized to an `AccountSet` xrpl4j object. This PR adds a new `AccountSetFlag` called `NONE` that maps to `0`.