### PR TITLE
Support for NetworkID

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/client/serverinfo/ServerInfo.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/client/serverinfo/ServerInfo.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.client.serverinfo;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,6 +37,7 @@ import com.google.common.primitives.UnsignedLong;
 import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
 import java.io.IOException;
@@ -176,6 +177,14 @@ public interface ServerInfo {
    */
   @JsonProperty("validation_quorum")
   Optional<UnsignedInteger> validationQuorum();
+
+  /**
+   * The {@link NetworkId} of the network that this server is connected to.
+   *
+   * @return An optionally-present {@link NetworkId}.
+   */
+  @JsonProperty("network_id")
+  Optional<NetworkId> networkId();
 
   /**
    * Deserializes complete_ledgers field in the server_info response from hyphen-separated ledger indices to list of

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/NetworkIdDeserializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/NetworkIdDeserializer.java
@@ -1,0 +1,47 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: core
+ * %%
+ * Copyright (C) 2020 - 2023 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.google.common.primitives.UnsignedInteger;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson deserializer for {@link NetworkId}s.
+ */
+public class NetworkIdDeserializer extends StdDeserializer<NetworkId> {
+
+  /**
+   * No-args constructor.
+   */
+  public NetworkIdDeserializer() {
+    super(NetworkId.class);
+  }
+
+  @Override
+  public NetworkId deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
+    return NetworkId.of(UnsignedInteger.valueOf(jsonParser.getValueAsLong()));
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/NetworkIdSerializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/NetworkIdSerializer.java
@@ -1,0 +1,46 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: core
+ * %%
+ * Copyright (C) 2020 - 2023 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson serializer for {@link NetworkId}s.
+ */
+public class NetworkIdSerializer extends StdScalarSerializer<NetworkId> {
+
+  /**
+   * No-args constructor.
+   */
+  public NetworkIdSerializer() {
+    super(NetworkId.class, false);
+  }
+
+  @Override
+  public void serialize(NetworkId networkId, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    gen.writeNumber(networkId.value().longValue());
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/NetworkIdSerializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/NetworkIdSerializer.java
@@ -36,7 +36,7 @@ public class NetworkIdSerializer extends StdScalarSerializer<NetworkId> {
    * No-args constructor.
    */
   public NetworkIdSerializer() {
-    super(NetworkId.class, false);
+    super(NetworkId.class);
   }
 
   @Override

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
@@ -198,4 +198,7 @@ public interface Transaction {
   @JsonProperty("TxnSignature")
   Optional<Signature> transactionSignature();
 
+  @JsonProperty("NetworkID")
+  Optional<NetworkId> networkId();
+
 }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -37,6 +37,8 @@ import org.xrpl.xrpl4j.model.jackson.modules.Hash256Deserializer;
 import org.xrpl.xrpl4j.model.jackson.modules.Hash256Serializer;
 import org.xrpl.xrpl4j.model.jackson.modules.MarkerDeserializer;
 import org.xrpl.xrpl4j.model.jackson.modules.MarkerSerializer;
+import org.xrpl.xrpl4j.model.jackson.modules.NetworkIdDeserializer;
+import org.xrpl.xrpl4j.model.jackson.modules.NetworkIdSerializer;
 import org.xrpl.xrpl4j.model.jackson.modules.NfTokenIdDeserializer;
 import org.xrpl.xrpl4j.model.jackson.modules.NfTokenIdSerializer;
 import org.xrpl.xrpl4j.model.jackson.modules.NfTokenUriSerializer;
@@ -350,6 +352,7 @@ public class Wrappers {
      * Construct {@link TransferFee} as a percentage value.
      *
      * @param percent of type {@link BigDecimal}
+     *
      * @return {@link TransferFee}
      */
     static TransferFee ofPercent(BigDecimal percent) {
@@ -374,4 +377,30 @@ public class Wrappers {
 
   }
 
+  /**
+   * A wrapped {@link com.google.common.primitives.UnsignedInteger} containing a Network ID.
+   */
+  @Value.Immutable
+  @Wrapped
+  @JsonSerialize(as = NetworkId.class, using = NetworkIdSerializer.class)
+  @JsonDeserialize(as = NetworkId.class, using = NetworkIdDeserializer.class)
+  abstract static class _NetworkId extends Wrapper<UnsignedInteger> implements Serializable {
+
+    @Override
+    public String toString() {
+      return this.value().toString();
+    }
+
+    /**
+     * Construct a {@link NetworkId} from a {@code long}. The supplied value must be less than or equal to
+     * 4,294,967,295, the largest unsigned 32-bit integer.
+     *
+     * @param networkId A {@code long}.
+     *
+     * @return A {@link NetworkId}.
+     */
+    public static NetworkId of(long networkId) {
+      return NetworkId.of(UnsignedInteger.valueOf(networkId));
+    }
+  }
 }

--- a/xrpl4j-core/src/main/resources/definitions.json
+++ b/xrpl4j-core/src/main/resources/definitions.json
@@ -1,29 +1,33 @@
 {
   "TYPES": {
-    "Validation": 10003,
     "Done": -1,
+    "Unknown": -2,
+    "NotPresent": 0,
+    "UInt16": 1,
+    "UInt32": 2,
+    "UInt64": 3,
     "Hash128": 4,
+    "Hash256": 5,
+    "Amount": 6,
     "Blob": 7,
     "AccountID": 8,
-    "Amount": 6,
-    "Hash256": 5,
-    "UInt8": 16,
-    "Vector256": 19,
     "STObject": 14,
-    "Unknown": -2,
-    "Transaction": 10001,
+    "STArray": 15,
+    "UInt8": 16,
     "Hash160": 17,
     "PathSet": 18,
+    "Vector256": 19,
+    "UInt96": 20,
+    "UInt192": 21,
+    "UInt384": 22,
+    "UInt512": 23,
+    "Issue": 24,
+    "Transaction": 10001,
     "LedgerEntry": 10002,
-    "UInt16": 1,
-    "NotPresent": 0,
-    "UInt64": 3,
-    "UInt32": 2,
-    "STArray": 15
+    "Validation": 10003,
+    "Metadata": 10004
   },
   "LEDGER_ENTRY_TYPES": {
-    "Any": -3,
-    "Child": -2,
     "Invalid": -1,
     "AccountRoot": 97,
     "DirectoryNode": 100,
@@ -36,13 +40,17 @@
     "FeeSettings": 115,
     "Escrow": 117,
     "PayChannel": 120,
-    "DepositPreauth": 112,
     "Check": 67,
-    "Nickname": 110,
-    "Contract": 99,
+    "DepositPreauth": 112,
+    "NegativeUNL": 78,
     "NFTokenPage": 80,
     "NFTokenOffer": 55,
-    "NegativeUNL": 78
+    "AMM": 121,
+    "Any": -3,
+    "Child": -2,
+    "Nickname": 110,
+    "Contract": 99,
+    "GeneratorMap": 103
   },
   "FIELDS": [
     [
@@ -63,6 +71,166 @@
         "isSerialized": false,
         "isSigningField": false,
         "type": "Unknown"
+      }
+    ],
+    [
+      "ObjectEndMarker",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "ArrayEndMarker",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STArray"
+      }
+    ],
+    [
+      "hash",
+      {
+        "nth": 257,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": false,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "index",
+      {
+        "nth": 258,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": false,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "taker_gets_funded",
+      {
+        "nth": 258,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": false,
+        "type": "Amount"
+      }
+    ],
+    [
+      "taker_pays_funded",
+      {
+        "nth": 259,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": false,
+        "type": "Amount"
+      }
+    ],
+    [
+      "LedgerEntry",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": true,
+        "type": "LedgerEntry"
+      }
+    ],
+    [
+      "Transaction",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": true,
+        "type": "Transaction"
+      }
+    ],
+    [
+      "Validation",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": false,
+        "isSigningField": true,
+        "type": "Validation"
+      }
+    ],
+    [
+      "Metadata",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Metadata"
+      }
+    ],
+    [
+      "CloseResolution",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "Method",
+      {
+        "nth": 2,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "TransactionResult",
+      {
+        "nth": 3,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "TickSize",
+      {
+        "nth": 16,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "UNLModifyDisabling",
+      {
+        "nth": 17,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "HookResult",
+      {
+        "nth": 18,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt8"
       }
     ],
     [
@@ -103,6 +271,86 @@
         "isSerialized": true,
         "isSigningField": true,
         "type": "UInt16"
+      }
+    ],
+    [
+      "TradingFee",
+      {
+        "nth": 5,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "DiscountedFee",
+      {
+        "nth": 6,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "Version",
+      {
+        "nth": 16,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "HookStateChangeCount",
+      {
+        "nth": 17,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "HookEmitCount",
+      {
+        "nth": 18,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "HookExecutionIndex",
+      {
+        "nth": 19,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "HookApiVersion",
+      {
+        "nth": 20,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "NetworkID",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
       }
     ],
     [
@@ -456,6 +704,116 @@
       }
     ],
     [
+      "SignerListID",
+      {
+        "nth": 38,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "SettleDelay",
+      {
+        "nth": 39,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "TicketCount",
+      {
+        "nth": 40,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "TicketSequence",
+      {
+        "nth": 41,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "NFTokenTaxon",
+      {
+        "nth": 42,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "MintedNFTokens",
+      {
+        "nth": 43,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "BurnedNFTokens",
+      {
+        "nth": 44,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "HookStateCount",
+      {
+        "nth": 45,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "EmitGeneration",
+      {
+        "nth": 46,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "VoteWeight",
+      {
+        "nth": 48,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
+      "FirstNFTokenSequence",
+      {
+        "nth": 50,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt32"
+      }
+    ],
+    [
       "IndexNext",
       {
         "nth": 1,
@@ -536,6 +894,96 @@
       }
     ],
     [
+      "DestinationNode",
+      {
+        "nth": 9,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "Cookie",
+      {
+        "nth": 10,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "ServerVersion",
+      {
+        "nth": 11,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "NFTokenOfferNode",
+      {
+        "nth": 12,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "EmitBurden",
+      {
+        "nth": 13,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "HookOn",
+      {
+        "nth": 16,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "HookInstructionCount",
+      {
+        "nth": 17,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "HookReturnCode",
+      {
+        "nth": 18,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "ReferenceCount",
+      {
+        "nth": 19,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "UInt64"
+      }
+    ],
+    [
       "EmailHash",
       {
         "nth": 1,
@@ -543,6 +991,46 @@
         "isSerialized": true,
         "isSigningField": true,
         "type": "Hash128"
+      }
+    ],
+    [
+      "TakerPaysCurrency",
+      {
+        "nth": 1,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash160"
+      }
+    ],
+    [
+      "TakerPaysIssuer",
+      {
+        "nth": 2,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash160"
+      }
+    ],
+    [
+      "TakerGetsCurrency",
+      {
+        "nth": 3,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash160"
+      }
+    ],
+    [
+      "TakerGetsIssuer",
+      {
+        "nth": 4,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash160"
       }
     ],
     [
@@ -646,6 +1134,46 @@
       }
     ],
     [
+      "EmitParentTxnID",
+      {
+        "nth": 11,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "EmitNonce",
+      {
+        "nth": 12,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "EmitHookHash",
+      {
+        "nth": 13,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "AMMID",
+      {
+        "nth": 14,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
       "BookDirectory",
       {
         "nth": 16,
@@ -686,16 +1214,6 @@
       }
     ],
     [
-      "TicketID",
-      {
-        "nth": 20,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
       "Digest",
       {
         "nth": 21,
@@ -706,22 +1224,122 @@
       }
     ],
     [
-      "hash",
+      "Channel",
       {
-        "nth": 257,
+        "nth": 22,
         "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
+        "isSerialized": true,
+        "isSigningField": true,
         "type": "Hash256"
       }
     ],
     [
-      "index",
+      "ConsensusHash",
       {
-        "nth": 258,
+        "nth": 23,
         "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "CheckID",
+      {
+        "nth": 24,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "ValidatedHash",
+      {
+        "nth": 25,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "PreviousPageMin",
+      {
+        "nth": 26,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "NextPageMin",
+      {
+        "nth": 27,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "NFTokenBuyOffer",
+      {
+        "nth": 28,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "NFTokenSellOffer",
+      {
+        "nth": 29,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "HookStateKey",
+      {
+        "nth": 30,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "HookHash",
+      {
+        "nth": 31,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "HookNamespace",
+      {
+        "nth": 32,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "HookSetTxnID",
+      {
+        "nth": 33,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
         "type": "Hash256"
       }
     ],
@@ -826,6 +1444,36 @@
       }
     ],
     [
+      "Amount2",
+      {
+        "nth": 11,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Amount"
+      }
+    ],
+    [
+      "BidMin",
+      {
+        "nth": 12,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Amount"
+      }
+    ],
+    [
+      "BidMax",
+      {
+        "nth": 13,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Amount"
+      }
+    ],
+    [
       "MinimumOffer",
       {
         "nth": 16,
@@ -866,22 +1514,82 @@
       }
     ],
     [
-      "taker_gets_funded",
+      "BaseFeeDrops",
       {
-        "nth": 258,
+        "nth": 22,
         "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
+        "isSerialized": true,
+        "isSigningField": true,
         "type": "Amount"
       }
     ],
     [
-      "taker_pays_funded",
+      "ReserveBaseDrops",
       {
-        "nth": 259,
+        "nth": 23,
         "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Amount"
+      }
+    ],
+    [
+      "ReserveIncrementDrops",
+      {
+        "nth": 24,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Amount"
+      }
+    ],
+    [
+      "LPTokenOut",
+      {
+        "nth": 25,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Amount"
+      }
+    ],
+    [
+      "LPTokenIn",
+      {
+        "nth": 26,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Amount"
+      }
+    ],
+    [
+      "EPrice",
+      {
+        "nth": 27,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Amount"
+      }
+    ],
+    [
+      "Price",
+      {
+        "nth": 28,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Amount"
+      }
+    ],
+    [
+      "LPTokenBalance",
+      {
+        "nth": 31,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
         "type": "Amount"
       }
     ],
@@ -1086,6 +1794,46 @@
       }
     ],
     [
+      "HookStateData",
+      {
+        "nth": 22,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Blob"
+      }
+    ],
+    [
+      "HookReturnString",
+      {
+        "nth": 23,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Blob"
+      }
+    ],
+    [
+      "HookParameterName",
+      {
+        "nth": 24,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Blob"
+      }
+    ],
+    [
+      "HookParameterValue",
+      {
+        "nth": 25,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Blob"
+      }
+    ],
+    [
       "Account",
       {
         "nth": 1,
@@ -1146,16 +1894,6 @@
       }
     ],
     [
-      "Target",
-      {
-        "nth": 7,
-        "isVLEncoded": true,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "AccountID"
-      }
-    ],
-    [
       "RegularKey",
       {
         "nth": 8,
@@ -1176,13 +1914,93 @@
       }
     ],
     [
-      "ObjectEndMarker",
+      "EmitCallback",
+      {
+        "nth": 10,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "AccountID"
+      }
+    ],
+    [
+      "HookAccount",
+      {
+        "nth": 16,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "AccountID"
+      }
+    ],
+    [
+      "Indexes",
+      {
+        "nth": 1,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "Hashes",
+      {
+        "nth": 2,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "Amendments",
+      {
+        "nth": 3,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "NFTokenOffers",
+      {
+        "nth": 4,
+        "isVLEncoded": true,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "Paths",
       {
         "nth": 1,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "type": "STObject"
+        "type": "PathSet"
+      }
+    ],
+    [
+      "Asset",
+      {
+        "nth": 3,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Issue"
+      }
+    ],
+    [
+      "Asset2",
+      {
+        "nth": 4,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "Issue"
       }
     ],
     [
@@ -1296,6 +2114,26 @@
       }
     ],
     [
+      "EmitDetails",
+      {
+        "nth": 13,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "Hook",
+      {
+        "nth": 14,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
       "Signer",
       {
         "nth": 16,
@@ -1326,13 +2164,83 @@
       }
     ],
     [
-      "ArrayEndMarker",
+      "EmittedTxn",
       {
-        "nth": 1,
+        "nth": 20,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "type": "STArray"
+        "type": "STObject"
+      }
+    ],
+    [
+      "HookExecution",
+      {
+        "nth": 21,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "HookDefinition",
+      {
+        "nth": 22,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "HookParameter",
+      {
+        "nth": 23,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "HookGrant",
+      {
+        "nth": 24,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "VoteEntry",
+      {
+        "nth": 25,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "AuctionSlot",
+      {
+        "nth": 26,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
+      }
+    ],
+    [
+      "AuthAccount",
+      {
+        "nth": 27,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STObject"
       }
     ],
     [
@@ -1416,6 +2324,26 @@
       }
     ],
     [
+      "Hooks",
+      {
+        "nth": 11,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STArray"
+      }
+    ],
+    [
+      "VoteSlots",
+      {
+        "nth": 12,
+        "isVLEncoded": false,
+        "isSerialized": true,
+        "isSigningField": true,
+        "type": "STArray"
+      }
+    ],
+    [
       "Majorities",
       {
         "nth": 16,
@@ -1436,363 +2364,43 @@
       }
     ],
     [
-      "CloseResolution",
+      "HookExecutions",
       {
-        "nth": 1,
+        "nth": 18,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "type": "UInt8"
+        "type": "STArray"
       }
     ],
     [
-      "Method",
+      "HookParameters",
       {
-        "nth": 2,
+        "nth": 19,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "type": "UInt8"
+        "type": "STArray"
       }
     ],
     [
-      "TransactionResult",
+      "HookGrants",
       {
-        "nth": 3,
+        "nth": 20,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "type": "UInt8"
+        "type": "STArray"
       }
     ],
     [
-      "TakerPaysCurrency",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash160"
-      }
-    ],
-    [
-      "TakerPaysIssuer",
-      {
-        "nth": 2,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash160"
-      }
-    ],
-    [
-      "TakerGetsCurrency",
-      {
-        "nth": 3,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash160"
-      }
-    ],
-    [
-      "TakerGetsIssuer",
-      {
-        "nth": 4,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash160"
-      }
-    ],
-    [
-      "Paths",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "PathSet"
-      }
-    ],
-    [
-      "Indexes",
-      {
-        "nth": 1,
-        "isVLEncoded": true,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Vector256"
-      }
-    ],
-    [
-      "Hashes",
-      {
-        "nth": 2,
-        "isVLEncoded": true,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Vector256"
-      }
-    ],
-    [
-      "Amendments",
-      {
-        "nth": 3,
-        "isVLEncoded": true,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Vector256"
-      }
-    ],
-    [
-      "NFTokenOffers",
-      {
-        "nth": 4,
-        "isVLEncoded": true,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Vector256"
-      }
-    ],
-    [
-      "Transaction",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
-        "type": "Transaction"
-      }
-    ],
-    [
-      "LedgerEntry",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
-        "type": "LedgerEntry"
-      }
-    ],
-    [
-      "Validation",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
-        "type": "Validation"
-      }
-    ],
-    [
-      "SignerListID",
-      {
-        "nth": 38,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "SettleDelay",
-      {
-        "nth": 39,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "TicketCount",
-      {
-        "nth": 40,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "TicketSequence",
-      {
-        "nth": 41,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "NFTokenTaxon",
-      {
-        "nth": 42,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "MintedNFTokens",
-      {
-        "nth": 43,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "BurnedNFTokens",
-      {
-        "nth": 44,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt32"
-      }
-    ],
-    [
-      "Channel",
-      {
-        "nth": 22,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "ConsensusHash",
-      {
-        "nth": 23,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "CheckID",
-      {
-        "nth": 24,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "ValidatedHash",
+      "AuthAccounts",
       {
         "nth": 25,
         "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "PreviousPageMin",
-      {
-        "nth": 26,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "NextPageMin",
-      {
-        "nth": 27,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "NFTokenBuyOffer",
-      {
-        "nth": 28,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "NFTokenSellOffer",
-      {
-        "nth": 29,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "TickSize",
-      {
-        "nth": 16,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt8"
-      }
-    ],
-    [
-      "UNLModifyDisabling",
-      {
-        "nth": 17,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt8"
-      }
-    ],
-    [
-      "DestinationNode",
-      {
-        "nth": 9,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt64"
-      }
-    ],
-    [
-      "Cookie",
-      {
-        "nth": 10,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt64"
-      }
-    ],
-    [
-      "ServerVersion",
-      {
-        "nth": 11,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt64"
-      }
-    ],
-    [
-      "NFTokenOfferNode",
-      {
-        "nth": 12,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt64"
+        "type": "STArray"
       }
     ]
   ],
@@ -1810,6 +2418,9 @@
     "telCAN_NOT_QUEUE_BLOCKED": -389,
     "telCAN_NOT_QUEUE_FEE": -388,
     "telCAN_NOT_QUEUE_FULL": -387,
+    "telWRONG_NETWORK": -386,
+    "telREQUIRES_NETWORK_ID": -385,
+    "telNETWORK_ID_MAKES_TX_NON_CANONICAL": -384,
 
     "temMALFORMED": -299,
     "temBAD_AMOUNT": -298,
@@ -1844,8 +2455,12 @@
     "temBAD_TICK_SIZE": -269,
     "temINVALID_ACCOUNT_ID": -268,
     "temCANNOT_PREAUTH_SELF": -267,
-    "temUNCERTAIN": -266,
-    "temUNKNOWN": -265,
+    "temINVALID_COUNT": -266,
+    "temUNCERTAIN": -265,
+    "temUNKNOWN": -264,
+    "temSEQ_AND_TICKET": -263,
+    "temBAD_NFTOKEN_TRANSFER_FEE": -262,
+    "temBAD_AMM_TOKENS": -261,
 
     "tefFAILURE": -199,
     "tefALREADY": -198,
@@ -1867,7 +2482,8 @@
     "tefINVARIANT_FAILED": -182,
     "tefTOO_BIG": -181,
     "tefNO_TICKET": -180,
-    "tefTOKEN_IS_NOT_TRANSFERABLE": -179,
+    "tefNFTOKEN_IS_NOT_TRANSFERABLE": -179,
+
     "terRETRY": -99,
     "terFUNDS_SPENT": -98,
     "terINSUF_FEE_B": -97,
@@ -1879,6 +2495,8 @@
     "terLAST": -91,
     "terNO_RIPPLE": -90,
     "terQUEUED": -89,
+    "terPRE_TICKET": -88,
+    "terNO_AMM": -87,
 
     "tesSUCCESS": 0,
 
@@ -1921,19 +2539,20 @@
     "tecHAS_OBLIGATIONS": 151,
     "tecTOO_SOON": 152,
     "tecMAX_SEQUENCE_REACHED": 154,
-    "tecNO_SUITABLE_PAGE": 155,
-    "tecBUY_SELL_MISMATCH": 156,
-    "tecOFFER_TYPE_MISMATCH": 157,
-    "tecCANT_ACCEPT_OWN_OFFER": 158,
+    "tecNO_SUITABLE_NFTOKEN_PAGE": 155,
+    "tecNFTOKEN_BUY_SELL_MISMATCH": 156,
+    "tecNFTOKEN_OFFER_TYPE_MISMATCH": 157,
+    "tecCANT_ACCEPT_OWN_NFTOKEN_OFFER": 158,
     "tecINSUFFICIENT_FUNDS": 159,
     "tecOBJECT_NOT_FOUND": 160,
     "tecINSUFFICIENT_PAYMENT": 161,
-    "tecINCORRECT_ASSET": 162,
-    "tecTOO_MANY": 163
+    "tecUNFUNDED_AMM": 162,
+    "tecAMM_BALANCE": 163,
+    "tecAMM_FAILED": 164,
+    "tecAMM_INVALID_TOKENS": 165
   },
   "TRANSACTION_TYPES": {
     "Invalid": -1,
-
     "Payment": 0,
     "EscrowCreate": 1,
     "EscrowFinish": 2,
@@ -1956,11 +2575,18 @@
     "DepositPreauth": 19,
     "TrustSet": 20,
     "AccountDelete": 21,
+    "SetHook": 22,
     "NFTokenMint": 25,
     "NFTokenBurn": 26,
     "NFTokenCreateOffer": 27,
     "NFTokenCancelOffer": 28,
     "NFTokenAcceptOffer": 29,
+    "Clawback": 30,
+    "AMMCreate": 35,
+    "AMMDeposit": 36,
+    "AMMWithdraw": 37,
+    "AMMVote": 38,
+    "AMMBid": 39,
     "EnableAmendment": 100,
     "SetFee": 101,
     "UNLModify": 102

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/BinarySerializationTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/BinarySerializationTests.java
@@ -87,7 +87,7 @@ public class BinarySerializationTests {
   }
 
   @Test
-  public void serializeAccountSetTransactionWithEmptyFlags() throws JsonProcessingException {
+  public void serializeAccountSetTransactionWithNetworkId() throws JsonProcessingException {
     AccountSet accountSet = AccountSet.builder()
       .account(Address.of("rpP2GdsQwenNnFPefbXFgiTvEgJWQpq8Rw"))
       .fee(XrpCurrencyAmount.ofDrops(10))
@@ -96,6 +96,19 @@ public class BinarySerializationTests {
       .build();
 
     String expectedBinary = "12000321FFFFFFFF240000296668400000000000000A730081140F3D0C7D2CFAB2EC8295451F0B3CA03" +
+      "8E8E9CDCD";
+    assertSerializesAndDeserializes(accountSet, expectedBinary);
+  }
+
+  @Test
+  public void serializeAccountSetTransactionWithEmptyFlags() throws JsonProcessingException {
+    AccountSet accountSet = AccountSet.builder()
+      .account(Address.of("rpP2GdsQwenNnFPefbXFgiTvEgJWQpq8Rw"))
+      .fee(XrpCurrencyAmount.ofDrops(10))
+      .sequence(UnsignedInteger.valueOf(10598))
+      .build();
+
+    String expectedBinary = "120003240000296668400000000000000A730081140F3D0C7D2CFAB2EC8295451F0B3CA03" +
       "8E8E9CDCD";
     assertSerializesAndDeserializes(accountSet, expectedBinary);
   }

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/BinarySerializationTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/BinarySerializationTests.java
@@ -58,6 +58,7 @@ import org.xrpl.xrpl4j.model.transactions.EscrowCreate;
 import org.xrpl.xrpl4j.model.transactions.EscrowFinish;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
 import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.OfferCancel;
 import org.xrpl.xrpl4j.model.transactions.OfferCreate;
 import org.xrpl.xrpl4j.model.transactions.Payment;
@@ -91,9 +92,10 @@ public class BinarySerializationTests {
       .account(Address.of("rpP2GdsQwenNnFPefbXFgiTvEgJWQpq8Rw"))
       .fee(XrpCurrencyAmount.ofDrops(10))
       .sequence(UnsignedInteger.valueOf(10598))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "120003240000296668400000000000000A730081140F3D0C7D2CFAB2EC8295451F0B3CA03" +
+    String expectedBinary = "12000321FFFFFFFF240000296668400000000000000A730081140F3D0C7D2CFAB2EC8295451F0B3CA03" +
       "8E8E9CDCD";
     assertSerializesAndDeserializes(accountSet, expectedBinary);
   }
@@ -134,9 +136,10 @@ public class BinarySerializationTests {
       .sequence(UnsignedInteger.valueOf(2470665))
       .destination(Address.of("rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe"))
       .destinationTag(UnsignedInteger.valueOf(13))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "120015240025B3092E0000000D6840000000004C4B40730081140596915CFDEEE" +
+    String expectedBinary = "12001521FFFFFFFF240025B3092E0000000D6840000000004C4B40730081140596915CFDEEE" +
       "3A695B3EFD6BDA9AC788A368B7B8314F667B0CA50CC7709A220B0561B85E53A48461FA8";
     assertSerializesAndDeserializes(accountDelete, expectedBinary);
   }
@@ -180,9 +183,10 @@ public class BinarySerializationTests {
       .checkId(Hash256.of("49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0"))
       .sequence(UnsignedInteger.valueOf(12))
       .fee(XrpCurrencyAmount.ofDrops(12))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "120012240000000C501849647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97" +
+    String expectedBinary = "12001221FFFFFFFF240000000C501849647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97" +
       "F67E9977FB068400000000000000C730081147990EC5D1D8DF69E070A968D4B186986FDF06ED0";
     assertSerializesAndDeserializes(checkCancel, expectedBinary);
   }
@@ -257,9 +261,10 @@ public class BinarySerializationTests {
       .sequence(UnsignedInteger.ONE)
       .fee(XrpCurrencyAmount.ofDrops(12))
       .amount(XrpCurrencyAmount.ofDrops(100))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "12001124000000015018838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4" +
+    String expectedBinary = "12001121FFFFFFFF24000000015018838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4" +
       "056FCBD657F5733461400000000000006468400000000000000C7300811449FF0C73CA6AF9733DA805F76CA2C37776B7C46B";
     assertSerializesAndDeserializes(checkCash, expectedBinary);
   }
@@ -310,9 +315,10 @@ public class BinarySerializationTests {
       .sendMax(XrpCurrencyAmount.ofDrops(100000000))
       .expiration(UnsignedInteger.valueOf(570113521))
       .invoiceId(Hash256.of("6F1DFD1D0FE8A32E40E1F2C05CF1C15545BAB56B617F9C6C2D63A6B704BEF59B"))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "12001024000000012A21FB3DF12E0000000150116F1DFD1D0FE8A32E40E1F2C05CF1C" +
+    String expectedBinary = "12001021FFFFFFFF24000000012A21FB3DF12E0000000150116F1DFD1D0FE8A32E40E1F2C05CF1C" +
       "15545BAB56B617F9C6C2D63A6B704BEF59B68400000000000000C694000000005F5E100730081147990EC5D1D8DF69E070A96" +
       "8D4B186986FDF06ED0831449FF0C73CA6AF9733DA805F76CA2C37776B7C46B";
     assertSerializesAndDeserializes(checkCreate, expectedBinary);
@@ -365,9 +371,10 @@ public class BinarySerializationTests {
       .authorize(Address.of("rDJFnv5sEfp42LMFiX3mVQKczpFTdxYDzM"))
       .fee(XrpCurrencyAmount.ofDrops(10))
       .sequence(UnsignedInteger.valueOf(65))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "120013240000004168400000000000000A730081148A928D14A643F388AC0D26B" +
+    String expectedBinary = "12001321FFFFFFFF240000004168400000000000000A730081148A928D14A643F388AC0D26B" +
       "AF9755B07EB0A2B44851486FFE2A17E861BA0FE9A3ED8352F895D80E789E0";
     assertSerializesAndDeserializes(preAuth, expectedBinary);
   }
@@ -416,9 +423,10 @@ public class BinarySerializationTests {
       .condition(CryptoConditionReader.readCondition(BaseEncoding.base16().decode(
         "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100"))
       )
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "12000124000000012E00005BB82024258D09812025258D0980614000000000000064684" +
+    String expectedBinary = "12000121FFFFFFFF24000000012E00005BB82024258D09812025258D0980614000000000000064684" +
       "00000000000000C7300701127A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100" +
       "8114EE5F7CF61504C7CF7E0C22562EB19CC7ACB0FCBA8314B5F762798A53D543A014CAF8B297CFF8F2F937E8";
     assertSerializesAndDeserializes(checkCreate, expectedBinary);
@@ -478,9 +486,10 @@ public class BinarySerializationTests {
       .sequence(UnsignedInteger.ONE)
       .owner(Address.of("r4jQDHCUvgcBAa5EzcB1D8BHGcjYP9eBC2"))
       .offerSequence(UnsignedInteger.valueOf(25))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "120004240000000120190000001968400000000000000C73008114EE5F7CF61504C7" +
+    String expectedBinary = "12000421FFFFFFFF240000000120190000001968400000000000000C73008114EE5F7CF61504C7" +
       "CF7E0C22562EB19CC7ACB0FCBA8214EE5F7CF61504C7CF7E0C22562EB19CC7ACB0FCBA";
     assertSerializesAndDeserializes(escrowCancel, expectedBinary);
   }
@@ -529,9 +538,10 @@ public class BinarySerializationTests {
         "A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100")
       ))
       .fulfillment(CryptoConditionReader.readFulfillment(BaseEncoding.base16().decode("A0028000")))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "120002240000000320190000001968400000000000014A7300701004A0028000701127A02" +
+    String expectedBinary = "12000221FFFFFFFF240000000320190000001968400000000000014A7300701004A0028000701127A02" +
       "58020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B8558101008114E151CA3207BAB5B91D2F0E4D35" +
       "ECDFD4551C69A18214E151CA3207BAB5B91D2F0E4D35ECDFD4551C69A1";
     assertSerializesAndDeserializes(escrowFinish, expectedBinary);
@@ -597,9 +607,10 @@ public class BinarySerializationTests {
       .amount(XrpCurrencyAmount.ofDrops(12345))
       .fee(XrpCurrencyAmount.ofDrops(789))
       .sequence(UnsignedInteger.valueOf(56565656))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "120000230000000124035F1F982E0000000261400000000000303968" +
+    String expectedBinary = "12000021FFFFFFFF230000000124035F1F982E0000000261400000000000303968" +
       "400000000000031573008114EE39E6D05CFD6A90DAB700A1D70149ECEE29DFEC83140000000000000000000000000000000000000001";
     assertSerializesAndDeserializes(payment, expectedBinary);
   }
@@ -708,9 +719,10 @@ public class BinarySerializationTests {
       .settleDelay(UnsignedInteger.ONE)
       .publicKey("32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A")
       .cancelAfter(UnsignedLong.valueOf(533171558))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "12000D230000000124000000012E0000000220241FC78D66202700000001614000" +
+    String expectedBinary = "12000D21FFFFFFFF230000000124000000012E0000000220241FC78D66202700000001614000" +
       "000000002710684000000000000064712132D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0" +
       "F0A730081144B4E9C06F24296074F7BC48F92A97916C6DC5EA983144B4E9C06F24296074F7BC48F92A97916C6DC5EA9";
     assertSerializesAndDeserializes(create, expectedBinary);
@@ -772,9 +784,10 @@ public class BinarySerializationTests {
       .signature("30440220718D264EF05CAED7C781FF6DE298DCAC68D002562C9BF3A07C1E721B420C0DAB02203A5A4779E" +
         "F4D2CCC7BC3EF886676D803A9981B928D3B8ACA483B80ECA3CD7B9B")
       .publicKey("32D2471DB72B27E3310F355BB33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A")
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "12000F24000000015016C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749D" +
+    String expectedBinary = "12000F21FFFFFFFF24000000015016C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749D" +
       "CDD3B9E5992CA61986140000000000F42406240000000000F424068400000000000000A712132D2471DB72B27E3310F355B" +
       "B33E339BF26F8392D5A93D3BC0FC3B566612DA0F0A7300764630440220718D264EF05CAED7C781FF6DE298DCAC68D002562" +
       "C9BF3A07C1E721B420C0DAB02203A5A4779EF4D2CCC7BC3EF886676D803A9981B928D3B8ACA483B80ECA3CD7B9B81142042" +
@@ -840,9 +853,10 @@ public class BinarySerializationTests {
       .channel(Hash256.of("C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198"))
       .amount(XrpCurrencyAmount.ofDrops(200000))
       .expiration(UnsignedLong.valueOf(543171558))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedJson = "12000E24000000012A206023E65016C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC7" +
+    String expectedJson = "12000E21FFFFFFFF24000000012A206023E65016C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC7" +
       "49DCDD3B9E5992CA6198614000000000030D4068400000000000000A730081144B4E9C06F24296074F7BC48F92A97916C6DC5EA9";
 
     assertSerializesAndDeserializes(fund, expectedJson);
@@ -895,10 +909,11 @@ public class BinarySerializationTests {
         .issuer(Address.of("rUx4xgE7bNWCCgGcXv1CCoQyTcCeZ275YG"))
         .value("10000000")
         .build())
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
 
-    String expectedBinary = "120014240000002C63D6438D7EA4C68000000000000000000000000000574347000000" +
+    String expectedBinary = "12001421FFFFFFFF240000002C63D6438D7EA4C68000000000000000000000000000574347000000" +
       "0000832297BEF589D59F9C03A84F920F8D9128CC1CE468400000000000000C73008114BE6C30732AE33CF2AF3344CE8172A6B9" +
       "300183E3";
     assertSerializesAndDeserializes(trustSet, expectedBinary);
@@ -1411,9 +1426,10 @@ public class BinarySerializationTests {
       .sequence(UnsignedInteger.valueOf(11223344))
       .offerSequence(UnsignedInteger.valueOf(123))
       .expiration(UnsignedInteger.valueOf(456))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "1200072400AB41302A000001C820190000007B64D5071AFD498D0000000000000000000" +
+    String expectedBinary = "12000721FFFFFFFF2400AB41302A000001C820190000007B64D5071AFD498D0000000000000000000" +
       "0000000005743470000000000832297BEF589D59F9C03A84F920F8D9128CC1CE465D5038D7EA4C6800000000000000000000000" +
       "00005743470000000000832297BEF589D59F9C03A84F920F8D9128CC1CE468400000000000012C73008114832297BEF589D59F9" +
       "C03A84F920F8D9128CC1CE4";
@@ -1467,9 +1483,10 @@ public class BinarySerializationTests {
       .account(Address.of("rUx4xgE7bNWCCgGcXv1CCoQyTcCeZ275YG"))
       .sequence(UnsignedInteger.valueOf(11223344))
       .offerSequence(UnsignedInteger.valueOf(123))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "1200082400AB413020190000007B68400000000000012C73008114832297BEF589" +
+    String expectedBinary = "12000821FFFFFFFF2400AB413020190000007B68400000000000012C73008114832297BEF589" +
       "D59F9C03A84F920F8D9128CC1CE4";
     assertSerializesAndDeserializes(offerCreate, expectedBinary);
   }
@@ -1511,9 +1528,10 @@ public class BinarySerializationTests {
       .fee(XrpCurrencyAmount.ofDrops(12))
       .sequence(UnsignedInteger.ONE)
       .regularKey(Address.of("rAR8rR8sUkBoCZFawhkWzY4Y5YoyuznwD"))
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "120005240000000168400000000000000C730081144B4E9C06F24296074F7BC48F92" +
+    String expectedBinary = "12000521FFFFFFFF240000000168400000000000000C730081144B4E9C06F24296074F7BC48F92" +
       "A97916C6DC5EA988140A4B24D606281E6E5A78D9F80E039F5E66FA5AC5";
 
     assertSerializesAndDeserializes(setRegularKey, expectedBinary);
@@ -1578,9 +1596,10 @@ public class BinarySerializationTests {
             .build()
         )
       )
+      .networkId(NetworkId.of(UnsignedInteger.MAX_VALUE))
       .build();
 
-    String expectedBinary = "12000C240000000120230000000368400000000000000C730081144B4E9C06F24296074" +
+    String expectedBinary = "12000C21FFFFFFFF240000000120230000000368400000000000000C730081144B4E9C06F24296074" +
       "F7BC48F92A97916C6DC5EA9F4EB1300028114204288D2E47F8EF6C99BCC457966320D12409711E1EB13000181147908A7F0EDD4" +
       "8EA896C3580A399F0EE78611C8E3E1EB13000181143A4C02EA95AD6AC3BED92FA036E0BBFB712C030CE1F1";
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/FieldHeaderCodecTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/FieldHeaderCodecTest.java
@@ -43,7 +43,7 @@ class FieldHeaderCodecTest {
     ObjectMapper objectMapper = BinaryCodecObjectMapperFactory.getObjectMapper();
     fieldHeaderCodec = new FieldHeaderCodec(new DefaultDefinitionsProvider(objectMapper).get(), objectMapper);
     fieldTests = FixtureUtils.getDataDrivenFixtures().fieldTests();
-    assertThat(fieldTests).hasSize(125);
+    assertThat(fieldTests).hasSize(123);
   }
 
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/serverinfo/ServerInfoResultTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/serverinfo/ServerInfoResultTest.java
@@ -33,6 +33,7 @@ import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.client.serverinfo.ServerInfo.LastClose;
 import org.xrpl.xrpl4j.model.client.serverinfo.ServerInfo.ValidatedLedger;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
 import java.math.BigDecimal;
@@ -47,7 +48,83 @@ import java.util.Locale;
 public class ServerInfoResultTest extends AbstractJsonTest {
 
   @Test
-  void serverInfoResultTest() throws JSONException, JsonProcessingException {
+  void testJsonWithNetworkId() throws JsonProcessingException {
+    String json = "{\n" +
+      "    \"info\": {\n" +
+      "      \"build_version\": \"1.7.0\",\n" +
+      "      \"amendment_blocked\": false,\n" +
+      "      \"complete_ledgers\": \"61881385-62562429\",\n" +
+      "      \"hostid\": \"LARD\",\n" +
+      "      \"io_latency_ms\": 2,\n" +
+      "      \"jq_trans_overflow\": \"0\",\n" +
+      "      \"last_close\": {\n" +
+      "        \"converge_time_s\": 3.002,\n" +
+      "        \"proposers\": 38\n" +
+      "      },\n" +
+      "      \"load_factor\": 511.83203125,\n" +
+      "      \"network_id\": 25,\n" +
+      "      \"load_factor_server\": 1,\n" +
+      "      \"peers\": 261,\n" +
+      "      \"pubkey_node\": \"n9MozjnGB3tpULewtTsVtuudg5JqYFyV3QFdAtVLzJaxHcBaxuXD\",\n" +
+      "      \"server_state\": \"full\",\n" +
+      "      \"server_state_duration_us\": \"2274468435925\",\n" +
+      "      \"time\": \"2021-Mar-30 15:37:51.486384 UTC\",\n" +
+      "      \"uptime\": 2274704,\n" +
+      "      \"validated_ledger\": {\n" +
+      "        \"age\": 4,\n" +
+      "        \"base_fee_xrp\": 0.00001,\n" +
+      "        \"hash\": \"E5A958048D98D4EFEEDD2BC3F36D23893BBC1D9354CB3E739068D2DFDE3D1AA3\",\n" +
+      "        \"reserve_base_xrp\": 20.1,\n" +
+      "        \"reserve_inc_xrp\": 5.0,\n" +
+      "        \"seq\": 62562429\n" +
+      "      },\n" +
+      "      \"validation_quorum\": 31\n" +
+      "  },\n" +
+      "  \"status\": \"success\"\n" +
+      "}";
+
+    ServerInfo serverInfo = RippledServerInfo.builder()
+      .buildVersion("1.7.0")
+      .completeLedgers(LedgerRangeUtils.completeLedgersToListOfRange("61881385-62562429"))
+      .hostId("LARD")
+      .ioLatencyMs(UnsignedLong.valueOf(2))
+      .jqTransOverflow("0")
+      .lastClose(LastClose.builder()
+        .convergeTimeSeconds(BigDecimal.valueOf(3.002))
+        .proposers(UnsignedInteger.valueOf(38))
+        .build())
+      .loadFactor(new BigDecimal("511.83203125"))
+      .networkId(NetworkId.of(25))
+      .loadFactorServer(BigDecimal.ONE)
+      .peers(UnsignedInteger.valueOf(261))
+      .publicKeyNode("n9MozjnGB3tpULewtTsVtuudg5JqYFyV3QFdAtVLzJaxHcBaxuXD")
+      .serverState("full")
+      .serverStateDurationUs("2274468435925")
+      .time(ZonedDateTime.parse("2021-Mar-30 15:37:51.486384 UTC",
+        DateTimeFormatter.ofPattern("yyyy-MMM-dd HH:mm:ss.SSSSSS z", Locale.US)).withZoneSameLocal(ZoneId.of("UTC")))
+      .upTime(UnsignedLong.valueOf(2274704))
+      .validatedLedger(ValidatedLedger.builder()
+        .age(UnsignedInteger.valueOf(4))
+        .hash(Hash256.of("E5A958048D98D4EFEEDD2BC3F36D23893BBC1D9354CB3E739068D2DFDE3D1AA3"))
+        .reserveBaseXrp(XrpCurrencyAmount.ofDrops(20100000))
+        .reserveIncXrp(XrpCurrencyAmount.ofDrops(5000000))
+        .sequence(LedgerIndex.of(UnsignedInteger.valueOf(62562429)))
+        .baseFeeXrp(new BigDecimal("0.000010"))
+        .build())
+      .validationQuorum(UnsignedInteger.valueOf(31))
+      .build();
+    ImmutableServerInfoResult.Builder resultBuilder = ServerInfoResult.builder()
+      .info(serverInfo)
+      .status("success");
+
+    ServerInfoResult result = Assertions.assertDoesNotThrow(() -> resultBuilder.build());
+
+    assertCanDeserialize(json, result);
+    assertThat(result.info()).isEqualTo(serverInfo);
+  }
+
+  @Test
+  void testJsonWithoutNetworkId() throws JsonProcessingException {
     String json = "{\n" +
       "    \"info\": {\n" +
       "      \"build_version\": \"1.7.0\",\n" +

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/NetworkIdTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/NetworkIdTest.java
@@ -1,0 +1,90 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.primitives.UnsignedInteger;
+import org.assertj.core.api.Assertions;
+import org.immutables.value.Value;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+
+public class NetworkIdTest {
+
+  ObjectMapper objectMapper = ObjectMapperFactory.create();
+
+  @Test
+  void testBounds() {
+    NetworkId networkId = NetworkId.of(UnsignedInteger.ZERO);
+    assertThat(networkId.value()).isEqualTo(UnsignedInteger.ZERO);
+
+    networkId = NetworkId.of(UnsignedInteger.MAX_VALUE);
+    assertThat(networkId.value()).isEqualTo(UnsignedInteger.MAX_VALUE);
+  }
+
+  @Test
+  void testToString() {
+    NetworkId networkId = NetworkId.of(UnsignedInteger.valueOf(1024));
+    assertThat(networkId.toString()).isEqualTo("1024");
+  }
+
+  @Test
+  void testBoundsWithLongConstructor() {
+    NetworkId networkId = NetworkId.of(0);
+    assertThat(networkId.value()).isEqualTo(UnsignedInteger.ZERO);
+
+    networkId = NetworkId.of(1);
+    assertThat(networkId.value()).isEqualTo(UnsignedInteger.ONE);
+
+    networkId = NetworkId.of(4_294_967_295L);
+    assertThat(networkId.value()).isEqualTo(UnsignedInteger.MAX_VALUE);
+
+    assertThatThrownBy(() -> NetworkId.of(4_294_967_296L))
+      .isInstanceOf(IllegalArgumentException.class);
+
+    assertThatThrownBy(() -> NetworkId.of(-1))
+      .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void testJson() throws JsonProcessingException, JSONException {
+    NetworkId networkId = NetworkId.of(UnsignedInteger.valueOf(1000));
+    NetworkIdWrapper wrapper = NetworkIdWrapper.of(networkId);
+
+    String json = "{\"networkId\": 1000}";
+    assertSerializesAndDeserializes(wrapper, json);
+  }
+
+  private void assertSerializesAndDeserializes(
+    NetworkIdWrapper wrapper,
+    String json
+  ) throws JsonProcessingException, JSONException {
+    String serialized = objectMapper.writeValueAsString(wrapper);
+    JSONAssert.assertEquals(json, serialized, JSONCompareMode.STRICT);
+    NetworkIdWrapper deserialized = objectMapper.readValue(
+      serialized, NetworkIdWrapper.class
+    );
+    Assertions.assertThat(deserialized).isEqualTo(wrapper);
+  }
+
+
+  @Value.Immutable
+  @JsonSerialize(as = ImmutableNetworkIdWrapper.class)
+  @JsonDeserialize(as = ImmutableNetworkIdWrapper.class)
+  interface NetworkIdWrapper {
+
+    static NetworkIdWrapper of(NetworkId networkId) {
+      return ImmutableNetworkIdWrapper.builder().networkId(networkId).build();
+    }
+
+    NetworkId networkId();
+
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/AccountDeleteJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/AccountDeleteJsonTests.java
@@ -29,6 +29,7 @@ import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.TransactionFlags;
 import org.xrpl.xrpl4j.model.transactions.AccountDelete;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
 public class AccountDeleteJsonTests extends AbstractJsonTest {
@@ -44,6 +45,7 @@ public class AccountDeleteJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -53,6 +55,7 @@ public class AccountDeleteJsonTests extends AbstractJsonTest {
       "    \"DestinationTag\": 13,\n" +
       "    \"Fee\": \"5000000\",\n" +
       "    \"Sequence\": 2470665,\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\"\n" +
       "}";
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/AccountSetJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/AccountSetJsonTests.java
@@ -32,6 +32,7 @@ import org.xrpl.xrpl4j.model.transactions.AccountDelete;
 import org.xrpl.xrpl4j.model.transactions.AccountSet;
 import org.xrpl.xrpl4j.model.transactions.AccountSet.AccountSetFlag;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
 public class AccountSetJsonTests extends AbstractJsonTest {
@@ -54,6 +55,7 @@ public class AccountSetJsonTests extends AbstractJsonTest {
       )
       .flags(AccountSetTransactionFlags.of(TransactionFlags.FULLY_CANONICAL_SIG.getValue()))
       .mintAccount(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -70,6 +72,7 @@ public class AccountSetJsonTests extends AbstractJsonTest {
       "    \"ClearFlag\":8,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
       "    \"NFTokenMinter\" : \"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"EmailHash\":\"f9879d71855b5ff21e4963273a886bfc\"\n" +
       "}";
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/CheckJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/CheckJsonTests.java
@@ -32,6 +32,7 @@ import org.xrpl.xrpl4j.model.transactions.CheckCancel;
 import org.xrpl.xrpl4j.model.transactions.CheckCash;
 import org.xrpl.xrpl4j.model.transactions.CheckCreate;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
 public class CheckJsonTests extends AbstractJsonTest {
@@ -46,6 +47,7 @@ public class CheckJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey( "02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -54,6 +56,7 @@ public class CheckJsonTests extends AbstractJsonTest {
       "    \"CheckID\": \"49647F0D748DC3FE26BDACBC57F251AADEFFF391403EC9BF87C97F67E9977FB0\",\n" +
       "    \"Sequence\": 12,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"Fee\": \"12\"\n" +
       "}";
 
@@ -123,6 +126,7 @@ public class CheckJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -132,6 +136,7 @@ public class CheckJsonTests extends AbstractJsonTest {
       "    \"CheckID\": \"838766BA2B995C00744175F69A1B11E32C3DBC40E64801A4056FCBD657F57334\",\n" +
       "    \"Sequence\": 1,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"Fee\": \"12\"\n" +
       "}";
 
@@ -234,6 +239,7 @@ public class CheckJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -246,6 +252,7 @@ public class CheckJsonTests extends AbstractJsonTest {
       "  \"DestinationTag\": 1,\n" +
       "  \"Sequence\": 1,\n" +
       "  \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+      "  \"NetworkID\": 1024,\n" +
       "  \"Fee\": \"12\"\n" +
       "}";
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/EscrowJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/EscrowJsonTests.java
@@ -38,6 +38,7 @@ import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.EscrowCancel;
 import org.xrpl.xrpl4j.model.transactions.EscrowCreate;
 import org.xrpl.xrpl4j.model.transactions.EscrowFinish;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
 public class EscrowJsonTests extends AbstractJsonTest {
@@ -61,6 +62,7 @@ public class EscrowJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -75,6 +77,7 @@ public class EscrowJsonTests extends AbstractJsonTest {
       "    \"SourceTag\": 11747,\n" +
       "    \"Sequence\": 1,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"Fee\": \"12\"\n" +
       "}";
 
@@ -175,6 +178,7 @@ public class EscrowJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -184,6 +188,7 @@ public class EscrowJsonTests extends AbstractJsonTest {
       "    \"OfferSequence\": 7,\n" +
       "    \"Sequence\": 1,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"Fee\": \"12\"\n" +
       "}";
     assertCanSerializeAndDeserialize(escrowCancel, json);
@@ -258,6 +263,7 @@ public class EscrowJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -269,6 +275,7 @@ public class EscrowJsonTests extends AbstractJsonTest {
       "    \"Fulfillment\": \"A0028000\",\n" +
       "    \"Sequence\": 1,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"Fee\": \"330\"\n" +
       "}";
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/NfTokenAcceptOfferJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/NfTokenAcceptOfferJsonTests.java
@@ -29,6 +29,7 @@ import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.TransactionFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.NfTokenAcceptOffer;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
@@ -48,6 +49,7 @@ public class NfTokenAcceptOfferJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -58,6 +60,7 @@ public class NfTokenAcceptOfferJsonTests extends AbstractJsonTest {
       "    \"NFTokenBuyOffer\": \"000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65\",\n" +
       "    \"NFTokenSellOffer\": \"000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65\",\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"NFTokenBrokerFee\": \"10\"\n" +
       "}";
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/NfTokenBurnJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/NfTokenBurnJsonTests.java
@@ -28,6 +28,7 @@ import org.xrpl.xrpl4j.crypto.keys.PublicKey;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.TransactionFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.NfTokenBurn;
 import org.xrpl.xrpl4j.model.transactions.NfTokenId;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
@@ -46,6 +47,7 @@ public class NfTokenBurnJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -54,6 +56,7 @@ public class NfTokenBurnJsonTests extends AbstractJsonTest {
       "    \"Fee\": \"12\",\n" +
       "    \"Sequence\": 12,\n" +
       "    \"NFTokenID\": \"000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\"\n" +
       "}";
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/NfTokenCancelOfferJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/NfTokenCancelOfferJsonTests.java
@@ -29,6 +29,7 @@ import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.TransactionFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.NfTokenCancelOffer;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
@@ -50,6 +51,7 @@ public class NfTokenCancelOfferJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -57,6 +59,7 @@ public class NfTokenCancelOfferJsonTests extends AbstractJsonTest {
       "    \"Account\": \"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn\",\n" +
       "    \"Fee\": \"12\",\n" +
       "    \"Sequence\": 12,\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"NFTokenOffers\": [" +
       "                     \"000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65\"" +
       "                  ],\n" +

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/NfTokenCreateOfferJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/NfTokenCreateOfferJsonTests.java
@@ -28,6 +28,7 @@ import org.xrpl.xrpl4j.crypto.keys.PublicKey;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.NfTokenCreateOfferFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.NfTokenCreateOffer;
 import org.xrpl.xrpl4j.model.transactions.NfTokenId;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
@@ -47,6 +48,7 @@ public class NfTokenCreateOfferJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -55,6 +57,7 @@ public class NfTokenCreateOfferJsonTests extends AbstractJsonTest {
       "    \"Fee\": \"12\",\n" +
       "    \"Sequence\": 12,\n" +
       "    \"Amount\": \"2000\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"NFTokenID\": \"000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65\",\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\"\n" +
       "}";

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/NfTokenMintJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/NfTokenMintJsonTests.java
@@ -29,6 +29,7 @@ import org.xrpl.xrpl4j.crypto.keys.PublicKey;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.NfTokenMintFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.NfTokenMint;
 import org.xrpl.xrpl4j.model.transactions.NfTokenUri;
 import org.xrpl.xrpl4j.model.transactions.TransferFee;
@@ -50,6 +51,7 @@ public class NfTokenMintJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -59,6 +61,7 @@ public class NfTokenMintJsonTests extends AbstractJsonTest {
       "    \"Flags\": 2147483656,\n" +
       "    \"Sequence\": 12,\n" +
       "    \"TransferFee\": 1000,\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
       "    \"NFTokenTaxon\": 146999694\n" +
       "}";

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/OfferJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/OfferJsonTests.java
@@ -29,6 +29,7 @@ import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.OfferCreateFlags;
 import org.xrpl.xrpl4j.model.flags.TransactionFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.OfferCancel;
 import org.xrpl.xrpl4j.model.transactions.OfferCreate;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
@@ -45,6 +46,7 @@ public class OfferJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -53,6 +55,7 @@ public class OfferJsonTests extends AbstractJsonTest {
       "    \"Sequence\": 12,\n" +
       "    \"OfferSequence\": 13,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"Fee\": \"14\"\n" +
       "}";
 
@@ -124,6 +127,7 @@ public class OfferJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -135,6 +139,7 @@ public class OfferJsonTests extends AbstractJsonTest {
       "    \"TakerGets\": \"15\",\n" +
       "    \"Fee\": \"12\",\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"Expiration\": 16\n" +
       "}";
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/PaymentChannelJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/PaymentChannelJsonTests.java
@@ -31,6 +31,7 @@ import org.xrpl.xrpl4j.model.flags.PaymentChannelClaimFlags;
 import org.xrpl.xrpl4j.model.flags.TransactionFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.PaymentChannelClaim;
 import org.xrpl.xrpl4j.model.transactions.PaymentChannelCreate;
 import org.xrpl.xrpl4j.model.transactions.PaymentChannelFund;
@@ -54,6 +55,7 @@ public class PaymentChannelJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -68,6 +70,7 @@ public class PaymentChannelJsonTests extends AbstractJsonTest {
       "    \"CancelAfter\": 533171558,\n" +
       "    \"DestinationTag\": 23480,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"SourceTag\": 11747\n" +
       "}";
 
@@ -165,6 +168,7 @@ public class PaymentChannelJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -175,6 +179,7 @@ public class PaymentChannelJsonTests extends AbstractJsonTest {
       "  \"Channel\": \"C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198\",\n" +
       "  \"Balance\": \"1000000\",\n" +
       "  \"Amount\": \"1000000\",\n" +
+      "  \"NetworkID\": 1024,\n" +
       "  \"Signature\": \"30440220718D264EF05CAED7C781FF6DE298DCAC68D002562C9BF3A07C1E721B420C0DAB02203A5A4" +
       "779EF4D2CCC7BC3EF886676D803A9981B928D3B8ACA483B80ECA3CD7B9B\",\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
@@ -230,6 +235,7 @@ public class PaymentChannelJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -239,6 +245,7 @@ public class PaymentChannelJsonTests extends AbstractJsonTest {
       "    \"TransactionType\": \"PaymentChannelFund\",\n" +
       "    \"Channel\": \"C1AE6DDDEEC05CF2978C0BAD6FE302948E9533691DC749DCDD3B9E5992CA6198\",\n" +
       "    \"Amount\": \"200000\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
       "    \"Expiration\": 543171558\n" +
       "}";

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/PaymentJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/PaymentJsonTests.java
@@ -31,6 +31,7 @@ import org.xrpl.xrpl4j.model.flags.PaymentFlags;
 import org.xrpl.xrpl4j.model.flags.TransactionFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.PathStep;
 import org.xrpl.xrpl4j.model.transactions.Payment;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
@@ -51,6 +52,7 @@ public class PaymentJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -60,6 +62,7 @@ public class PaymentJsonTests extends AbstractJsonTest {
       "                \"Amount\": \"25000000\",\n" +
       "                \"Fee\": \"10\",\n" +
       "                \"Flags\": 0,\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
       "                \"Sequence\": 2\n" +
       "            }";

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/SetRegularKeyJsonTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/SetRegularKeyJsonTest.java
@@ -28,6 +28,7 @@ import org.xrpl.xrpl4j.crypto.keys.PublicKey;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.TransactionFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.SetRegularKey;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
@@ -43,6 +44,7 @@ public class SetRegularKeyJsonTest extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -51,6 +53,7 @@ public class SetRegularKeyJsonTest extends AbstractJsonTest {
       "    \"Account\": \"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn\",\n" +
       "    \"Fee\": \"12\",\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"RegularKey\": \"rAR8rR8sUkBoCZFawhkWzY4Y5YoyuznwD\"\n" +
       "}";
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/SignerListSetJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/SignerListSetJsonTests.java
@@ -30,6 +30,7 @@ import org.xrpl.xrpl4j.model.flags.TransactionFlags;
 import org.xrpl.xrpl4j.model.ledger.SignerEntry;
 import org.xrpl.xrpl4j.model.ledger.SignerEntryWrapper;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.SignerListSet;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
@@ -65,6 +66,7 @@ public class SignerListSetJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -73,6 +75,7 @@ public class SignerListSetJsonTests extends AbstractJsonTest {
       "    \"Account\": \"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn\",\n" +
       "    \"Fee\": \"12\",\n" +
       "    \"SignerQuorum\": 3,\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
       "    \"SignerEntries\": [\n" +
       "        {\n" +

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/TicketCreateJsonTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/TicketCreateJsonTest.java
@@ -28,6 +28,7 @@ import org.xrpl.xrpl4j.crypto.keys.PublicKey;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.TransactionFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.TicketCreate;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
@@ -43,6 +44,7 @@ class TicketCreateJsonTest extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -50,6 +52,7 @@ class TicketCreateJsonTest extends AbstractJsonTest {
       "    \"Account\": \"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn\",\n" +
       "    \"Fee\": \"12\",\n" +
       "    \"Sequence\": 1,\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
       "    \"TicketCount\": 200\n" +
       "}";

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/TrustSetJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/json/TrustSetJsonTests.java
@@ -29,6 +29,7 @@ import org.xrpl.xrpl4j.model.AbstractJsonTest;
 import org.xrpl.xrpl4j.model.flags.TrustSetFlags;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;
+import org.xrpl.xrpl4j.model.transactions.NetworkId;
 import org.xrpl.xrpl4j.model.transactions.TrustSet;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
@@ -51,6 +52,7 @@ public class TrustSetJsonTests extends AbstractJsonTest {
       .signingPublicKey(
         PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
       )
+      .networkId(NetworkId.of(1024))
       .build();
 
     String json = "{\n" +
@@ -64,6 +66,7 @@ public class TrustSetJsonTests extends AbstractJsonTest {
       "      \"issuer\": \"rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc\",\n" +
       "      \"value\": \"100\"\n" +
       "    },\n" +
+      "    \"NetworkID\": 1024,\n" +
       "    \"Sequence\": 12\n" +
       "}";
 

--- a/xrpl4j-core/src/test/resources/data-driven-tests.json
+++ b/xrpl4j-core/src/test/resources/data-driven-tests.json
@@ -485,13 +485,6 @@
     },
     {
       "type_name": "Hash256",
-      "name": "TicketID",
-      "nth_of_type": 20,
-      "type": 5,
-      "expected_hex": "5014"
-    },
-    {
-      "type_name": "Hash256",
       "name": "Digest",
       "nth_of_type": 21,
       "type": 5,
@@ -720,13 +713,6 @@
       "nth_of_type": 4,
       "type": 8,
       "expected_hex": "84"
-    },
-    {
-      "type_name": "AccountID",
-      "name": "Target",
-      "nth_of_type": 7,
-      "type": 8,
-      "expected_hex": "87"
     },
     {
       "type_name": "AccountID",


### PR DESCRIPTION
Adds support for the `NetworkID` transaction field. This field is `Optional` in `Transaction`, as it is only required on networks with ID > 1024.

Fixes #427 