### PR TITLE
Fixes #486

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -411,7 +411,8 @@
           <version>3.3.0</version>
           <inherited>true</inherited>
           <configuration>
-            <encoding>UTF-8</encoding>
+            <inputEncoding>UTF-8</inputEncoding>
+            <outputEncoding>UTF-8</outputEncoding>
             <consoleOutput>true</consoleOutput>
             <linkXRef>false</linkXRef>
             <failOnViolation>true</failOnViolation>

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/AddressBase58.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/AddressBase58.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.codec.addresses;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -56,7 +56,7 @@ public class AddressBase58 extends Base58 {
     Objects.requireNonNull(expectedLength);
 
     if (expectedLength.intValue() != bytes.getUnsignedBytes().size()) {
-      throw new EncodeException("Length of bytes does not match expectedLength.");
+      throw new EncodeException(String.format("Length of bytes does not match expectedLength of %s.", expectedLength));
     }
 
     return encodeChecked(bytes.toByteArray(), versions);
@@ -99,6 +99,7 @@ public class AddressBase58 extends Base58 {
    * @param version     The {@link Version} to try decoding with.
    *
    * @return A {@link Decoded} containing the decoded value and version.
+   *
    * @throws EncodingFormatException If the version bytes of the Base58 value are invalid.
    */
   public static Decoded decode(
@@ -136,14 +137,14 @@ public class AddressBase58 extends Base58 {
    * Decode a Base58Check {@link String}.
    *
    * @param base58Value    The Base58Check encoded {@link String} to be decoded.
-   * @param keyTypes   A {@link List} of {@link KeyType}s which can be associated with the result of this
-   *                       method.
+   * @param keyTypes       A {@link List} of {@link KeyType}s which can be associated with the result of this method.
    * @param versions       A {@link List} of {@link Version}s to try decoding with.
    * @param expectedLength The expected length of the decoded value.
    *
    * @return A {@link Decoded} containing the decoded value, version, and type.
-   * @throws EncodingFormatException If more than one version is supplied without an expectedLength value present,
-   *                                 or if the version bytes of the Base58 value are invalid.
+   *
+   * @throws EncodingFormatException If more than one version is supplied without an expectedLength value present, or if
+   *                                 the version bytes of the Base58 value are invalid.
    */
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   public static Decoded decode(

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/AddressCodec.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/AddressCodec.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.codec.addresses;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -86,7 +86,10 @@ public class AddressCodec {
    * @param publicKey An {@link UnsignedByteArray} containing the public key to be encoded.
    *
    * @return The Base58 representation of publicKey.
+   *
+   * @deprecated Prefer {@link PublicKeyCodec#encodeNodePublicKey(UnsignedByteArray)}.
    */
+  @Deprecated
   public String encodeNodePublicKey(final UnsignedByteArray publicKey) {
     Objects.requireNonNull(publicKey);
 
@@ -101,7 +104,9 @@ public class AddressCodec {
    * @return An {@link UnsignedByteArray} containing the decoded public key.
    *
    * @see "https://xrpl.org/base58-encodings.html"
+   * @deprecated Prefer {@link PublicKeyCodec#decodeNodePublicKey(String)}.
    */
+  @Deprecated
   public UnsignedByteArray decodeNodePublicKey(final String publicKey) {
     Objects.requireNonNull(publicKey);
 

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodec.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodec.java
@@ -62,7 +62,7 @@ public class PrivateKeyCodec {
    *
    * @see "https://xrpl.org/base58-encodings.html"
    */
-  public UnsignedByteArray decodeNodePrivateKey(final String privateKeyBytes) {
+  public UnsignedByteArray decodeNodePrivateKey(final String privateKeyBase58) {
     Objects.requireNonNull(privateKeyBytes);
 
     return AddressBase58.decode(

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodec.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodec.java
@@ -63,10 +63,10 @@ public class PrivateKeyCodec {
    * @see "https://xrpl.org/base58-encodings.html"
    */
   public UnsignedByteArray decodeNodePrivateKey(final String privateKeyBase58) {
-    Objects.requireNonNull(privateKeyBytes);
+    Objects.requireNonNull(privateKeyBase58);
 
     return AddressBase58.decode(
-      privateKeyBytes,
+      privateKeyBase58,
       Lists.newArrayList(Version.NODE_PRIVATE),
       UnsignedInteger.valueOf(32)
     ).bytes();
@@ -99,10 +99,10 @@ public class PrivateKeyCodec {
    * @see "https://xrpl.org/base58-encodings.html"
    */
   public UnsignedByteArray decodeAccountPrivateKey(final String privateKeyBase58) {
-    Objects.requireNonNull(publicKey);
+    Objects.requireNonNull(privateKeyBase58);
 
     return AddressBase58.decode(
-      publicKey,
+      privateKeyBase58,
       Lists.newArrayList(Version.ACCOUNT_SECRET_KEY),
       UnsignedInteger.valueOf(32)
     ).bytes();

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodec.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodec.java
@@ -56,7 +56,7 @@ public class PrivateKeyCodec {
   /**
    * Decode a Base58Check encoded XRPL Node Private Key.
    *
-   * @param privateKeyBytes The Base58 encoded public key to be decoded.
+   * @param privateKeyBase58 The Base58 encoded public key to be decoded.
    *
    * @return An {@link UnsignedByteArray} containing the decoded public key.
    *

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodec.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodec.java
@@ -28,69 +28,69 @@ import java.util.Objects;
 /**
  * A Codec for encoding/decoding various seed primitives.
  */
-public class PublicKeyCodec {
+public class PrivateKeyCodec {
 
-  private static final PublicKeyCodec INSTANCE = new PublicKeyCodec();
+  private static final PrivateKeyCodec INSTANCE = new PrivateKeyCodec();
 
-  public static PublicKeyCodec getInstance() {
+  public static PrivateKeyCodec getInstance() {
     return INSTANCE;
   }
 
   /**
-   * Encode an XRPL Node Public Key to a Base58Check encoded {@link String}.
+   * Encode an XRPL Node Private Key to a Base58Check encoded {@link String}.
    *
-   * @param publicKey An {@link UnsignedByteArray} containing the public key to be encoded.
+   * @param privateKeyBytes An {@link UnsignedByteArray} containing the public key to be encoded.
    *
-   * @return The Base58 representation of publicKey.
+   * @return The Base58 representation of privateKeyBytes.
    */
-  public String encodeNodePublicKey(final UnsignedByteArray publicKey) {
-    Objects.requireNonNull(publicKey);
+  public String encodeNodePrivateKey(final UnsignedByteArray privateKeyBytes) {
+    Objects.requireNonNull(privateKeyBytes);
 
     return AddressBase58.encode(
-      publicKey,
-      Lists.newArrayList(Version.NODE_PUBLIC),
-      UnsignedInteger.valueOf(33)
+      privateKeyBytes,
+      Lists.newArrayList(Version.NODE_PRIVATE),
+      UnsignedInteger.valueOf(32)
     );
   }
 
   /**
-   * Decode a Base58Check encoded XRPL Node Public Key.
+   * Decode a Base58Check encoded XRPL Node Private Key.
    *
-   * @param publicKey The Base58 encoded public key to be decoded.
+   * @param privateKeyBytes The Base58 encoded public key to be decoded.
    *
    * @return An {@link UnsignedByteArray} containing the decoded public key.
    *
    * @see "https://xrpl.org/base58-encodings.html"
    */
-  public UnsignedByteArray decodeNodePublicKey(final String publicKey) {
-    Objects.requireNonNull(publicKey);
+  public UnsignedByteArray decodeNodePrivateKey(final String privateKeyBytes) {
+    Objects.requireNonNull(privateKeyBytes);
 
     return AddressBase58.decode(
-      publicKey,
-      Lists.newArrayList(Version.NODE_PUBLIC),
-      UnsignedInteger.valueOf(33)
+      privateKeyBytes,
+      Lists.newArrayList(Version.NODE_PRIVATE),
+      UnsignedInteger.valueOf(32)
     ).bytes();
   }
 
   /**
-   * Encode an XRPL Account Public Key to a Base58Check encoded {@link String}.
+   * Encode an XRPL Account Private Key to a Base58Check encoded {@link String}.
    *
-   * @param publicKey An {@link UnsignedByteArray} containing the public key to be encoded.
+   * @param privateKeyBytes An {@link UnsignedByteArray} containing the public key to be encoded.
    *
-   * @return The Base58 representation of publicKey.
+   * @return The Base58 representation of privateKeyBytes.
    */
-  public String encodeAccountPublicKey(final UnsignedByteArray publicKey) {
-    Objects.requireNonNull(publicKey);
+  public String encodeAccountPrivateKey(final UnsignedByteArray privateKeyBytes) {
+    Objects.requireNonNull(privateKeyBytes);
 
     return AddressBase58.encode(
-      publicKey,
-      Lists.newArrayList(Version.ACCOUNT_PUBLIC_KEY),
-      UnsignedInteger.valueOf(33)
+      privateKeyBytes,
+      Lists.newArrayList(Version.ACCOUNT_SECRET_KEY),
+      UnsignedInteger.valueOf(32)
     );
   }
 
   /**
-   * Decode a Base58Check encoded XRPL Account Public Key.
+   * Decode a Base58Check encoded XRPL Account Private Key.
    *
    * @param publicKey The Base58 encoded public key to be decoded.
    *
@@ -98,13 +98,13 @@ public class PublicKeyCodec {
    *
    * @see "https://xrpl.org/base58-encodings.html"
    */
-  public UnsignedByteArray decodeAccountPublicKey(final String publicKey) {
+  public UnsignedByteArray decodeAccountPrivateKey(final String publicKey) {
     Objects.requireNonNull(publicKey);
 
     return AddressBase58.decode(
       publicKey,
-      Lists.newArrayList(Version.ACCOUNT_PUBLIC_KEY),
-      UnsignedInteger.valueOf(33)
+      Lists.newArrayList(Version.ACCOUNT_SECRET_KEY),
+      UnsignedInteger.valueOf(32)
     ).bytes();
   }
 

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodec.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodec.java
@@ -92,7 +92,7 @@ public class PrivateKeyCodec {
   /**
    * Decode a Base58Check encoded XRPL Account Private Key.
    *
-   * @param publicKey The Base58 encoded public key to be decoded.
+   * @param privateKeyBase58 The Base58 encoded public key to be decoded.
    *
    * @return An {@link UnsignedByteArray} containing the decoded public key.
    *

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodec.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodec.java
@@ -98,7 +98,7 @@ public class PrivateKeyCodec {
    *
    * @see "https://xrpl.org/base58-encodings.html"
    */
-  public UnsignedByteArray decodeAccountPrivateKey(final String publicKey) {
+  public UnsignedByteArray decodeAccountPrivateKey(final String privateKeyBase58) {
     Objects.requireNonNull(publicKey);
 
     return AddressBase58.decode(

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByte.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByte.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.codec.addresses;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,7 @@ import com.google.common.io.BaseEncoding;
 
 import java.math.BigInteger;
 import java.util.Objects;
+
 import javax.security.auth.Destroyable;
 
 /**
@@ -40,6 +41,17 @@ public class UnsignedByte implements Destroyable {
     Preconditions.checkArgument(value >= 0);
     Preconditions.checkArgument(value <= 255);
     this.value = value;
+  }
+
+  /**
+   * Copy constructor. Constructs an {@link UnsignedByte} from an {@code UnsignedByte}.
+   *
+   * @param value An {@code int} value.
+   *
+   * @return An {@link UnsignedByte}.
+   */
+  public static UnsignedByte of(final UnsignedByte value) {
+    return new UnsignedByte(value.asInt());
   }
 
   /**
@@ -141,8 +153,8 @@ public class UnsignedByte implements Destroyable {
   }
 
   /**
-   * Does a bitwise OR on this {@link UnsignedByte} and the given {@link UnsignedByte}, and returns a new {@link
-   * UnsignedByte} as the result.
+   * Does a bitwise OR on this {@link UnsignedByte} and the given {@link UnsignedByte}, and returns a new
+   * {@link UnsignedByte} as the result.
    *
    * @param unsignedByte The {@link UnsignedByte} to perform a bitwise OR on.
    *

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByte.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByte.java
@@ -25,7 +25,6 @@ import com.google.common.io.BaseEncoding;
 
 import java.math.BigInteger;
 import java.util.Objects;
-
 import javax.security.auth.Destroyable;
 
 /**

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-
 import javax.security.auth.Destroyable;
 
 /**
@@ -116,6 +115,23 @@ public class UnsignedByteArray implements Destroyable {
   }
 
   /**
+   * Construct a new {@link UnsignedByteArray} that contains this byte array's bytes, but with enough `0x00` prefix
+   * padding bytes such that the final length of the returned value is {@code minFinalByteLength}.
+   *
+   * @param minFinalByteLength The minimum length, in bytes, that the final result must be zero-byte prefix-padded to.
+   *                           If this number is greater-than {@code #length}, then this value will be reduced to
+   *                           {@code #length}.
+   *
+   * @return A copy of this {@link UnsignedByteArray} that has been zero-byte prefix-padded such that its final length
+   *   is at least {@code minFinalByteLength}.
+   */
+  public UnsignedByteArray withPrefixPadding(int minFinalByteLength) {
+    Preconditions.checkArgument(minFinalByteLength >= 0, "minFinalByteLength must not be negative");
+
+    return withPrefixPadding(this.toByteArray(), minFinalByteLength);
+  }
+
+  /**
    * Creates a new {@link UnsignedByteArray} from a byte array by prefixing enough zero-pad bytes to ensure that the
    * result has at least {@code minFinalByteLength} bytes.
    *
@@ -178,23 +194,6 @@ public class UnsignedByteArray implements Destroyable {
       unsignedBytes.add(i, UnsignedByte.of(0));
     }
     return unsignedBytes;
-  }
-
-  /**
-   * Construct a new {@link UnsignedByteArray} that contains this byte array's bytes, but with enough `0x00` prefix
-   * padding bytes such that the final length of the returned value is {@code minFinalByteLength}.
-   *
-   * @param minFinalByteLength The minimum length, in bytes, that the final result must be zero-byte prefix-padded to.
-   *                           If this number is greater-than {@code #length}, then this value will be reduced to
-   *                           {@code #length}.
-   *
-   * @return A copy of this {@link UnsignedByteArray} that has been zero-byte prefix-padded such that its final length
-   *   is at least {@code minFinalByteLength}.
-   */
-  public UnsignedByteArray withPrefixPadding(int minFinalByteLength) {
-    Preconditions.checkArgument(minFinalByteLength >= 0, "minFinalByteLength must not be negative");
-
-    return withPrefixPadding(this.toByteArray(), minFinalByteLength);
   }
 
   /**

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
@@ -86,7 +86,7 @@ public class UnsignedByteArray implements Destroyable {
    * <p>This function primarily exists to ensure that transformation of secp256k1 private keys from one form to another
    * (e.g., from {@link BigInteger} to a byte array) are done in a consistent manner, always yielding the desired number
    * of bytes. For example, secp256k1 private keys are 32-bytes long naturally. However, when transformed to a byte
-   * array via `BigInteger.toByteArray()`, the result will not always have the same number of leading zero bytes that
+   * array via {@link BigInteger#toByteArray()}, the result will not always have the same number of leading zero bytes that
    * one might expect. Sometimes the returned array will have 33 bytes, one of which is a zero-byte prefix pad that is
    * meant to ensure the underlying number is not represented as a negative number. Other times, the array will have
    * fewer than 32 bytes, for example 31 or even 30, if the byte array has redundant leading zero bytes.

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-
 import javax.security.auth.Destroyable;
 
 /**

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
@@ -82,18 +82,18 @@ public class UnsignedByteArray implements Destroyable {
    * Creates an {@link UnsignedByteArray} from the bytes of a supplied {@link BigInteger}. If the length of the
    * resulting array is not at least {@code minFinalByteLength}, then the result prefix padded with `0x00` bytes until
    * the final array length is {@code minFinalByteLength}.
-   * <p>
-   * This function primarily exists to ensure that transformation of secp256k1 private keys from one form to another
+   *
+   * <p>This function primarily exists to ensure that transformation of secp256k1 private keys from one form to another
    * (e.g., from {@link BigInteger} to a byte array) are done in a consistent manner, always yielding the desired number
    * of bytes. For example, secp256k1 private keys are 32-bytes long naturally. However, when transformed to a byte
    * array via `BigInteger.toByteArray()`, the result will not always have the same number of leading zero bytes that
    * one might expect. For example, sometimes the returned array will have 33 bytes, one of which is a zero-byte prefix
    * pad that is meant to ensure the underlying number is not represented as a negative number. Other times, the array
    * will have fewer than 32 bytes, for example 31 or even 30, if the byte array has redundant leading zero bytes.
-   * <p>
-   * Thus, this function can be used to normalize a byte array with a desired number of 0-byte padding to ensure that
-   * the resulting byte array is always the desired {@code minFinalByteLength} (e.g., in this library, secp256k1 private
-   * keys should always be comprised of a 32-byte natural private key with a one-byte `0x00` prefix pad).
+   *
+   * <p>Thus, this function can be used to normalize a byte array with a desired number of 0-byte padding to ensure
+   * that the resulting byte array is always the desired {@code minFinalByteLength} (e.g., in this library, secp256k1
+   * private keys should always be comprised of a 32-byte natural private key with a one-byte `0x00` prefix pad).
    *
    * @param amount             A {@link BigInteger} to convert into an {@link UnsignedByteArray}.
    * @param minFinalByteLength The minimum length, in bytes, that the final result must be. If the final byte length is

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
@@ -80,20 +80,21 @@ public class UnsignedByteArray implements Destroyable {
   }
 
   /**
-   * Creates an {@link UnsignedByteArray} from a {@link BigInteger} with a minimum number of prefix padding bytes.
+   * Creates an {@link UnsignedByteArray} from the bytes of a supplied {@link BigInteger}. If the length of the
+   * resulting array is not at least {@code minFinalByteLength}, then the result prefix padded with `0x00` bytes until
+   * the final array length is {@code minFinalByteLength}.
    * <p>
-   * This function primarily exists to ensure that transforming a secp256k1 private key (as a {@link BigInteger}) to an
-   * instance of {@link UnsignedByteArray} is always done in a consistent fashion yielding the desired number of bytes.
-   * For example, secp256k1 private keys are 32-bytes long naturally. However, when transformed to a byte array via
-   * `BigInteger.toByteArray()`, the result will occasionally be unexpectedly (though correctly) truncated. For example,
-   * sometimes the returned array will have 33 bytes, one of which is a zero-byte prefix pad that is meant to ensure the
-   * underlying number is not represented as a negative number. Other times, the array will have fewer than 32 bytes,
-   * for example 31 or even 30, if the byte array has redundant leading zero bytes. Thus, this function can be used to
-   * normalize the bytes array with a desired number of 0-byte padding to ensure that the resulting byte array is always
-   * the desired {@code minFinalByteLength} (e.g., in this library, secp256k1 private keys should always be comprised of
-   * a 32-byte natural private key with a one-byte `0x00` prefix pad). For more details, see
-   * <a href="https://github.com/XRPLF/xrpl4j/issues/486">Github issue #486</a>.
-   * </p>
+   * This function primarily exists to ensure that transformation of secp256k1 private keys from one form to another
+   * (e.g., from {@link BigInteger} to a byte array) are done in a consistent manner, always yielding the desired number
+   * of bytes. For example, secp256k1 private keys are 32-bytes long naturally. However, when transformed to a byte
+   * array via `BigInteger.toByteArray()`, the result will not always have the same number of leading zero bytes that
+   * one might expect. For example, sometimes the returned array will have 33 bytes, one of which is a zero-byte prefix
+   * pad that is meant to ensure the underlying number is not represented as a negative number. Other times, the array
+   * will have fewer than 32 bytes, for example 31 or even 30, if the byte array has redundant leading zero bytes.
+   * <p>
+   * Thus, this function can be used to normalize a byte array with a desired number of 0-byte padding to ensure that
+   * the resulting byte array is always the desired {@code minFinalByteLength} (e.g., in this library, secp256k1 private
+   * keys should always be comprised of a 32-byte natural private key with a one-byte `0x00` prefix pad).
    *
    * @param amount             A {@link BigInteger} to convert into an {@link UnsignedByteArray}.
    * @param minFinalByteLength The minimum length, in bytes, that the final result must be. If the final byte length is
@@ -102,6 +103,8 @@ public class UnsignedByteArray implements Destroyable {
    *
    * @return An {@link UnsignedByteArray}with a length of at least {@code minFinalByteLength} (possibly via zero-byte
    *   prefix padding).
+   *
+   * @see "https://github.com/XRPLF/xrpl4j/issues/486"
    */
   public static UnsignedByteArray from(final BigInteger amount, int minFinalByteLength) {
     Objects.requireNonNull(amount);

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+
 import javax.security.auth.Destroyable;
 
 /**
@@ -86,9 +87,9 @@ public class UnsignedByteArray implements Destroyable {
    * <p>This function primarily exists to ensure that transformation of secp256k1 private keys from one form to another
    * (e.g., from {@link BigInteger} to a byte array) are done in a consistent manner, always yielding the desired number
    * of bytes. For example, secp256k1 private keys are 32-bytes long naturally. However, when transformed to a byte
-   * array via {@link BigInteger#toByteArray()}, the result will not always have the same number of leading zero bytes that
-   * one might expect. Sometimes the returned array will have 33 bytes, one of which is a zero-byte prefix pad that is
-   * meant to ensure the underlying number is not represented as a negative number. Other times, the array will have
+   * array via {@link BigInteger#toByteArray()}, the result will not always have the same number of leading zero bytes
+   * that one might expect. Sometimes the returned array will have 33 bytes, one of which is a zero-byte prefix pad that
+   * is meant to ensure the underlying number is not represented as a negative number. Other times, the array will have
    * fewer than 32 bytes, for example 31 or even 30, if the byte array has redundant leading zero bytes.
    *
    * <p>Thus, this function can be used to normalize a byte array with a desired number of 0-byte padding to ensure

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
@@ -80,16 +80,16 @@ public class UnsignedByteArray implements Destroyable {
 
   /**
    * Creates an {@link UnsignedByteArray} from the bytes of a supplied {@link BigInteger}. If the length of the
-   * resulting array is not at least {@code minFinalByteLength}, then the result prefix padded with `0x00` bytes until
-   * the final array length is {@code minFinalByteLength}.
+   * resulting array is not at least {@code minFinalByteLength}, then the result is prefix padded with `0x00` bytes
+   * until the final array length is {@code minFinalByteLength}.
    *
    * <p>This function primarily exists to ensure that transformation of secp256k1 private keys from one form to another
    * (e.g., from {@link BigInteger} to a byte array) are done in a consistent manner, always yielding the desired number
    * of bytes. For example, secp256k1 private keys are 32-bytes long naturally. However, when transformed to a byte
    * array via `BigInteger.toByteArray()`, the result will not always have the same number of leading zero bytes that
-   * one might expect. For example, sometimes the returned array will have 33 bytes, one of which is a zero-byte prefix
-   * pad that is meant to ensure the underlying number is not represented as a negative number. Other times, the array
-   * will have fewer than 32 bytes, for example 31 or even 30, if the byte array has redundant leading zero bytes.
+   * one might expect. Sometimes the returned array will have 33 bytes, one of which is a zero-byte prefix pad that is
+   * meant to ensure the underlying number is not represented as a negative number. Other times, the array will have
+   * fewer than 32 bytes, for example 31 or even 30, if the byte array has redundant leading zero bytes.
    *
    * <p>Thus, this function can be used to normalize a byte array with a desired number of 0-byte padding to ensure
    * that the resulting byte array is always the desired {@code minFinalByteLength} (e.g., in this library, secp256k1
@@ -100,8 +100,7 @@ public class UnsignedByteArray implements Destroyable {
    *                           less than this number, the resulting array will be prefix padded to increase its length
    *                           to this number.
    *
-   * @return An {@link UnsignedByteArray}with a length of at least {@code minFinalByteLength} (possibly via zero-byte
-   *   prefix padding).
+   * @return An {@link UnsignedByteArray} with a length of at least {@code minFinalByteLength}.
    *
    * @see "https://github.com/XRPLF/xrpl4j/issues/486"
    */

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArray.java
@@ -20,15 +20,11 @@ package org.xrpl.xrpl4j.codec.addresses;
  * =========================LICENSE_END==================================
  */
 
-import com.google.common.base.Preconditions;
-
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-
 import javax.security.auth.Destroyable;
 
 /**

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/Version.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/addresses/Version.java
@@ -23,10 +23,12 @@ package org.xrpl.xrpl4j.codec.addresses;
 public enum Version {
 
   ED25519_SEED(new int[] {0x01, 0xE1, 0x4B}),
-  FAMILY_SEED(new int[] {0x21}),
+  FAMILY_SEED(new int[] {0x21}), // 33 in decimal
   ACCOUNT_ID(new int[] {0}),
-  NODE_PUBLIC(new int[] {0x1C}),
-  ACCOUNT_PUBLIC_KEY(new int[] {0x23});
+  NODE_PUBLIC(new int[] {0x1C}), // 28 in decimal
+  NODE_PRIVATE(new int[] {0x20}), // 32 in decimal
+  ACCOUNT_SECRET_KEY(new int[] {0x22}), // 34 in decimal
+  ACCOUNT_PUBLIC_KEY(new int[] {0x23}); // 35 in decimal
 
   private final int[] values;
 

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
@@ -21,12 +21,10 @@ package org.xrpl.xrpl4j.crypto.keys;
  */
 
 import com.google.common.base.Preconditions;
-import com.google.common.hash.HashCode;
 import org.xrpl.xrpl4j.codec.addresses.KeyType;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByte;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
 
-import java.security.Key;
 import java.util.Objects;
 
 /**
@@ -182,7 +180,7 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
     } else {
       // Note: `toByteArray()` will perform a copy, which is what we want in order to enforce immutability of this
       // PrivateKey (because Java 8 doesn't support immutable byte arrays).
-      return UnsignedByteArray.of(value.slice(0, 32).toByteArray());
+      return UnsignedByteArray.of(value.toByteArray());
     }
   }
 
@@ -204,10 +202,12 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
       // arrays).
       switch (keyType) {
         case ED25519: {
-          return UnsignedByteArray.of(ED2559_PREFIX).append(value);
+          return UnsignedByteArray.of(ED2559_PREFIX)
+            .append(this.valueWithNaturalBytes()); // <-- Forward to this function to guarantee copied bytes
         }
         case SECP256K1: {
-          return UnsignedByteArray.of(SECP256K1_PREFIX).append(value);
+          return UnsignedByteArray.of(SECP256K1_PREFIX)
+            .append(this.valueWithNaturalBytes()); // <-- Forward to this function to guarantee copied bytes
         }
         default: {
           // This should never happen; if it does, there's a bug in this implementation

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
@@ -123,8 +123,7 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
     // Assumption: Any developer using this method before it was deprecated (i.e., v3.2.1 and before) will likely have
     // expected `value` to have been prefixed. However, until this method was "fixed" in v3.2.2, a developer might have
     // used this method incorrectly because (1) this method had no length check and (2) the computation of the KeyType
-    // naively inspected the first byte, and defaulted to secp256k1 if the first byte was `0xED`. For example, in that
-    // world, padding in a one-byte value of `0x00` would have produced a `PrivateKey` object with invalid byte data.
+    // simply inspected the first byte, and naively defaulted to secp256k1 if the first byte was not `0xED`.
     return fromPrefixedBytes(value);
   }
 

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
@@ -120,10 +120,11 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
    */
   @Deprecated
   public static PrivateKey of(final UnsignedByteArray value) {
-    // Assumption: Any developer using this method before this method was deprecated (i.e., v3.3) will likely have
-    // expected `value` to have been prefixed. That said, this assumption is technically invalid because it's ambiguous
-    // what any particular developer would have meant (see #486) because prior to #486, there was no byte-length check
-    // on these bytes.
+    // Assumption: Any developer using this method before it was deprecated (i.e., v3.2.1 and before) will likely have
+    // expected `value` to have been prefixed. However, until this method was "fixed" in v3.2.2, a developer might have
+    // used this method incorrectly because (1) this method had no length check and (2) the computation of the KeyType
+    // naively inspected the first byte, and defaulted to secp256k1 if the first byte was `0xED`. For example, in that
+    // world, padding in a one-byte value of `0x00` would have produced a `PrivateKey` object with invalid byte data.
     return fromPrefixedBytes(value);
   }
 

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
@@ -191,10 +191,9 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
   }
 
   /**
-   * Accessor for the byte value in {@link #value()} but in a more natural form (i.e., the size of the returned value
-   * will be 32 bytes). Natural ed25519 or secp256k1 private keys will ordinarily contain only 32 bytes. However, in
-   * XRPL, private keys are represented with a single-byte prefix (i.e., `0xED` for ed25519 and `0x00` for secp256k1
-   * keys).
+   * Accessor for the bytes of this private key in a prefixed. Natural ed25519 or secp256k1 private keys will ordinarily
+   * contain only 32 bytes. However, in XRPL, private keys are typically represented with a single-byte prefix (i.e.,
+   * `0xED` for ed25519 and `0x00` for secp256k1 keys), which this method provides.
    *
    * @return An instance of {@link UnsignedByteArray}.
    */

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
@@ -144,6 +144,8 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
       "Byte values passed to this constructor must be 32 bytes long, with no prefix."
     );
 
+    // Note: `UnsignedByteArray#toByteArray` will perform a copy, which is what we want in order to enforce
+    // immutability of this PrivateKey (because Java 8 doesn't support immutable byte arrays).
     this.value = UnsignedByteArray.of(value.toByteArray()); // <- Always copy to ensure immutability
   }
 
@@ -198,9 +200,6 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
     if (value.length() == 0) {
       return UnsignedByteArray.empty();
     } else {
-      // Note: value.slice() will take a view of the existing UBA, then `.toByteArray()` will perform a copy, which is
-      // what we want in order to enforce immutability of this PrivateKey (because Java 8 doesn't support immutable byte
-      // arrays).
       switch (keyType) {
         case ED25519: {
           return UnsignedByteArray.of(ED2559_PREFIX)

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
@@ -157,7 +157,7 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
    *
    * @return An instance of {@link UnsignedByteArray}.
    *
-   * @deprecated Prefer {@link #valueWithPrefixedBytes()} or {@link #valueWithNaturalBytes()} instead.
+   * @deprecated Prefer {@link #prefixedBytes()} or {@link #naturalBytes()} instead.
    */
   @Deprecated
   public UnsignedByteArray value() {
@@ -167,7 +167,7 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
     } else {
       // This is technically wrong (because `value()` had an ambiguous meaning prior to fixing #486), but this mirrors
       // what's in v3 prior to fixing #486, and will be fixed in v4 once the deprecated `.value()` is removed.
-      return this.valueWithPrefixedBytes();
+      return this.prefixedBytes();
     }
   }
 
@@ -179,7 +179,7 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
    *
    * @return An instance of {@link UnsignedByteArray}.
    */
-  public UnsignedByteArray valueWithNaturalBytes() {
+  public UnsignedByteArray naturalBytes() {
     // Check for empty value, which can occur if this PrivateKey is "destroyed" but still in memory.
     if (value.length() == 0) {
       return UnsignedByteArray.empty();
@@ -198,7 +198,7 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
    *
    * @return An instance of {@link UnsignedByteArray}.
    */
-  public UnsignedByteArray valueWithPrefixedBytes() {
+  public UnsignedByteArray prefixedBytes() {
     // Check for empty value, which can occur if this PrivateKey is "destroyed" but still in memory.
     if (value.length() == 0) {
       return UnsignedByteArray.empty();
@@ -206,11 +206,11 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
       switch (keyType) {
         case ED25519: {
           return UnsignedByteArray.of(ED2559_PREFIX)
-            .append(this.valueWithNaturalBytes()); // <-- Forward to this function to guarantee copied bytes
+            .append(this.naturalBytes()); // <-- Forward to this function to guarantee copied bytes
         }
         case SECP256K1: {
           return UnsignedByteArray.of(SECP256K1_PREFIX)
-            .append(this.valueWithNaturalBytes()); // <-- Forward to this function to guarantee copied bytes
+            .append(this.naturalBytes()); // <-- Forward to this function to guarantee copied bytes
         }
         default: {
           // This should never happen; if it does, there's a bug in this implementation

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
@@ -207,6 +207,7 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
           return UnsignedByteArray.of(SECP256K1_PREFIX).append(value);
         }
         default: {
+          // This should never happen; if it does, there's a bug in this implementation
           throw new IllegalStateException(String.format("Invalid keyType=%s", keyType));
         }
       }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
@@ -100,9 +100,9 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
       return new PrivateKey(value.slice(1, 33), KeyType.SECP256K1);
     } else {
       throw new IllegalArgumentException(String.format(
-        "Constructing a PrivateKey with raw bytes requires a one-byte prefix in front of the 32 natural bytes of a" +
-          " private key. Use the prefix `0xED` for ed25519 private keys, or `0x00` for secp256k1 private keys. " +
-          "Length was %s bytes.", value.length())
+        "PrivateKey construction requires 32 natural bytes plug a one-byte prefix value of either `0xED` for ed25519 " +
+          "private keys or `0x00` for secp256k1 private keys. Input byte length was %s bytes with a prefixByte value of " +
+          "`0x%s`", value.length(), prefixByte.hexValue())
       );
     }
   }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
@@ -67,10 +67,6 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
 
   private boolean destroyed;
 
-  private static final String CONSTRUCTOR_ERROR_MESSAGE =
-    "Constructing a PrivateKey with raw bytes requires a one-byte prefix in front of the 32 natural bytes of a" +
-      " private key. Use the prefix `0xED` for ed25519 private keys, or `0x00` for secp256k1 private keys.";
-
   /**
    * Instantiates a new instance of {@link PrivateKey} using the supplied 32 bytes and specified key type.
    *
@@ -94,7 +90,10 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
   public static PrivateKey fromPrefixedBytes(final UnsignedByteArray value) {
     Objects.requireNonNull(value);
 
-    Preconditions.checkArgument(value.length() == 33, CONSTRUCTOR_ERROR_MESSAGE);
+    Preconditions.checkArgument(value.length() == 33, String.format(
+      "The `fromPrefixedBytes` function requires input length of 33 bytes, but %s were supplied.",
+      value.length()
+    ));
 
     final UnsignedByte prefixByte = value.get(0); // <-- relies upon the above length check.
     if (ED2559_PREFIX.equals(prefixByte)) {
@@ -102,7 +101,11 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
     } else if (SECP256K1_PREFIX.equals(prefixByte)) {
       return new PrivateKey(value.slice(1, 33), KeyType.SECP256K1);
     } else {
-      throw new IllegalArgumentException(CONSTRUCTOR_ERROR_MESSAGE);
+      throw new IllegalArgumentException(String.format(
+        "Constructing a PrivateKey with raw bytes requires a one-byte prefix in front of the 32 natural bytes of a" +
+          " private key. Use the prefix `0xED` for ed25519 private keys, or `0x00` for secp256k1 private keys. " +
+          "Length was %s bytes.", value.length())
+      );
     }
   }
 

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
@@ -33,6 +33,8 @@ import java.util.Objects;
 public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyable {
 
   /**
+   * A one-byte prefix for ed25519 keys.
+   *
    * @deprecated This value will be removed in a future version. Prefer {@link #ED2559_PREFIX} or
    *   {@link #SECP256K1_PREFIX} instead.
    */

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
@@ -101,8 +101,8 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
     } else {
       throw new IllegalArgumentException(String.format(
         "PrivateKey construction requires 32 natural bytes plug a one-byte prefix value of either `0xED` for ed25519 " +
-          "private keys or `0x00` for secp256k1 private keys. Input byte length was %s bytes with a prefixByte value of " +
-          "`0x%s`", value.length(), prefixByte.hexValue())
+          "private keys or `0x00` for secp256k1 private keys. Input byte length was %s bytes with a prefixByte value " +
+          "of `0x%s`", value.length(), prefixByte.hexValue())
       );
     }
   }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PrivateKey.java
@@ -144,6 +144,10 @@ public class PrivateKey implements PrivateKeyable, javax.security.auth.Destroyab
       "Byte values passed to this constructor must be 32 bytes long, with no prefix."
     );
 
+    // NOTE: We do not do any further sanity checking of `value` (e.g., converting to a BigInteger and checking if it's
+    // in the proper range of [1, N-1]) on grounds that any particular underlying implementation will enforce these
+    // invariants for us, and will likely be more correct than we would.
+
     // Note: `UnsignedByteArray#toByteArray` will perform a copy, which is what we want in order to enforce
     // immutability of this PrivateKey (because Java 8 doesn't support immutable byte arrays).
     this.value = UnsignedByteArray.of(value.toByteArray()); // <- Always copy to ensure immutability

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PublicKey.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/PublicKey.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.crypto.keys;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,6 +35,7 @@ import org.xrpl.xrpl4j.codec.addresses.AddressCodec;
 import org.xrpl.xrpl4j.codec.addresses.Decoded;
 import org.xrpl.xrpl4j.codec.addresses.KeyType;
 import org.xrpl.xrpl4j.codec.addresses.PublicKeyCodec;
+import org.xrpl.xrpl4j.codec.addresses.UnsignedByte;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
 import org.xrpl.xrpl4j.codec.addresses.Version;
 import org.xrpl.xrpl4j.model.jackson.modules.PublicKeyDeserializer;
@@ -53,12 +54,18 @@ import java.util.Objects;
 public interface PublicKey {
 
   /**
-   * Multi-signed transactions must contain an empty String in the SigningPublicKey field. This constant
-   * is an {@link PublicKey} that can be used as the {@link Transaction#signingPublicKey()} value for multi-signed
+   * A one-byte prefix for ed25519 keys. In XRPL, ed25519 public keys are prefixed with a one-byte prefix (i.e., `0xED`)
+   * in order to be consistent with secp256k1 public keys, which always have 33 bytes.
+   */
+  UnsignedByte ED2559_PREFIX = UnsignedByte.of(0xED);
+
+  /**
+   * Multi-signed transactions must contain an empty String in the SigningPublicKey field. This constant is an
+   * {@link PublicKey} that can be used as the {@link Transaction#signingPublicKey()} value for multi-signed
    * transactions.
    */
   PublicKey MULTI_SIGN_PUBLIC_KEY = PublicKey.builder().value(UnsignedByteArray.empty()).build();
-  
+
   /**
    * Instantiates a new builder.
    *
@@ -77,11 +84,11 @@ public interface PublicKey {
    */
   static PublicKey fromBase58EncodedPublicKey(final String base58EncodedPublicKey) {
     Objects.requireNonNull(base58EncodedPublicKey);
-    
+
     if (base58EncodedPublicKey.isEmpty()) {
       return MULTI_SIGN_PUBLIC_KEY;
     }
-    
+
     return PublicKey.builder()
       .value(PublicKeyCodec.getInstance().decodeAccountPublicKey(base58EncodedPublicKey))
       .build();
@@ -100,7 +107,7 @@ public interface PublicKey {
     if (base16EncodedPublicKey.isEmpty()) {
       return MULTI_SIGN_PUBLIC_KEY;
     }
-    
+
     return PublicKey.builder()
       .value(UnsignedByteArray.of(BaseEncoding.base16().decode(base16EncodedPublicKey.toUpperCase())))
       .build();
@@ -123,7 +130,7 @@ public interface PublicKey {
     if (value().length() == 0) {
       return "";
     }
-    
+
     return PublicKeyCodec.getInstance().encodeAccountPublicKey(this.value());
   }
 
@@ -175,5 +182,5 @@ public interface PublicKey {
     digest.doFinal(ripemdSha256, 0);
     return UnsignedByteArray.of(ripemdSha256);
   }
-  
+
 }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
@@ -389,9 +389,11 @@ public interface Seed extends javax.security.auth.Destroyable {
         final BigInteger privateKeyInt = derivePrivateKey(seedBytes, accountNumber);
         final UnsignedByteArray publicKeyInt = derivePublicKey(privateKeyInt);
 
-        // Both ed25519 and secp256k1 _private_ keys are always 32 bytes long. However, in this library, both types of
-        // private key are prefixed with one byte (0xED for ed25519 and 0x00 for secp256k1) because this is what other
-        // libraries do, and also so that any particular set of 32 private key bytes can be properly disambiguated.
+        // All natural secp256k1 private keys always have only 32-bytes. However, when computing `publicKeyInt`,
+        // the `BigInteger.toByteArray()` will return the byte array in two's-complement form and occasionally prepend
+        // a zero byte to ensure the number is not negative. When this doesn't happen, we want to normalize the
+        // private key bytes to always have this one-byte prefix because this library prefixes all private keys with a
+        // prefix to identify the key type (`0xED` for ed25519 and `0x00` for secp256k1).
         // See https://github.com/XRPLF/xrpl4j/issues/486 for more details.
         final UnsignedByteArray prefixedPrivateKey;
         if (privateKeyInt.toByteArray().length == 32) {

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
@@ -20,8 +20,6 @@ package org.xrpl.xrpl4j.crypto.keys;
  * =========================LICENSE_END==================================
  */
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -37,7 +35,6 @@ import org.xrpl.xrpl4j.codec.addresses.Base58;
 import org.xrpl.xrpl4j.codec.addresses.Decoded;
 import org.xrpl.xrpl4j.codec.addresses.KeyType;
 import org.xrpl.xrpl4j.codec.addresses.SeedCodec;
-import org.xrpl.xrpl4j.codec.addresses.UnsignedByte;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
 import org.xrpl.xrpl4j.codec.addresses.Version;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.DecodeException;
@@ -384,20 +381,17 @@ public interface Seed extends javax.security.auth.Destroyable {
       private static KeyPair deriveKeyPair(final UnsignedByteArray seedBytes, final int accountNumber) {
         Objects.requireNonNull(seedBytes);
 
-        // private key needs to be a BigInteger so we can derive the public key by multiplying G by the private key.
+        // private key needs to be a BigInteger, so we can derive the public key by multiplying G by the private key.
         final BigInteger privateKeyInt = derivePrivateKey(seedBytes, accountNumber);
 
         // This derivePublicKey will pad to 33 bytes.
-        final UnsignedByteArray publicKeyInt = derivePublicKey(privateKeyInt);
+        final UnsignedByteArray publicKeyByteArray = derivePublicKey(privateKeyInt);
         // This merely enforces the invariant that should be defined in `derivePublicKey(privateKeyInt);`
-        Preconditions.checkArgument(publicKeyInt.length() == 33, "Length was " + publicKeyInt.length());
-
-        // No need to prefix secp256k1 public keys because these are always 33 bytes.
-        final UnsignedByteArray prefixedPublicKey = UnsignedByteArray.of(publicKeyInt.toByteArray());
+        Preconditions.checkArgument(publicKeyByteArray.length() == 33, "Length was " + publicKeyByteArray.length());
 
         return KeyPair.builder()
           .privateKey(PrivateKey.fromPrefixedBytes(UnsignedByteArray.from(privateKeyInt, 33)))
-          .publicKey(PublicKey.fromBase16EncodedPublicKey(prefixedPublicKey.hexValue()))
+          .publicKey(PublicKey.builder().value(publicKeyByteArray).build())
           .build();
       }
 

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
@@ -409,15 +409,13 @@ public interface Seed extends javax.security.auth.Destroyable {
         UnsignedByteArray unpaddedBytes = UnsignedByteArray.of(
           EC_DOMAIN_PARAMETERS.getG().multiply(privateKey).getEncoded(true));
 
-        return Secp256k1.withZeroPrefixPadding(unpaddedBytes, 33);
-
-//        return unpaddedBytes.withZeroPrefixPadding(33); // <-- Ensure that the returned UBA has 33 bytes.
+        return Secp256k1.withZeroPrefixPadding(unpaddedBytes, 33); // <-- Ensure returned UBA has 33 bytes.
       }
 
       /**
        * Derive a public key from the supplied {@code seed} and {@code accountNumber}.
        *
-       * @param seed          A {@link UnsignedByteArray} representing a seed that can be used to generated an XRPL
+       * @param seed          A {@link UnsignedByteArray} representing a seed that can be used to generate an XRPL
        *                      address.
        * @param accountNumber An integer representing the account nunmber.
        *

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
@@ -389,6 +389,7 @@ public interface Seed extends javax.security.auth.Destroyable {
 
         // This derivePublicKey will pad to 33 bytes.
         final UnsignedByteArray publicKeyInt = derivePublicKey(privateKeyInt);
+        // This merely enforces the invariant that should be defined in `derivePublicKey(privateKeyInt);`
         Preconditions.checkArgument(publicKeyInt.length() == 33, "Length was " + publicKeyInt.length());
 
         // No need to prefix secp256k1 public keys because these are always 33 bytes.

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
@@ -318,7 +318,7 @@ public interface Seed extends javax.security.auth.Destroyable {
 
         // ed25519 public keys in XRPL have a one-byte prefix of `0xED` so that all public keys have 33 bytes (this is
         // to conform with secp256k1 public keys, which are 33 bytes long and have a `0x00` byte prefix.
-        final UnsignedByteArray prefixedPublicKey = UnsignedByteArray.of(PrivateKey.ED2559_PREFIX)
+        final UnsignedByteArray prefixedPublicKey = UnsignedByteArray.of(PublicKey.ED2559_PREFIX)
           .append(UnsignedByteArray.of(publicKey.getEncoded()));
 
         return KeyPair.builder()

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
@@ -136,7 +136,7 @@ public final class BcKeyUtils {
     Objects.requireNonNull(ed25519PublicKeyParameters);
     // XRPL ED25519 keys are prefixed with 0xED so that the keys are 33 bytes and match the length of sekp256k1 keys.
     // Bouncy Castle only deals with 32 byte keys, so we need to manually add the prefix
-    UnsignedByteArray prefixedPublicKey = UnsignedByteArray.of(PrivateKey.ED2559_PREFIX)
+    UnsignedByteArray prefixedPublicKey = UnsignedByteArray.of(PublicKey.ED2559_PREFIX)
       .append(UnsignedByteArray.of(ed25519PublicKeyParameters.getEncoded()));
 
     return PublicKey.builder()

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
@@ -37,6 +37,7 @@ import org.xrpl.xrpl4j.codec.addresses.KeyType;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
 import org.xrpl.xrpl4j.crypto.keys.PrivateKey;
 import org.xrpl.xrpl4j.crypto.keys.PublicKey;
+import org.xrpl.xrpl4j.crypto.signing.bc.Secp256k1;
 
 import java.math.BigInteger;
 import java.security.Security;
@@ -101,7 +102,7 @@ public final class BcKeyUtils {
   public static PrivateKey toPrivateKey(final ECPrivateKeyParameters ecPrivateKeyParameters) {
     return PrivateKey.fromPrefixedBytes(
       // Call `UnsignedByteArray.from` to properly prefix-pad the BigInteger's bytes.
-      UnsignedByteArray.from(ecPrivateKeyParameters.getD(), 33)
+      Secp256k1.toUnsignedByteArray(ecPrivateKeyParameters.getD(), 33)
     );
   }
 

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
@@ -100,8 +100,10 @@ public final class BcKeyUtils {
   public static PrivateKey toPrivateKey(final ECPrivateKeyParameters ecPrivateKeyParameters) {
     // Convert the HEX representation of the BigInteger into bytes.
     byte[] privateKeyBytes = BaseEncoding.base16().decode(ecPrivateKeyParameters.getD().toString(16).toUpperCase());
-    final UnsignedByteArray privateKeyUba = UnsignedByteArray.of(privateKeyBytes);
-    return PrivateKey.of(privateKeyUba);
+    return PrivateKey.of(
+      UnsignedByteArray.of(PrivateKey.SECP256K1_PREFIX) // <-- Per #486, always append 0x00 to secp256k1 private keys
+        .append(UnsignedByteArray.of(privateKeyBytes))
+    );
   }
 
   /**

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
@@ -85,7 +85,7 @@ public final class BcKeyUtils {
 
     // XRPL ED25519 keys are prefixed with 0xED so that the keys are 33 bytes and match the length of sekp256k1 keys.
     // Bouncy Castle only deals with 32 byte keys, so we need to manually add the prefix
-    UnsignedByteArray prefixedPrivateKey = UnsignedByteArray.of(PrivateKey.PREFIX)
+    UnsignedByteArray prefixedPrivateKey = UnsignedByteArray.of(PrivateKey.ED2559_PREFIX)
       .append(UnsignedByteArray.of(ed25519PrivateKeyParameters.getEncoded()));
     return PrivateKey.of(prefixedPrivateKey);
   }
@@ -136,7 +136,7 @@ public final class BcKeyUtils {
     Objects.requireNonNull(ed25519PublicKeyParameters);
     // XRPL ED25519 keys are prefixed with 0xED so that the keys are 33 bytes and match the length of sekp256k1 keys.
     // Bouncy Castle only deals with 32 byte keys, so we need to manually add the prefix
-    UnsignedByteArray prefixedPublicKey = UnsignedByteArray.of(PrivateKey.PREFIX)
+    UnsignedByteArray prefixedPublicKey = UnsignedByteArray.of(PrivateKey.ED2559_PREFIX)
       .append(UnsignedByteArray.of(ed25519PublicKeyParameters.getEncoded()));
 
     return PublicKey.builder()

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
@@ -206,7 +206,7 @@ public final class BcKeyUtils {
     Objects.requireNonNull(privateKey);
     Preconditions.checkArgument(privateKey.keyType() == ED25519);
     // Use offset 0 with no prefix
-    return new Ed25519PrivateKeyParameters(privateKey.valueWithNaturalBytes().toByteArray(), 0);
+    return new Ed25519PrivateKeyParameters(privateKey.naturalBytes().toByteArray(), 0);
   }
 
   /**
@@ -237,7 +237,7 @@ public final class BcKeyUtils {
     Preconditions.checkArgument(privateKey.keyType() == KeyType.SECP256K1, "KeyType must be SECP256K1");
 
     final BigInteger privateKeyInt = new BigInteger(
-      BaseEncoding.base16().encode(privateKey.valueWithNaturalBytes().toByteArray()), 16
+      BaseEncoding.base16().encode(privateKey.naturalBytes().toByteArray()), 16
     );
     return new ECPrivateKeyParameters(privateKeyInt, BcKeyUtils.PARAMS);
   }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtils.java
@@ -236,9 +236,9 @@ public final class BcKeyUtils {
     Objects.requireNonNull(privateKey);
     Preconditions.checkArgument(privateKey.keyType() == KeyType.SECP256K1, "KeyType must be SECP256K1");
 
-    final BigInteger privateKeyInt = new BigInteger(
-      BaseEncoding.base16().encode(privateKey.naturalBytes().toByteArray()), 16
-    );
-    return new ECPrivateKeyParameters(privateKeyInt, BcKeyUtils.PARAMS);
+    // From http://www.secg.org/sec1-v2.pdf: A PrivateKey consists of an elliptic curve secret key `d` which is an
+    // integer in the interval [1, n − 1]. Therefore, it is safe to assume that the signum below should always be 1.
+    final BigInteger secretKeyD = new BigInteger(1, privateKey.naturalBytes().toByteArray());
+    return new ECPrivateKeyParameters(secretKeyD, BcKeyUtils.PARAMS);
   }
 }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/AbstractTransactionSigner.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/AbstractTransactionSigner.java
@@ -31,7 +31,9 @@ import org.xrpl.xrpl4j.model.transactions.Transaction;
 import java.util.Objects;
 
 /**
- * An abstract implementation of {@link SignatureService} with common functionality that sub-classes can utilize.
+ * An abstract implementation of {@link SignatureService} with common functionality that subclasses can utilize.
+ *
+ * @param <P> A type that extends {@link PrivateKeyable}.
  */
 public abstract class AbstractTransactionSigner<P extends PrivateKeyable> implements TransactionSigner<P> {
 

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/BcSignatureService.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/BcSignatureService.java
@@ -96,17 +96,14 @@ public class BcSignatureService extends AbstractSignatureService<PrivateKey> imp
 
     final byte[] privateKeyBytes = new byte[32];
     try {
-      // Remove ED prefix byte (if it's there)
       System.arraycopy(privateKey.valueWithNaturalBytes().toByteArray(), 0, privateKeyBytes, 0, 32);
-      Ed25519PrivateKeyParameters privateKeyParameters = new Ed25519PrivateKeyParameters(
-        privateKeyBytes, 0
-      );
+      Ed25519PrivateKeyParameters privateKeyParameters = new Ed25519PrivateKeyParameters(privateKeyBytes, 0);
+
+      final byte[] signableBytes = signableTransactionBytes.toByteArray();
 
       ed25519Signer.reset();
       ed25519Signer.init(true, privateKeyParameters);
-      ed25519Signer.update(
-        signableTransactionBytes.toByteArray(), 0, signableTransactionBytes.getUnsignedBytes().size()
-      );
+      ed25519Signer.update(signableTransactionBytes.toByteArray(), 0, signableBytes.length);
 
       final UnsignedByteArray sigBytes = UnsignedByteArray.of(ed25519Signer.generateSignature());
       return Signature.builder()

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/BcSignatureService.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/BcSignatureService.java
@@ -97,7 +97,7 @@ public class BcSignatureService extends AbstractSignatureService<PrivateKey> imp
     final byte[] privateKeyBytes = new byte[32];
     try {
       // Remove ED prefix byte (if it's there)
-      System.arraycopy(privateKey.value().toByteArray(), 1, privateKeyBytes, 0, 32);
+      System.arraycopy(privateKey.valueWithNaturalBytes().toByteArray(), 0, privateKeyBytes, 0, 32);
       Ed25519PrivateKeyParameters privateKeyParameters = new Ed25519PrivateKeyParameters(
         privateKeyBytes, 0
       );
@@ -127,8 +127,7 @@ public class BcSignatureService extends AbstractSignatureService<PrivateKey> imp
     Objects.requireNonNull(transactionBytes);
 
     final UnsignedByteArray messageHash = HashingUtils.sha512Half(transactionBytes);
-
-    final BigInteger privateKeyInt = new BigInteger(privateKey.value().toByteArray());
+    final BigInteger privateKeyInt = new BigInteger(privateKey.valueWithPrefixedBytes().toByteArray());
     final ECPrivateKeyParameters parameters = new ECPrivateKeyParameters(privateKeyInt, BcKeyUtils.PARAMS);
 
     ecdsaSigner.init(true, parameters);

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/BcSignatureService.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/BcSignatureService.java
@@ -96,7 +96,7 @@ public class BcSignatureService extends AbstractSignatureService<PrivateKey> imp
 
     final byte[] privateKeyBytes = new byte[32];
     try {
-      System.arraycopy(privateKey.valueWithNaturalBytes().toByteArray(), 0, privateKeyBytes, 0, 32);
+      System.arraycopy(privateKey.naturalBytes().toByteArray(), 0, privateKeyBytes, 0, 32);
       Ed25519PrivateKeyParameters privateKeyParameters = new Ed25519PrivateKeyParameters(privateKeyBytes, 0);
 
       final byte[] signableBytes = signableTransactionBytes.toByteArray();
@@ -127,7 +127,7 @@ public class BcSignatureService extends AbstractSignatureService<PrivateKey> imp
 
     // From http://www.secg.org/sec1-v2.pdf:  consists of an elliptic curve secret key `d` which is an integer in
     // the interval [1, n − 1]
-    final BigInteger secretKeyD = new BigInteger(privateKey.valueWithPrefixedBytes().toByteArray());
+    final BigInteger secretKeyD = new BigInteger(privateKey.prefixedBytes().toByteArray());
     final ECPrivateKeyParameters parameters = new ECPrivateKeyParameters(secretKeyD, BcKeyUtils.PARAMS);
 
     ecdsaSigner.init(true, parameters);

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/BcSignatureService.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/BcSignatureService.java
@@ -124,8 +124,11 @@ public class BcSignatureService extends AbstractSignatureService<PrivateKey> imp
     Objects.requireNonNull(transactionBytes);
 
     final UnsignedByteArray messageHash = HashingUtils.sha512Half(transactionBytes);
-    final BigInteger privateKeyInt = new BigInteger(privateKey.valueWithPrefixedBytes().toByteArray());
-    final ECPrivateKeyParameters parameters = new ECPrivateKeyParameters(privateKeyInt, BcKeyUtils.PARAMS);
+
+    // From http://www.secg.org/sec1-v2.pdf:  consists of an elliptic curve secret key `d` which is an integer in
+    // the interval [1, n − 1]
+    final BigInteger secretKeyD = new BigInteger(privateKey.valueWithPrefixedBytes().toByteArray());
+    final ECPrivateKeyParameters parameters = new ECPrivateKeyParameters(secretKeyD, BcKeyUtils.PARAMS);
 
     ecdsaSigner.init(true, parameters);
     final BigInteger[] signatures = ecdsaSigner.generateSignature(messageHash.toByteArray());

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/Secp256k1.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/Secp256k1.java
@@ -20,17 +20,19 @@ package org.xrpl.xrpl4j.crypto.signing.bc;
  * =========================LICENSE_END==================================
  */
 
+import com.google.common.base.Preconditions;
 import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.params.ECDomainParameters;
+import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
 import org.xrpl.xrpl4j.crypto.keys.bc.BcKeyUtils;
+
+import java.math.BigInteger;
+import java.util.Objects;
 
 /**
  * Static constants for Secp256k1 operations.
- *
- * @deprecated This interface is deprecated in-favor of {@link BcKeyUtils#PARAMS}.
  */
-@Deprecated
 public interface Secp256k1 {
 
   /**
@@ -53,5 +55,88 @@ public interface Secp256k1 {
     EC_PARAMETERS.getN(),
     EC_PARAMETERS.getH()
   );
+
+
+  /**
+   * Creates an {@link UnsignedByteArray} from the bytes of a supplied {@link BigInteger}. If the length of the
+   * resulting array is not at least {@code minFinalByteLength}, then the result is prefix padded with `0x00` bytes
+   * until the final array length is {@code minFinalByteLength}.
+   *
+   * <p>This function exists to ensure that transformation of secp256k1 private keys from a {@link BigInteger} to a
+   * byte array are done in a consistent manner, always yielding the desired number of bytes. For example, secp256k1
+   * private keys are 32-bytes long naturally. However, when transformed to a byte array via
+   * {@link BigInteger#toByteArray()}, the result will not always have the same number of leading zero bytes that one
+   * might expect. Sometimes the returned array will have 33 bytes, one of which is a zero-byte prefix pad that is meant
+   * to ensure the underlying number is not represented as a negative number. Other times, the array will have fewer
+   * than 32 bytes, for example 31 or even 30, if the byte array has redundant leading zero bytes.
+   *
+   * <p>Note that this function assumes the supplied {@code amount} is always positive, which roughly correlates with
+   * the secp256k1 requirement that private key scalar `D` values be in the range [1, N-1].
+   *
+   * <p>Thus, this function can be used to normalize a byte array containing a secp256k1 private key with a desired
+   * number of 0-byte padding to ensure that it is always the desired {@code minFinalByteLength} (e.g., in this library,
+   * secp256k1 private keys should always be comprised of a 32-byte natural private key with a one-byte `0x00` prefix
+   * pad).
+   *
+   * @param amount             A {@link BigInteger} to convert into an {@link UnsignedByteArray}.
+   * @param minFinalByteLength The minimum length, in bytes, that the final result must be. If the final byte length is
+   *                           less than this number, the resulting array will be prefix padded to increase its length
+   *                           to this number.
+   *
+   * @return An {@link UnsignedByteArray} with a length of at least {@code minFinalByteLength}.
+   *
+   * @see "https://github.com/XRPLF/xrpl4j/issues/486"
+   */
+  static UnsignedByteArray toUnsignedByteArray(final BigInteger amount, int minFinalByteLength) {
+    Objects.requireNonNull(amount);
+    Preconditions.checkArgument(amount.signum() >= 0, "amount must not be negative");
+    Preconditions.checkArgument(minFinalByteLength >= 0, "minFinalByteLength must not be negative");
+
+    // Return the `amount` as an UnsignedByteArray, but with the proper zero-byte prefix padding.
+    return withZeroPrefixPadding(amount.toByteArray(), minFinalByteLength);
+  }
+
+  /**
+   * Construct a new {@link UnsignedByteArray} that contains the bytes from {@code bytes}, but with enough `0x00` prefix
+   * padding bytes such that the final length of the returned value is {@code minFinalByteLength}.
+   *
+   * @param bytes              An {@link UnsignedByteArray} to zero-pad.
+   * @param minFinalByteLength The minimum length, in bytes, that the final result must be zero-byte prefix-padded to.
+   *                           If this number is greater-than {@code #length}, then this value will be reduced to
+   *                           {@code #length}.
+   *
+   * @return A copy of this {@link UnsignedByteArray} that has been zero-byte prefix-padded such that its final length
+   *   is at least {@code minFinalByteLength}.
+   */
+  static UnsignedByteArray withZeroPrefixPadding(final UnsignedByteArray bytes, int minFinalByteLength) {
+    Preconditions.checkArgument(minFinalByteLength >= 0, "minFinalByteLength must not be negative");
+
+    return withZeroPrefixPadding(bytes.toByteArray(), minFinalByteLength);
+  }
+
+  /**
+   * Construct a new {@link UnsignedByteArray} that contains the bytes from {@code bytes}, but with enough `0x00` prefix
+   * padding bytes such that the final length of the returned value is {@code minFinalByteLength}.
+   *
+   * @param bytes              A byte array to zero-pad.
+   * @param minFinalByteLength The minimum length, in bytes, that the final result must be zero-byte prefix-padded to.
+   *                           If this number is greater-than {@code #length}, then this value will be reduced to
+   *                           {@code #length}.
+   *
+   * @return A copy of this {@link UnsignedByteArray} that has been zero-byte prefix-padded such that its final length
+   *   is at least {@code minFinalByteLength}.
+   */
+  static UnsignedByteArray withZeroPrefixPadding(final byte[] bytes, int minFinalByteLength) {
+    Preconditions.checkArgument(minFinalByteLength >= 0, "minFinalByteLength must not be negative");
+
+    if (bytes.length > minFinalByteLength) { // <-- Increase `minFinalByteLength` to be at least bytes.length
+      minFinalByteLength = bytes.length;
+    }
+
+    final int numPadBytes = minFinalByteLength - bytes.length; // <-- numPadBytes will never be negative
+    byte[] resultBytes = new byte[minFinalByteLength];
+    System.arraycopy(bytes, 0, resultBytes, numPadBytes, bytes.length);
+    return UnsignedByteArray.of(resultBytes);
+  }
 
 }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/Secp256k1.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/bc/Secp256k1.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.params.ECDomainParameters;
+import org.xrpl.xrpl4j.codec.addresses.UnsignedByte;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
 import org.xrpl.xrpl4j.crypto.keys.bc.BcKeyUtils;
 
@@ -56,6 +57,14 @@ public interface Secp256k1 {
     EC_PARAMETERS.getH()
   );
 
+  /**
+   * Private keys (whether from the ed25519 or secp256k1 curves) have 32 bytes naturally. At the same time, secp256k1
+   * public keys have 33 bytes naturally, whereas ed25519 public keys have 32 bytes naturally. Because of this, in XRPL,
+   * ed25519 public keys are prefixed with a one-byte prefix (i.e., 0xED). For consistency, this library (and other XRPL
+   * tooling) also prepends all private keys with artificial prefixes (0xED for ed25519 or 0x00 for secp256k1).  This
+   * value is the one-byte prefix for secp256k1 keys.
+   */
+  UnsignedByte SECP256K1_PREFIX = UnsignedByte.of(0x00);
 
   /**
    * Creates an {@link UnsignedByteArray} from the bytes of a supplied {@link BigInteger}. If the length of the

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/SignerListSet.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/SignerListSet.java
@@ -37,7 +37,7 @@ import java.util.List;
 @Value.Immutable
 @JsonSerialize(as = ImmutableSignerListSet.class)
 @JsonDeserialize(as = ImmutableSignerListSet.class)
-public interface SignerListSet extends Transaction {
+public interface  SignerListSet extends Transaction {
 
   /**
    * Construct a builder for this class.

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/SignerListSet.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/SignerListSet.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.transactions;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,13 +31,13 @@ import org.xrpl.xrpl4j.model.ledger.SignerEntryWrapper;
 import java.util.List;
 
 /**
- * The SignerListSet transaction creates, replaces, or removes a list of signers that can be used
- * to multi-sign a {@link Transaction}.
+ * The SignerListSet transaction creates, replaces, or removes a list of signers that can be used to multi-sign a
+ * {@link Transaction}.
  */
 @Value.Immutable
 @JsonSerialize(as = ImmutableSignerListSet.class)
 @JsonDeserialize(as = ImmutableSignerListSet.class)
-public interface  SignerListSet extends Transaction {
+public interface SignerListSet extends Transaction {
 
   /**
    * Construct a builder for this class.
@@ -49,8 +49,8 @@ public interface  SignerListSet extends Transaction {
   }
 
   /**
-   * Set of {@link TransactionFlags}s for this {@link SignerListSet}, which only allows the
-   * {@code tfFullyCanonicalSig} flag, which is deprecated.
+   * Set of {@link TransactionFlags}s for this {@link SignerListSet}, which only allows the {@code tfFullyCanonicalSig}
+   * flag, which is deprecated.
    *
    * <p>The value of the flags cannot be set manually, but exists for JSON serialization/deserialization only and for
    * proper signature computation in rippled.
@@ -64,8 +64,8 @@ public interface  SignerListSet extends Transaction {
   }
 
   /**
-   * A target number for the signer weights. A multi-signature from this list is valid only if the sum weights of
-   * the signatures provided is greater than or equal to this value. To delete a signer list, use the value 0.
+   * A target number for the signer weights. A multi-signature from this list is valid only if the sum weights of the
+   * signatures provided is greater than or equal to this value. To delete a signer list, use the value 0.
    *
    * @return An {@link UnsignedInteger} representing the singer quorum.
    */
@@ -73,10 +73,10 @@ public interface  SignerListSet extends Transaction {
   UnsignedInteger signerQuorum();
 
   /**
-   * (Omitted when deleting) Array of {@link org.xrpl.xrpl4j.model.ledger.SignerEntry} objects, indicating the
-   * addresses and weights of signers in this list. This signer list must have at least 1 member and no more
-   * than 8 members. No {@link Address} may appear more than once in the list, nor may the {@link #account()}
-   * submitting the transaction appear in the list.
+   * (Omitted when deleting) Array of {@link org.xrpl.xrpl4j.model.ledger.SignerEntry} objects, indicating the addresses
+   * and weights of signers in this list. This signer list must have at least 1 member and no more than 8 members. No
+   * {@link Address} may appear more than once in the list, nor may the {@link #account()} submitting the transaction
+   * appear in the list.
    *
    * @return A {@link List} of {@link SignerEntryWrapper}s.
    */

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/metadata/AffectedNode.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/metadata/AffectedNode.java
@@ -22,6 +22,7 @@ public interface AffectedNode {
    * @param createdNodeConsumer  A {@link Consumer} that is called if this instance is of type {@link CreatedNode}.
    * @param modifiedNodeConsumer A {@link Consumer} that is called if this instance is of type {@link ModifiedNode}.
    * @param deletedNodeConsumer  A {@link Consumer} that is called if this instance is of type {@link DeletedNode}.
+   * @param <T>                  An instance that extends {@link MetaLedgerObject}.
    */
   default <T extends MetaLedgerObject> void handle(
     final Consumer<CreatedNode<T>> createdNodeConsumer,
@@ -50,7 +51,9 @@ public interface AffectedNode {
    * @param modifiedNodeMapper A {@link Function} that is called if this instance is  of type {@link ModifiedNode}.
    * @param deletedNodeMapper  A {@link Function} that is called if this instance is  of type {@link DeletedNode}.
    * @param <R>                The type of object to return after mapping.
-   * @return A {@link R} that is constructed by the appropriate mapper function.
+   * @param <T>                An instance that extends {@link MetaLedgerObject}.
+   *
+   * @return An {@link R} that is constructed by the appropriate mapper function.
    */
   default <T extends MetaLedgerObject, R> R map(
     final Function<CreatedNode<T>, R> createdNodeMapper,

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodecTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodecTest.java
@@ -23,7 +23,7 @@ class PrivateKeyCodecTest extends AbstractCodecTest {
     testEncodeDecode(
       prefixedNodePrivateKey -> privateKeyCodec.encodeNodePrivateKey(prefixedNodePrivateKey),
       prefixedNodePrivateKey -> privateKeyCodec.decodeNodePrivateKey(prefixedNodePrivateKey),
-      TestConstants.ED_PRIVATE_KEY.valueWithNaturalBytes(),
+      TestConstants.getEdPrivateKey().valueWithNaturalBytes(),
       "paZHnTCvwm4GsxZ7qiA2nUBKE2DLnCoDWYqyocVZfVEZx3kvA4u"
     );
   }
@@ -48,7 +48,7 @@ class PrivateKeyCodecTest extends AbstractCodecTest {
     testEncodeDecode(
       prefixedAccountPrivateKey -> privateKeyCodec.encodeAccountPrivateKey(prefixedAccountPrivateKey),
       prefixedAccountPrivateKey -> privateKeyCodec.decodeAccountPrivateKey(prefixedAccountPrivateKey),
-      TestConstants.ED_PRIVATE_KEY.valueWithNaturalBytes(),
+      TestConstants.getEdPrivateKey().valueWithNaturalBytes(),
       "pwSmRvZy1c55Kb5tCpBZyq41noSmPn7ynFzUHu1MaoGLAP1VfrT"
     );
   }
@@ -73,7 +73,7 @@ class PrivateKeyCodecTest extends AbstractCodecTest {
     testEncodeDecode(
       prefixedNodePrivate -> privateKeyCodec.encodeNodePrivateKey(prefixedNodePrivate),
       prefixedNodePrivate -> privateKeyCodec.decodeNodePrivateKey(prefixedNodePrivate),
-      TestConstants.EC_PRIVATE_KEY.valueWithNaturalBytes(),
+      TestConstants.getEcPrivateKey().valueWithNaturalBytes(),
       "pa1UHARsPMiuDqrJLwFhzcJokoHgyiuaxgPhUGYhkG5ArCfG2vt"
     );
   }
@@ -83,7 +83,7 @@ class PrivateKeyCodecTest extends AbstractCodecTest {
     testEncodeDecode(
       prefixedAccountPrivateKey -> privateKeyCodec.encodeAccountPrivateKey(prefixedAccountPrivateKey),
       prefixedNodePrivateKey -> privateKeyCodec.decodeAccountPrivateKey(prefixedNodePrivateKey),
-      TestConstants.EC_PRIVATE_KEY.valueWithNaturalBytes(),
+      TestConstants.getEcPrivateKey().valueWithNaturalBytes(),
       "pwkgeQKfaDDMV7w59LhhuEWMbpX3HG2iXxXGgZuij2j6z1RYY7n"
     );
   }

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodecTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodecTest.java
@@ -23,7 +23,7 @@ class PrivateKeyCodecTest extends AbstractCodecTest {
     testEncodeDecode(
       prefixedNodePrivateKey -> privateKeyCodec.encodeNodePrivateKey(prefixedNodePrivateKey),
       prefixedNodePrivateKey -> privateKeyCodec.decodeNodePrivateKey(prefixedNodePrivateKey),
-      TestConstants.getEdPrivateKey().valueWithNaturalBytes(),
+      TestConstants.getEdPrivateKey().naturalBytes(),
       "paZHnTCvwm4GsxZ7qiA2nUBKE2DLnCoDWYqyocVZfVEZx3kvA4u"
     );
   }
@@ -38,7 +38,7 @@ class PrivateKeyCodecTest extends AbstractCodecTest {
     testEncodeDecode(
       prefixedNodePrivateKey -> privateKeyCodec.encodeNodePrivateKey(prefixedNodePrivateKey),
       prefixedNodePrivateKey -> privateKeyCodec.decodeNodePrivateKey(prefixedNodePrivateKey),
-      seed.deriveKeyPair().privateKey().valueWithNaturalBytes(),
+      seed.deriveKeyPair().privateKey().naturalBytes(),
       "paKv46LztLqK3GaKz1rG2nQGN6M4JLyRtxFBYFTw4wAVHtGys36"
     );
   }
@@ -48,7 +48,7 @@ class PrivateKeyCodecTest extends AbstractCodecTest {
     testEncodeDecode(
       prefixedAccountPrivateKey -> privateKeyCodec.encodeAccountPrivateKey(prefixedAccountPrivateKey),
       prefixedAccountPrivateKey -> privateKeyCodec.decodeAccountPrivateKey(prefixedAccountPrivateKey),
-      TestConstants.getEdPrivateKey().valueWithNaturalBytes(),
+      TestConstants.getEdPrivateKey().naturalBytes(),
       "pwSmRvZy1c55Kb5tCpBZyq41noSmPn7ynFzUHu1MaoGLAP1VfrT"
     );
   }
@@ -63,7 +63,7 @@ class PrivateKeyCodecTest extends AbstractCodecTest {
     testEncodeDecode(
       prefixedNodePrivateKey -> privateKeyCodec.encodeAccountPrivateKey(prefixedNodePrivateKey),
       prefixedNodePrivateKey -> privateKeyCodec.decodeAccountPrivateKey(prefixedNodePrivateKey),
-      seed.deriveKeyPair().privateKey().valueWithNaturalBytes(),
+      seed.deriveKeyPair().privateKey().naturalBytes(),
       "p9JfM6HHi64m6mvB6v5k7G2b1cXzGmYiCNJf6GHPKvFTWdeRVjh"
     );
   }
@@ -73,7 +73,7 @@ class PrivateKeyCodecTest extends AbstractCodecTest {
     testEncodeDecode(
       prefixedNodePrivate -> privateKeyCodec.encodeNodePrivateKey(prefixedNodePrivate),
       prefixedNodePrivate -> privateKeyCodec.decodeNodePrivateKey(prefixedNodePrivate),
-      TestConstants.getEcPrivateKey().valueWithNaturalBytes(),
+      TestConstants.getEcPrivateKey().naturalBytes(),
       "pa1UHARsPMiuDqrJLwFhzcJokoHgyiuaxgPhUGYhkG5ArCfG2vt"
     );
   }
@@ -83,7 +83,7 @@ class PrivateKeyCodecTest extends AbstractCodecTest {
     testEncodeDecode(
       prefixedAccountPrivateKey -> privateKeyCodec.encodeAccountPrivateKey(prefixedAccountPrivateKey),
       prefixedNodePrivateKey -> privateKeyCodec.decodeAccountPrivateKey(prefixedNodePrivateKey),
-      TestConstants.getEcPrivateKey().valueWithNaturalBytes(),
+      TestConstants.getEcPrivateKey().naturalBytes(),
       "pwkgeQKfaDDMV7w59LhhuEWMbpX3HG2iXxXGgZuij2j6z1RYY7n"
     );
   }

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodecTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/PrivateKeyCodecTest.java
@@ -1,0 +1,90 @@
+package org.xrpl.xrpl4j.codec.addresses;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.crypto.TestConstants;
+import org.xrpl.xrpl4j.crypto.keys.Passphrase;
+import org.xrpl.xrpl4j.crypto.keys.Seed;
+
+/**
+ * Unit tests for {@link PrivateKeyCodec}.
+ */
+class PrivateKeyCodecTest extends AbstractCodecTest {
+
+  private PrivateKeyCodec privateKeyCodec;
+
+  @BeforeEach
+  void setUp() {
+    privateKeyCodec = PrivateKeyCodec.getInstance();
+  }
+
+  @Test
+  public void encodeDecodeEdNodePrivate() {
+    testEncodeDecode(
+      prefixedNodePrivateKey -> privateKeyCodec.encodeNodePrivateKey(prefixedNodePrivateKey),
+      prefixedNodePrivateKey -> privateKeyCodec.decodeNodePrivateKey(prefixedNodePrivateKey),
+      TestConstants.ED_PRIVATE_KEY.valueWithNaturalBytes(),
+      "paZHnTCvwm4GsxZ7qiA2nUBKE2DLnCoDWYqyocVZfVEZx3kvA4u"
+    );
+  }
+
+  /**
+   * These values come from the rippled codebase in Seed_test.cpp.
+   */
+  @Test
+  public void encodeDecodeNodePrivateFromRippled() {
+    Seed seed = Seed.ed25519SeedFromPassphrase(Passphrase.of("masterpassphrase"));
+
+    testEncodeDecode(
+      prefixedNodePrivateKey -> privateKeyCodec.encodeNodePrivateKey(prefixedNodePrivateKey),
+      prefixedNodePrivateKey -> privateKeyCodec.decodeNodePrivateKey(prefixedNodePrivateKey),
+      seed.deriveKeyPair().privateKey().valueWithNaturalBytes(),
+      "paKv46LztLqK3GaKz1rG2nQGN6M4JLyRtxFBYFTw4wAVHtGys36"
+    );
+  }
+
+  @Test
+  public void encodeDecodeEdAccountPrivateKey() {
+    testEncodeDecode(
+      prefixedAccountPrivateKey -> privateKeyCodec.encodeAccountPrivateKey(prefixedAccountPrivateKey),
+      prefixedAccountPrivateKey -> privateKeyCodec.decodeAccountPrivateKey(prefixedAccountPrivateKey),
+      TestConstants.ED_PRIVATE_KEY.valueWithNaturalBytes(),
+      "pwSmRvZy1c55Kb5tCpBZyq41noSmPn7ynFzUHu1MaoGLAP1VfrT"
+    );
+  }
+
+  /**
+   * These values come from the rippled codebase in Seed_test.cpp.
+   */
+  @Test
+  public void encodeDecodeAccountPrivateKeyFromRippled() {
+    Seed seed = Seed.secp256k1SeedFromPassphrase(Passphrase.of("masterpassphrase"));
+
+    testEncodeDecode(
+      prefixedNodePrivateKey -> privateKeyCodec.encodeAccountPrivateKey(prefixedNodePrivateKey),
+      prefixedNodePrivateKey -> privateKeyCodec.decodeAccountPrivateKey(prefixedNodePrivateKey),
+      seed.deriveKeyPair().privateKey().valueWithNaturalBytes(),
+      "p9JfM6HHi64m6mvB6v5k7G2b1cXzGmYiCNJf6GHPKvFTWdeRVjh"
+    );
+  }
+
+  @Test
+  public void encodeDecodeEcNodePrivate() {
+    testEncodeDecode(
+      prefixedNodePrivate -> privateKeyCodec.encodeNodePrivateKey(prefixedNodePrivate),
+      prefixedNodePrivate -> privateKeyCodec.decodeNodePrivateKey(prefixedNodePrivate),
+      TestConstants.EC_PRIVATE_KEY.valueWithNaturalBytes(),
+      "pa1UHARsPMiuDqrJLwFhzcJokoHgyiuaxgPhUGYhkG5ArCfG2vt"
+    );
+  }
+
+  @Test
+  public void encodeDecodeEcAccountPrivateKey() {
+    testEncodeDecode(
+      prefixedAccountPrivateKey -> privateKeyCodec.encodeAccountPrivateKey(prefixedAccountPrivateKey),
+      prefixedNodePrivateKey -> privateKeyCodec.decodeAccountPrivateKey(prefixedNodePrivateKey),
+      TestConstants.EC_PRIVATE_KEY.valueWithNaturalBytes(),
+      "pwkgeQKfaDDMV7w59LhhuEWMbpX3HG2iXxXGgZuij2j6z1RYY7n"
+    );
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArrayTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArrayTest.java
@@ -22,7 +22,6 @@ package org.xrpl.xrpl4j.codec.addresses;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray.of;
 
 import com.google.common.io.BaseEncoding;
 import org.junit.jupiter.api.Test;
@@ -42,14 +41,17 @@ public class UnsignedByteArrayTest {
 
   static byte MAX_BYTE = (byte) 255;
 
-  @Test
-  public void ofByteArray() {
+  /////////
+  // of(byte[])
+  /////////
 
-    assertThat(of(new byte[] {0}).hexValue()).isEqualTo("00");
-    assertThat(of(new byte[] {MAX_BYTE}).hexValue()).isEqualTo("FF");
-    assertThat(of(new byte[] {0, MAX_BYTE}).hexValue()).isEqualTo("00FF");
-    assertThat(of(new byte[] {MAX_BYTE, 0}).hexValue()).isEqualTo("FF00");
-    assertThat(of(new byte[] {MAX_BYTE, MAX_BYTE}).hexValue()).isEqualTo("FFFF");
+  @Test
+  void ofByteArray() {
+    assertThat(UnsignedByteArray.of(new byte[] {0}).hexValue()).isEqualTo("00");
+    assertThat(UnsignedByteArray.of(new byte[] {MAX_BYTE}).hexValue()).isEqualTo("FF");
+    assertThat(UnsignedByteArray.of(new byte[] {0, MAX_BYTE}).hexValue()).isEqualTo("00FF");
+    assertThat(UnsignedByteArray.of(new byte[] {MAX_BYTE, 0}).hexValue()).isEqualTo("FF00");
+    assertThat(UnsignedByteArray.of(new byte[] {MAX_BYTE, MAX_BYTE}).hexValue()).isEqualTo("FFFF");
   }
 
   /////////
@@ -57,7 +59,7 @@ public class UnsignedByteArrayTest {
   /////////
 
   @Test
-  public void fromBigIntegerWithNull() {
+  void fromBigIntegerWithNull() {
     assertThrows(NullPointerException.class, () -> UnsignedByteArray.from(
       null, // <-- The crux of the test
       0
@@ -65,7 +67,7 @@ public class UnsignedByteArrayTest {
   }
 
   @Test
-  public void fromBigIntegerWithNegativeAmount() {
+  void fromBigIntegerWithNegativeAmount() {
     assertThrows(IllegalArgumentException.class, () -> UnsignedByteArray.from(
       BigInteger.valueOf(-1L), // <-- The crux of the test
       0
@@ -73,7 +75,7 @@ public class UnsignedByteArrayTest {
   }
 
   @Test
-  public void fromBigIntegerWithNegativeLength() {
+  void fromBigIntegerWithNegativeLength() {
     assertThrows(IllegalArgumentException.class, () -> UnsignedByteArray.from(
       BigInteger.valueOf(1L),
       -1 // <-- The crux of the test
@@ -81,7 +83,7 @@ public class UnsignedByteArrayTest {
   }
 
   @Test
-  public void fromBigIntegerWithZeroLength() {
+  void fromBigIntegerWithZeroLength() {
     assertThat(UnsignedByteArray.from(
         BigInteger.valueOf(1L),
         0 // <-- The crux of the test
@@ -132,7 +134,7 @@ public class UnsignedByteArrayTest {
       "0DCADB6BD9E78F0ECE39BB26928F8E4B2A5C7F9CF62C15C1C554B5F458F8," + // .toByteArray()
       "0000000DCADB6BD9E78F0ECE39BB26928F8E4B2A5C7F9CF62C15C1C554B5F458F8", // <-- BigInteger Hex, Padded to 33 bytes
   })
-  void testBigIntegerWithZeroPaddingBytes(
+  void fromBigIntegerWithZeroPaddingBytes(
     final String amountString,
     final String amountToString16,
     final String amountToByteArrayHexUnpadded,
@@ -146,7 +148,7 @@ public class UnsignedByteArrayTest {
   }
 
   @Test
-  void testBigIntegerWithNumberGreaterThan33Bytes() {
+  void fromBigIntegerWithNumberGreaterThan33Bytes() {
     final BigInteger amount = new BigInteger(
       "194815934319126504488398097255143744553440248783815166056530734282223472643" +
         "194815934319126504488398097255143744553440248783815166056530734282223472643");
@@ -163,17 +165,40 @@ public class UnsignedByteArrayTest {
         "9DDE6060821AAAAD5003");
   }
 
+  /////////
+  // withPrefixPadding
+  /////////
+
   @Test
-  public void ofUnsignedByteArray() {
-    assertThat(of(UnsignedByte.of(0)).hexValue()).isEqualTo("00");
-    assertThat(of(UnsignedByte.of(MAX_BYTE)).hexValue()).isEqualTo("FF");
-    assertThat(of(UnsignedByte.of(0), UnsignedByte.of((MAX_BYTE))).hexValue()).isEqualTo("00FF");
-    assertThat(of(UnsignedByte.of(MAX_BYTE), UnsignedByte.of((0))).hexValue()).isEqualTo("FF00");
-    assertThat(of(UnsignedByte.of(MAX_BYTE), UnsignedByte.of((MAX_BYTE))).hexValue()).isEqualTo("FFFF");
+  void withPrefixPadding() {
+    final byte[] bytes32 = new byte[32];
+    final UnsignedByteArray uba32 = UnsignedByteArray.of(bytes32);
+    final byte[] bytes33 = new byte[33];
+    final UnsignedByteArray uba33 = UnsignedByteArray.of(bytes33);
+
+    assertThrows(IllegalArgumentException.class, () -> uba32.withPrefixPadding(-1));
+    assertThat(uba32.withPrefixPadding(0)).isEqualTo(uba32);
+    assertThat(uba32.withPrefixPadding(1)).isEqualTo(uba32);
+    assertThat(uba32.withPrefixPadding(32)).isEqualTo(uba32);
+    assertThat(uba32.withPrefixPadding(33)).isEqualTo(uba33);
+  }
+
+  /////////
+  // of(UnsignedByteArray)
+  /////////
+
+  @Test
+  void ofUnsignedByteArray() {
+    assertThat(UnsignedByteArray.of(UnsignedByte.of(0)).hexValue()).isEqualTo("00");
+    assertThat(UnsignedByteArray.of(UnsignedByte.of(MAX_BYTE)).hexValue()).isEqualTo("FF");
+    assertThat(UnsignedByteArray.of(UnsignedByte.of(0), UnsignedByte.of((MAX_BYTE))).hexValue()).isEqualTo("00FF");
+    assertThat(UnsignedByteArray.of(UnsignedByte.of(MAX_BYTE), UnsignedByte.of((0))).hexValue()).isEqualTo("FF00");
+    assertThat(UnsignedByteArray.of(UnsignedByte.of(MAX_BYTE), UnsignedByte.of((MAX_BYTE))).hexValue())
+      .isEqualTo("FFFF");
   }
 
   @Test
-  public void lowerCaseOrUpperCase() {
+  void lowerCaseOrUpperCase() {
     assertThat(UnsignedByteArray.fromHex("Ff").hexValue()).isEqualTo("FF");
     assertThat(UnsignedByteArray.fromHex("00fF").hexValue()).isEqualTo("00FF");
     assertThat(UnsignedByteArray.fromHex("00ff").hexValue()).isEqualTo("00FF");
@@ -185,44 +210,44 @@ public class UnsignedByteArrayTest {
   }
 
   @Test
-  public void empty() {
-    assertThat(UnsignedByteArray.empty()).isEqualTo(of(new byte[] {}));
+  void empty() {
+    assertThat(UnsignedByteArray.empty()).isEqualTo(UnsignedByteArray.of(new byte[] {}));
     assertThat(UnsignedByteArray.empty().length()).isEqualTo(0);
     assertThat(
-      UnsignedByteArray.empty().equals(of(new byte[] {}))
+      UnsignedByteArray.empty().equals(UnsignedByteArray.of(new byte[] {}))
     ).isTrue();
   }
 
   @Test
-  public void length() {
+  void length() {
     final int size = 2;
-    assertThat(of(new byte[] {0, MAX_BYTE}).length()).isEqualTo(size);
-    assertThat(of(new byte[] {0, 1}).length()).isEqualTo(UnsignedByteArray.ofSize(size).length());
+    assertThat(UnsignedByteArray.of(new byte[] {0, MAX_BYTE}).length()).isEqualTo(size);
+    assertThat(UnsignedByteArray.of(new byte[] {0, 1}).length()).isEqualTo(UnsignedByteArray.ofSize(size).length());
     assertThat(UnsignedByteArray.ofSize(size).length()).isEqualTo(size);
   }
 
   @Test
-  public void ofSize() {
+  void ofSize() {
     final int size = 2;
-    assertThat(UnsignedByteArray.ofSize(size)).isEqualTo(of(new byte[] {0, 0}));
+    assertThat(UnsignedByteArray.ofSize(size)).isEqualTo(UnsignedByteArray.of(new byte[] {0, 0}));
     assertThat(UnsignedByteArray.ofSize(size).length()).isEqualTo(size);
-    assertThat(UnsignedByteArray.ofSize(size).length()).isEqualTo(of(new byte[] {0, 0}).length());
-    assertThat(UnsignedByteArray.ofSize(size).equals(of(new byte[] {0, 0}))).isTrue();
+    assertThat(UnsignedByteArray.ofSize(size).length()).isEqualTo(UnsignedByteArray.of(new byte[] {0, 0}).length());
+    assertThat(UnsignedByteArray.ofSize(size).equals(UnsignedByteArray.of(new byte[] {0, 0}))).isTrue();
   }
 
   @Test
-  public void get() {
+  void get() {
     byte[] byteArray = new byte[] {0, 1, 2};
-    UnsignedByteArray array = of(byteArray);
+    UnsignedByteArray array = UnsignedByteArray.of(byteArray);
     assertThat(array.get(0)).isEqualTo(array.getUnsignedBytes().get(0));
     assertThat(array.get(0).asInt()).isEqualTo(byteArray[0]);
     assertThat(array.get(1).asInt()).isEqualTo(byteArray[1]);
   }
 
   @Test
-  public void appendByte() {
-    UnsignedByteArray array1 = of(new byte[] {0, 1});
-    UnsignedByteArray array2 = of(new byte[] {0, 1, 9});
+  void appendByte() {
+    UnsignedByteArray array1 = UnsignedByteArray.of(new byte[] {0, 1});
+    UnsignedByteArray array2 = UnsignedByteArray.of(new byte[] {0, 1, 9});
     int initialLength = array1.length();
     assertThat(array1.append(UnsignedByte.of(9))).isEqualTo(array2);
     assertThat(array1.length() - 1).isEqualTo(initialLength);
@@ -230,17 +255,17 @@ public class UnsignedByteArrayTest {
   }
 
   @Test
-  public void appendByteArray() {
-    UnsignedByteArray array1 = of(new byte[] {0, 1});
-    UnsignedByteArray array2 = of(new byte[] {0, 1, 8, 9});
+  void appendByteArray() {
+    UnsignedByteArray array1 = UnsignedByteArray.of(new byte[] {0, 1});
+    UnsignedByteArray array2 = UnsignedByteArray.of(new byte[] {0, 1, 8, 9});
     int initialLength = array1.length();
-    assertThat(array1.append(of(new byte[] {8, 9}))).isEqualTo(array2);
+    assertThat(array1.append(UnsignedByteArray.of(new byte[] {8, 9}))).isEqualTo(array2);
     assertThat(array1.length()).isEqualTo(initialLength + 2);
     assertThat(array2.length()).isEqualTo(initialLength + 2);
   }
 
   @Test
-  public void fill() {
+  void fill() {
     List<UnsignedByte> unsignedBytes1 = new ArrayList<>();
     List<UnsignedByte> unsignedBytes2 = Arrays.asList(UnsignedByte.of(0), UnsignedByte.of(0));
     List<UnsignedByte> filledBytes = UnsignedByteArray.fill(2);
@@ -251,46 +276,46 @@ public class UnsignedByteArrayTest {
   }
 
   @Test
-  public void set() {
-    UnsignedByteArray array1 = of(new byte[] {0, 1});
-    UnsignedByteArray array2 = of(new byte[] {0, 9});
+  void set() {
+    UnsignedByteArray array1 = UnsignedByteArray.of(new byte[] {0, 1});
+    UnsignedByteArray array2 = UnsignedByteArray.of(new byte[] {0, 9});
     assertThat(array1).isNotEqualTo(array2);
     array1.set(1, UnsignedByte.of(9));
     assertThat(array1).isEqualTo(array2);
   }
 
   @Test
-  public void slice() {
-    UnsignedByteArray array1 = of(new byte[] {0, 8, 9, 1});
-    UnsignedByteArray array2 = of(new byte[] {8, 9});
+  void slice() {
+    UnsignedByteArray array1 = UnsignedByteArray.of(new byte[] {0, 8, 9, 1});
+    UnsignedByteArray array2 = UnsignedByteArray.of(new byte[] {8, 9});
     assertThat(array1).isNotEqualTo(array2);
     assertThat(array1.slice(1, 3)).isEqualTo(array2);
     assertThrows(IndexOutOfBoundsException.class, () -> array1.slice(1, 5));
   }
 
   @Test
-  public void hashcode() {
-    UnsignedByteArray array1 = of(new byte[] {0, 1});
-    assertThat(array1).isNotEqualTo(of(new byte[] {8, 9}));
-    assertThat(array1.hashCode()).isNotEqualTo(of(new byte[] {8, 9}).hashCode());
+  void hashcode() {
+    UnsignedByteArray array1 = UnsignedByteArray.of(new byte[] {0, 1});
+    assertThat(array1).isNotEqualTo(UnsignedByteArray.of(new byte[] {8, 9}));
+    assertThat(array1.hashCode()).isNotEqualTo(UnsignedByteArray.of(new byte[] {8, 9}).hashCode());
     assertThat(array1.hashCode()).isEqualTo(array1.hashCode());
-    assertThat(array1.hashCode()).isEqualTo(of(new byte[] {0, 1}).hashCode());
+    assertThat(array1.hashCode()).isEqualTo(UnsignedByteArray.of(new byte[] {0, 1}).hashCode());
   }
 
   @Test
-  public void unsignedByteArrayToString() {
-    UnsignedByteArray array1 = of(new byte[] {0, 1});
-    UnsignedByteArray array2 = of(new byte[] {8, 9});
+  void unsignedByteArrayToString() {
+    UnsignedByteArray array1 = UnsignedByteArray.of(new byte[] {0, 1});
+    UnsignedByteArray array2 = UnsignedByteArray.of(new byte[] {8, 9});
     assertThat(array1.toString()).isEqualTo(array1.toString());
     assertThat(array1).isNotEqualTo(array2);
     assertThat(array1.toString()).isEqualTo(array2.toString());
   }
 
   @Test
-  public void unsignedByteArrayEqualsTest() {
-    UnsignedByteArray array1 = of(new byte[] {0, MAX_BYTE});
-    UnsignedByteArray array2 = of(new byte[] {MAX_BYTE, 0});
-    UnsignedByteArray array3 = of(new byte[] {0, MAX_BYTE});
+  void unsignedByteArrayEqualsTest() {
+    UnsignedByteArray array1 = UnsignedByteArray.of(new byte[] {0, MAX_BYTE});
+    UnsignedByteArray array2 = UnsignedByteArray.of(new byte[] {MAX_BYTE, 0});
+    UnsignedByteArray array3 = UnsignedByteArray.of(new byte[] {0, MAX_BYTE});
     UnsignedByteArray array4 = array1;
 
     assertThat(array1.equals(array1)).isTrue();
@@ -309,7 +334,7 @@ public class UnsignedByteArrayTest {
 
   @Test
   void destroy() {
-    UnsignedByteArray uba = of(new byte[] {0, MAX_BYTE});
+    UnsignedByteArray uba = UnsignedByteArray.of(new byte[] {0, MAX_BYTE});
     uba.destroy();
     assertThat(uba.isDestroyed()).isTrue();
     assertThat(uba.toByteArray()).isEqualTo(new byte[0]);

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArrayTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArrayTest.java
@@ -23,16 +23,11 @@ package org.xrpl.xrpl4j.codec.addresses;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.google.common.io.BaseEncoding;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * Unit tests for {@link UnsignedByteArray}.
@@ -52,135 +47,6 @@ public class UnsignedByteArrayTest {
     assertThat(UnsignedByteArray.of(new byte[] {0, MAX_BYTE}).hexValue()).isEqualTo("00FF");
     assertThat(UnsignedByteArray.of(new byte[] {MAX_BYTE, 0}).hexValue()).isEqualTo("FF00");
     assertThat(UnsignedByteArray.of(new byte[] {MAX_BYTE, MAX_BYTE}).hexValue()).isEqualTo("FFFF");
-  }
-
-  /////////
-  // from(BigInteger)
-  /////////
-
-  @Test
-  void fromBigIntegerWithNull() {
-    assertThrows(NullPointerException.class, () -> UnsignedByteArray.from(
-      null, // <-- The crux of the test
-      0
-    ));
-  }
-
-  @Test
-  void fromBigIntegerWithNegativeAmount() {
-    assertThrows(IllegalArgumentException.class, () -> UnsignedByteArray.from(
-      BigInteger.valueOf(-1L), // <-- The crux of the test
-      0
-    ));
-  }
-
-  @Test
-  void fromBigIntegerWithNegativeLength() {
-    assertThrows(IllegalArgumentException.class, () -> UnsignedByteArray.from(
-      BigInteger.valueOf(1L),
-      -1 // <-- The crux of the test
-    ));
-  }
-
-  @Test
-  void fromBigIntegerWithZeroLength() {
-    assertThat(UnsignedByteArray.from(
-        BigInteger.valueOf(1L),
-        0 // <-- The crux of the test
-      )
-      .hexValue()).isEqualTo("01");
-  }
-
-  @ParameterizedTest
-  @CsvSource( {
-    // A BigInteger comprised of 33 Bytes; toByteArray has 33 bytes; 0 extra padding added
-    "107371972967791294617431936514364612285184717182742299921102689634201232605691," + // <-- The BigInteger
-      "ED6262116F8D51F1FDD98C184F74CA48DDA7B049CB741F1F7A0564B88FE601FB," + // .toString(16)
-      "00ED6262116F8D51F1FDD98C184F74CA48DDA7B049CB741F1F7A0564B88FE601FB," + // .toByteArray()
-      "00ED6262116F8D51F1FDD98C184F74CA48DDA7B049CB741F1F7A0564B88FE601FB", // <-- Padded to 33 bytes
-    // A BigInteger comprised of 33 Bytes; toByteArray has 33 bytes; 0 extra padding added
-    "84513109120471239583994879976286018548016554258021069224677925571161262209437," + // <-- The BigInteger
-      "BAD8B981A239980B1EC4CB901D698DDE7AA15F264D9537C7D141EE119DD5399D," + // .toString(16)
-      "00BAD8B981A239980B1EC4CB901D698DDE7AA15F264D9537C7D141EE119DD5399D," + // .toByteArray()
-      "00BAD8B981A239980B1EC4CB901D698DDE7AA15F264D9537C7D141EE119DD5399D", // <-- BigInteger Hex, Padded to 33 bytes
-    // A BigInteger comprised of 32 Bytes; toByteArray has 32 bytes; 1 extra padding added
-    "8427551091932113544047724072139537481003293113704693219824523888925672289487," + // <-- The BigInteger
-      "12A1D32B744B18FA0186A44F32D9241869FA0A05B5B831F188831A07163534CF," + // .toString(16)
-      "12A1D32B744B18FA0186A44F32D9241869FA0A05B5B831F188831A07163534CF," + // .toByteArray()
-      "0012A1D32B744B18FA0186A44F32D9241869FA0A05B5B831F188831A07163534CF", // <-- BigInteger Hex, Padded to 33 bytes
-    // A BigInteger comprised of 32 Bytes; toByteArray has 32 bytes; 1 extra padding added
-    "49026876502144691037964633390198098042987098960613207831256521276903508291997," + // <-- The BigInteger
-      "6C643A8EB51D365F3FF5B08C575DEA44B0D3CA5795BDD7B080A7057ABB9A319D," + // .toString(16)
-      "6C643A8EB51D365F3FF5B08C575DEA44B0D3CA5795BDD7B080A7057ABB9A319D," + // .toByteArray()
-      "006C643A8EB51D365F3FF5B08C575DEA44B0D3CA5795BDD7B080A7057ABB9A319D", // <-- BigInteger Hex, Padded to 33 bytes
-    // A BigInteger comprised of 31 Bytes; toByteArray has 31 bytes; 2 extra padding added
-    "125364023161033659590032058970590371956067907570302268576097734468145372487," + // <-- The BigInteger
-      "46F41A0ECE7D0C61B5B36EA377E20621E23C13BD0ABBAEF80754180E9DDD47," + // .toString(16)
-      "46F41A0ECE7D0C61B5B36EA377E20621E23C13BD0ABBAEF80754180E9DDD47," + // .toByteArray()
-      "000046F41A0ECE7D0C61B5B36EA377E20621E23C13BD0ABBAEF80754180E9DDD47", // <-- BigInteger Hex, Padded to 33 bytes
-    // A BigInteger comprised of 31 Bytes; toByteArray has 31 bytes; 2 extra padding added
-    "194815934319126504488398097255143744553440248783815166056530734282223472643," + // <-- The BigInteger
-      "6E430C9E47DFB2194C97385CC85C406DC69773145AE5DE6060821AAAAD5003," + // .toString(16)
-      "6E430C9E47DFB2194C97385CC85C406DC69773145AE5DE6060821AAAAD5003," + // .toByteArray()
-      "00006E430C9E47DFB2194C97385CC85C406DC69773145AE5DE6060821AAAAD5003", // <-- BigInteger Hex, Padded to 33 bytes
-    // A BigInteger comprised of 30 Bytes; toByteArray has 30 bytes; 3 extra padding added
-    "116983811426126878045574354873599490265363256342001470285420476536129339," + // <-- The BigInteger
-      "10F32BB4E0B8B00469196EDACCCAA87A55409FF1C66330D7590449C7073B," + // .toString(16)
-      "10F32BB4E0B8B00469196EDACCCAA87A55409FF1C66330D7590449C7073B," + // .toByteArray()
-      "00000010F32BB4E0B8B00469196EDACCCAA87A55409FF1C66330D7590449C7073B", // <-- BigInteger Hex, Padded to 33 bytes
-    // A BigInteger comprised of 30 Bytes; toByteArray has 30 bytes; 3 extra padding added
-    "95191719494323154714287471792160232496133380576373117355131561137428728," + // <-- The BigInteger
-      "DCADB6BD9E78F0ECE39BB26928F8E4B2A5C7F9CF62C15C1C554B5F458F8," + // .toString(16)
-      "0DCADB6BD9E78F0ECE39BB26928F8E4B2A5C7F9CF62C15C1C554B5F458F8," + // .toByteArray()
-      "0000000DCADB6BD9E78F0ECE39BB26928F8E4B2A5C7F9CF62C15C1C554B5F458F8", // <-- BigInteger Hex, Padded to 33 bytes
-  })
-  void fromBigIntegerWithZeroPaddingBytes(
-    final String amountString,
-    final String amountToString16,
-    final String amountToByteArrayHexUnpadded,
-    final String amountToByteArrayHexPrefixPadded
-  ) {
-    final BigInteger amount = new BigInteger(amountString);
-    // NOTE `amount.toString(16)` strips off all leading 0s, even in a nibble (beware of using this in actual impl code)
-    assertThat(amount.toString(16).toUpperCase(Locale.ENGLISH)).isEqualTo(amountToString16);
-    assertThat(BaseEncoding.base16().encode(amount.toByteArray())).isEqualTo(amountToByteArrayHexUnpadded);
-    assertThat(UnsignedByteArray.from(amount, 33).hexValue()).isEqualTo(amountToByteArrayHexPrefixPadded);
-  }
-
-  @Test
-  void fromBigIntegerWithNumberGreaterThan33Bytes() {
-    final BigInteger amount = new BigInteger(
-      "194815934319126504488398097255143744553440248783815166056530734282223472643" +
-        "194815934319126504488398097255143744553440248783815166056530734282223472643");
-    // NOTE `amount.toString(16)` strips off all leading 0s, even in a nibble (beware of using this in actual impl code)
-    assertThat(amount.toString(16).toUpperCase(Locale.ENGLISH)).isEqualTo(
-      "F3C607BB6CA7C4C335A24D0302484D16956259AC4510289E3E77A87BD72F36D1EED47F97D33F05F1715F603B45E83748DE37C087" +
-        "9DDE6060821AAAAD5003"
-    );
-    assertThat(BaseEncoding.base16().encode(amount.toByteArray())).isEqualTo(
-      "00F3C607BB6CA7C4C335A24D0302484D16956259AC4510289E3E77A87BD72F36D1EED47F97D33F05F1715F603B45E83748DE37C087" +
-        "9DDE6060821AAAAD5003");
-    assertThat(UnsignedByteArray.from(amount, 33).hexValue()).isEqualTo(
-      "00F3C607BB6CA7C4C335A24D0302484D16956259AC4510289E3E77A87BD72F36D1EED47F97D33F05F1715F603B45E83748DE37C087" +
-        "9DDE6060821AAAAD5003");
-  }
-
-  /////////
-  // withPrefixPadding
-  /////////
-
-  @Test
-  void withPrefixPadding() {
-    final byte[] bytes32 = new byte[32];
-    final UnsignedByteArray uba32 = UnsignedByteArray.of(bytes32);
-    final byte[] bytes33 = new byte[33];
-    final UnsignedByteArray uba33 = UnsignedByteArray.of(bytes33);
-
-    assertThrows(IllegalArgumentException.class, () -> uba32.withPrefixPadding(-1));
-    assertThat(uba32.withPrefixPadding(0)).isEqualTo(uba32);
-    assertThat(uba32.withPrefixPadding(1)).isEqualTo(uba32);
-    assertThat(uba32.withPrefixPadding(32)).isEqualTo(uba32);
-    assertThat(uba32.withPrefixPadding(33)).isEqualTo(uba33);
   }
 
   /////////

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArrayTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteArrayTest.java
@@ -24,12 +24,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray.of;
 
-import org.junit.jupiter.api.Assertions;
+import com.google.common.io.BaseEncoding;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Unit tests for {@link UnsignedByteArray}.
@@ -46,6 +50,117 @@ public class UnsignedByteArrayTest {
     assertThat(of(new byte[] {0, MAX_BYTE}).hexValue()).isEqualTo("00FF");
     assertThat(of(new byte[] {MAX_BYTE, 0}).hexValue()).isEqualTo("FF00");
     assertThat(of(new byte[] {MAX_BYTE, MAX_BYTE}).hexValue()).isEqualTo("FFFF");
+  }
+
+  /////////
+  // from(BigInteger)
+  /////////
+
+  @Test
+  public void fromBigIntegerWithNull() {
+    assertThrows(NullPointerException.class, () -> UnsignedByteArray.from(
+      null, // <-- The crux of the test
+      0
+    ));
+  }
+
+  @Test
+  public void fromBigIntegerWithNegativeAmount() {
+    assertThrows(IllegalArgumentException.class, () -> UnsignedByteArray.from(
+      BigInteger.valueOf(-1L), // <-- The crux of the test
+      0
+    ));
+  }
+
+  @Test
+  public void fromBigIntegerWithNegativeLength() {
+    assertThrows(IllegalArgumentException.class, () -> UnsignedByteArray.from(
+      BigInteger.valueOf(1L),
+      -1 // <-- The crux of the test
+    ));
+  }
+
+  @Test
+  public void fromBigIntegerWithZeroLength() {
+    assertThat(UnsignedByteArray.from(
+        BigInteger.valueOf(1L),
+        0 // <-- The crux of the test
+      )
+      .hexValue()).isEqualTo("01");
+  }
+
+  @ParameterizedTest
+  @CsvSource( {
+    // A BigInteger comprised of 33 Bytes; toByteArray has 33 bytes; 0 extra padding added
+    "107371972967791294617431936514364612285184717182742299921102689634201232605691," + // <-- The BigInteger
+      "ED6262116F8D51F1FDD98C184F74CA48DDA7B049CB741F1F7A0564B88FE601FB," + // .toString(16)
+      "00ED6262116F8D51F1FDD98C184F74CA48DDA7B049CB741F1F7A0564B88FE601FB," + // .toByteArray()
+      "00ED6262116F8D51F1FDD98C184F74CA48DDA7B049CB741F1F7A0564B88FE601FB", // <-- Padded to 33 bytes
+    // A BigInteger comprised of 33 Bytes; toByteArray has 33 bytes; 0 extra padding added
+    "84513109120471239583994879976286018548016554258021069224677925571161262209437," + // <-- The BigInteger
+      "BAD8B981A239980B1EC4CB901D698DDE7AA15F264D9537C7D141EE119DD5399D," + // .toString(16)
+      "00BAD8B981A239980B1EC4CB901D698DDE7AA15F264D9537C7D141EE119DD5399D," + // .toByteArray()
+      "00BAD8B981A239980B1EC4CB901D698DDE7AA15F264D9537C7D141EE119DD5399D", // <-- BigInteger Hex, Padded to 33 bytes
+    // A BigInteger comprised of 32 Bytes; toByteArray has 32 bytes; 1 extra padding added
+    "8427551091932113544047724072139537481003293113704693219824523888925672289487," + // <-- The BigInteger
+      "12A1D32B744B18FA0186A44F32D9241869FA0A05B5B831F188831A07163534CF," + // .toString(16)
+      "12A1D32B744B18FA0186A44F32D9241869FA0A05B5B831F188831A07163534CF," + // .toByteArray()
+      "0012A1D32B744B18FA0186A44F32D9241869FA0A05B5B831F188831A07163534CF", // <-- BigInteger Hex, Padded to 33 bytes
+    // A BigInteger comprised of 32 Bytes; toByteArray has 32 bytes; 1 extra padding added
+    "49026876502144691037964633390198098042987098960613207831256521276903508291997," + // <-- The BigInteger
+      "6C643A8EB51D365F3FF5B08C575DEA44B0D3CA5795BDD7B080A7057ABB9A319D," + // .toString(16)
+      "6C643A8EB51D365F3FF5B08C575DEA44B0D3CA5795BDD7B080A7057ABB9A319D," + // .toByteArray()
+      "006C643A8EB51D365F3FF5B08C575DEA44B0D3CA5795BDD7B080A7057ABB9A319D", // <-- BigInteger Hex, Padded to 33 bytes
+    // A BigInteger comprised of 31 Bytes; toByteArray has 31 bytes; 2 extra padding added
+    "125364023161033659590032058970590371956067907570302268576097734468145372487," + // <-- The BigInteger
+      "46F41A0ECE7D0C61B5B36EA377E20621E23C13BD0ABBAEF80754180E9DDD47," + // .toString(16)
+      "46F41A0ECE7D0C61B5B36EA377E20621E23C13BD0ABBAEF80754180E9DDD47," + // .toByteArray()
+      "000046F41A0ECE7D0C61B5B36EA377E20621E23C13BD0ABBAEF80754180E9DDD47", // <-- BigInteger Hex, Padded to 33 bytes
+    // A BigInteger comprised of 31 Bytes; toByteArray has 31 bytes; 2 extra padding added
+    "194815934319126504488398097255143744553440248783815166056530734282223472643," + // <-- The BigInteger
+      "6E430C9E47DFB2194C97385CC85C406DC69773145AE5DE6060821AAAAD5003," + // .toString(16)
+      "6E430C9E47DFB2194C97385CC85C406DC69773145AE5DE6060821AAAAD5003," + // .toByteArray()
+      "00006E430C9E47DFB2194C97385CC85C406DC69773145AE5DE6060821AAAAD5003", // <-- BigInteger Hex, Padded to 33 bytes
+    // A BigInteger comprised of 30 Bytes; toByteArray has 30 bytes; 3 extra padding added
+    "116983811426126878045574354873599490265363256342001470285420476536129339," + // <-- The BigInteger
+      "10F32BB4E0B8B00469196EDACCCAA87A55409FF1C66330D7590449C7073B," + // .toString(16)
+      "10F32BB4E0B8B00469196EDACCCAA87A55409FF1C66330D7590449C7073B," + // .toByteArray()
+      "00000010F32BB4E0B8B00469196EDACCCAA87A55409FF1C66330D7590449C7073B", // <-- BigInteger Hex, Padded to 33 bytes
+    // A BigInteger comprised of 30 Bytes; toByteArray has 30 bytes; 3 extra padding added
+    "95191719494323154714287471792160232496133380576373117355131561137428728," + // <-- The BigInteger
+      "DCADB6BD9E78F0ECE39BB26928F8E4B2A5C7F9CF62C15C1C554B5F458F8," + // .toString(16)
+      "0DCADB6BD9E78F0ECE39BB26928F8E4B2A5C7F9CF62C15C1C554B5F458F8," + // .toByteArray()
+      "0000000DCADB6BD9E78F0ECE39BB26928F8E4B2A5C7F9CF62C15C1C554B5F458F8", // <-- BigInteger Hex, Padded to 33 bytes
+  })
+  void testBigIntegerWithZeroPaddingBytes(
+    final String amountString,
+    final String amountToString16,
+    final String amountToByteArrayHexUnpadded,
+    final String amountToByteArrayHexPrefixPadded
+  ) {
+    final BigInteger amount = new BigInteger(amountString);
+    // NOTE `amount.toString(16)` strips off all leading 0s, even in a nibble (beware of using this in actual impl code)
+    assertThat(amount.toString(16).toUpperCase(Locale.ENGLISH)).isEqualTo(amountToString16);
+    assertThat(BaseEncoding.base16().encode(amount.toByteArray())).isEqualTo(amountToByteArrayHexUnpadded);
+    assertThat(UnsignedByteArray.from(amount, 33).hexValue()).isEqualTo(amountToByteArrayHexPrefixPadded);
+  }
+
+  @Test
+  void testBigIntegerWithNumberGreaterThan33Bytes() {
+    final BigInteger amount = new BigInteger(
+      "194815934319126504488398097255143744553440248783815166056530734282223472643" +
+        "194815934319126504488398097255143744553440248783815166056530734282223472643");
+    // NOTE `amount.toString(16)` strips off all leading 0s, even in a nibble (beware of using this in actual impl code)
+    assertThat(amount.toString(16).toUpperCase(Locale.ENGLISH)).isEqualTo(
+      "F3C607BB6CA7C4C335A24D0302484D16956259AC4510289E3E77A87BD72F36D1EED47F97D33F05F1715F603B45E83748DE37C087" +
+        "9DDE6060821AAAAD5003"
+    );
+    assertThat(BaseEncoding.base16().encode(amount.toByteArray())).isEqualTo(
+      "00F3C607BB6CA7C4C335A24D0302484D16956259AC4510289E3E77A87BD72F36D1EED47F97D33F05F1715F603B45E83748DE37C087" +
+        "9DDE6060821AAAAD5003");
+    assertThat(UnsignedByteArray.from(amount, 33).hexValue()).isEqualTo(
+      "00F3C607BB6CA7C4C335A24D0302484D16956259AC4510289E3E77A87BD72F36D1EED47F97D33F05F1715F603B45E83748DE37C087" +
+        "9DDE6060821AAAAD5003");
   }
 
   @Test

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/addresses/UnsignedByteTest.java
@@ -21,15 +21,27 @@ package org.xrpl.xrpl4j.codec.addresses;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.internal.matchers.Null;
 
 import java.math.BigInteger;
 
+/**
+ * Unit tests for {@link UnsignedByte}.
+ */
 public class UnsignedByteTest {
 
   @Test
-  public void hexValue() {
+  void constructorTests() {
+    assertThrows(IllegalArgumentException.class, () -> UnsignedByte.of(-1));
+    assertThrows(NullPointerException.class, () -> UnsignedByte.of((UnsignedByte) null));
+    assertThat(UnsignedByte.of(UnsignedByte.of(0))).isEqualTo(UnsignedByte.of(0));
+  }
+
+  @Test
+  void hexValue() {
     assertThat(UnsignedByte.of(0).hexValue()).isEqualTo("00");
     assertThat(UnsignedByte.of(127).hexValue()).isEqualTo("7F");
     assertThat(UnsignedByte.of(128).hexValue()).isEqualTo("80");
@@ -38,7 +50,7 @@ public class UnsignedByteTest {
   }
 
   @Test
-  public void isNthBitSetAllZero() {
+  void isNthBitSetAllZero() {
     UnsignedByte value = UnsignedByte.of(0);
     for (int i = 1; i <= 8; i++) {
       assertThat(value.isNthBitSet(i)).isFalse();
@@ -46,7 +58,7 @@ public class UnsignedByteTest {
   }
 
   @Test
-  public void isNthBitSetAllSet() {
+  void isNthBitSetAllSet() {
     UnsignedByte value = UnsignedByte.of(new BigInteger("11111111", 2).intValue());
     for (int i = 1; i <= 8; i++) {
       assertThat(value.isNthBitSet(i)).isTrue();
@@ -54,7 +66,7 @@ public class UnsignedByteTest {
   }
 
   @Test
-  public void isNthBitSetEveryOther() {
+  void isNthBitSetEveryOther() {
     UnsignedByte value = UnsignedByte.of(new BigInteger("10101010", 2).intValue());
     assertThat(value.isNthBitSet(1)).isTrue();
     assertThat(value.isNthBitSet(2)).isFalse();
@@ -67,7 +79,7 @@ public class UnsignedByteTest {
   }
 
   @Test
-  public void intValue() {
+  void intValue() {
     assertThat(UnsignedByte.of(0x00).asInt()).isEqualTo(0);
     assertThat(UnsignedByte.of(0x0F).asInt()).isEqualTo(15);
     assertThat(UnsignedByte.of(0xFF).asInt()).isEqualTo(255);

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/TestConstants.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/TestConstants.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.crypto;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@ package org.xrpl.xrpl4j.crypto;
  */
 
 import com.google.common.io.BaseEncoding;
+import org.xrpl.xrpl4j.codec.addresses.KeyType;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
 import org.xrpl.xrpl4j.crypto.keys.PrivateKey;
 import org.xrpl.xrpl4j.crypto.keys.PublicKey;
@@ -36,18 +37,26 @@ public interface TestConstants {
   String ED_PUBLIC_KEY_B58 = "aKEusmsH9dJvjfeEg8XhDfpEgmhcK1epAtFJfAQbACndz5mUA73B";
   PublicKey ED_PUBLIC_KEY = PublicKey.fromBase16EncodedPublicKey(ED_PUBLIC_KEY_HEX);
 
-  String ED_PRIVATE_KEY_HEX = "EDB224AFDCCEC7AA4E245E35452585D4FBBE37519BCA3929578BFC5BBD4640E163";
-  String ED_PRIVATE_KEY_B58 = "pDcQTi2uFBAzQ7cY2mYQtk9QuQBoLU6rJypEf8EYPQoouh";
-  PrivateKey ED_PRIVATE_KEY = PrivateKey.of(UnsignedByteArray.of(BaseEncoding.base16().decode(ED_PRIVATE_KEY_HEX)));
+  String ED_PRIVATE_KEY_HEX = "B224AFDCCEC7AA4E245E35452585D4FBBE37519BCA3929578BFC5BBD4640E163";
+  String ED_PRIVATE_KEY_WITH_PREFIX_HEX = "ED" + ED_PRIVATE_KEY_HEX;
+  String ED_PRIVATE_KEY_B58 = "UzQrAxCr8oeMRzzm6FFVJao8xkFc3g2ZQBs5GNBWRhZg";
+  PrivateKey ED_PRIVATE_KEY = PrivateKey.fromNaturalBytes(
+    UnsignedByteArray.of(BaseEncoding.base16().decode(ED_PRIVATE_KEY_HEX)),
+    KeyType.ED25519
+  );
 
   // Secp256k1 Public Key
   String EC_PUBLIC_KEY_HEX = "027535A4E90B2189CF9885563F45C4F454B3BFAB21930089C3878A9427B4D648D9";
   String EC_PUBLIC_KEY_B58 = "aB4ifx88a26RYRSSzeKW8HpbXfbpzQFRsX6dMNmMwEVHUTKzfWdk";
   PublicKey EC_PUBLIC_KEY = PublicKey.fromBase16EncodedPublicKey(EC_PUBLIC_KEY_HEX);
 
-  String EC_PRIVATE_KEY_HEX = "00DAD3C2B4BF921398932C889DE5335F89D90249355FC6FFB73F1256D2957F9F17";
-  String EC_PRIVATE_KEY_B58 = "rEjDwJp2Pm3NrUtcf8v17jWopvqPJxyi5RTrDfhcJcWSi";
-  PrivateKey EC_PRIVATE_KEY = PrivateKey.of(UnsignedByteArray.of(BaseEncoding.base16().decode(EC_PRIVATE_KEY_HEX)));
+  String EC_PRIVATE_KEY_HEX = "DAD3C2B4BF921398932C889DE5335F89D90249355FC6FFB73F1256D2957F9F17";
+  String EC_PRIVATE_KEY_WITH_PREFIX_HEX = "00" + EC_PRIVATE_KEY_HEX;
+  String EC_PRIVATE_KEY_WITH_PREFIX_B58 = "rEjDwJp2Pm3NrUtcf8v17jWopvqPJxyi5RTrDfhcJcWSi";
+
+  PrivateKey EC_PRIVATE_KEY = PrivateKey.fromNaturalBytes(
+    UnsignedByteArray.of(BaseEncoding.base16().decode(EC_PRIVATE_KEY_HEX)), KeyType.SECP256K1
+  );
 
   // Both generated from Passphrase.of("hello")
   Address ED_ADDRESS = Address.of("rwGWYtRR6jJJJq7FKQg74YwtkiPyUqJ466");

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/TestConstants.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/TestConstants.java
@@ -40,6 +40,11 @@ public interface TestConstants {
   String ED_PRIVATE_KEY_HEX = "B224AFDCCEC7AA4E245E35452585D4FBBE37519BCA3929578BFC5BBD4640E163";
   String ED_PRIVATE_KEY_WITH_PREFIX_HEX = "ED" + ED_PRIVATE_KEY_HEX;
 
+  /**
+   * Helper method to return a newly constructed {@link PrivateKey} with its own copy of bytes.
+   *
+   * @return A {@link PrivateKey}.
+   */
   static PrivateKey getEdPrivateKey() {
     return PrivateKey.fromNaturalBytes(
       UnsignedByteArray.of(BaseEncoding.base16().decode(ED_PRIVATE_KEY_HEX)),
@@ -55,6 +60,11 @@ public interface TestConstants {
   String EC_PRIVATE_KEY_HEX = "DAD3C2B4BF921398932C889DE5335F89D90249355FC6FFB73F1256D2957F9F17";
   String EC_PRIVATE_KEY_WITH_PREFIX_HEX = "00" + EC_PRIVATE_KEY_HEX;
 
+  /**
+   * Helper method to return a newly constructed {@link PrivateKey} with its own copy of bytes.
+   *
+   * @return A {@link PrivateKey}.
+   */
   static PrivateKey getEcPrivateKey() {
     return PrivateKey.fromNaturalBytes(
       UnsignedByteArray.of(BaseEncoding.base16().decode(EC_PRIVATE_KEY_HEX)), KeyType.SECP256K1

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/TestConstants.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/TestConstants.java
@@ -39,11 +39,13 @@ public interface TestConstants {
 
   String ED_PRIVATE_KEY_HEX = "B224AFDCCEC7AA4E245E35452585D4FBBE37519BCA3929578BFC5BBD4640E163";
   String ED_PRIVATE_KEY_WITH_PREFIX_HEX = "ED" + ED_PRIVATE_KEY_HEX;
-  String ED_PRIVATE_KEY_B58 = "UzQrAxCr8oeMRzzm6FFVJao8xkFc3g2ZQBs5GNBWRhZg";
-  PrivateKey ED_PRIVATE_KEY = PrivateKey.fromNaturalBytes(
-    UnsignedByteArray.of(BaseEncoding.base16().decode(ED_PRIVATE_KEY_HEX)),
-    KeyType.ED25519
-  );
+
+  static PrivateKey getEdPrivateKey() {
+    return PrivateKey.fromNaturalBytes(
+      UnsignedByteArray.of(BaseEncoding.base16().decode(ED_PRIVATE_KEY_HEX)),
+      KeyType.ED25519
+    );
+  }
 
   // Secp256k1 Public Key
   String EC_PUBLIC_KEY_HEX = "027535A4E90B2189CF9885563F45C4F454B3BFAB21930089C3878A9427B4D648D9";
@@ -52,11 +54,12 @@ public interface TestConstants {
 
   String EC_PRIVATE_KEY_HEX = "DAD3C2B4BF921398932C889DE5335F89D90249355FC6FFB73F1256D2957F9F17";
   String EC_PRIVATE_KEY_WITH_PREFIX_HEX = "00" + EC_PRIVATE_KEY_HEX;
-  String EC_PRIVATE_KEY_WITH_PREFIX_B58 = "rEjDwJp2Pm3NrUtcf8v17jWopvqPJxyi5RTrDfhcJcWSi";
 
-  PrivateKey EC_PRIVATE_KEY = PrivateKey.fromNaturalBytes(
-    UnsignedByteArray.of(BaseEncoding.base16().decode(EC_PRIVATE_KEY_HEX)), KeyType.SECP256K1
-  );
+  static PrivateKey getEcPrivateKey() {
+    return PrivateKey.fromNaturalBytes(
+      UnsignedByteArray.of(BaseEncoding.base16().decode(EC_PRIVATE_KEY_HEX)), KeyType.SECP256K1
+    );
+  }
 
   // Both generated from Passphrase.of("hello")
   Address ED_ADDRESS = Address.of("rwGWYtRR6jJJJq7FKQg74YwtkiPyUqJ466");

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
@@ -239,6 +239,36 @@ class PrivateKeyTest {
     assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
   }
 
+  @Test
+  void testEdFromPrefixedBytesWith0Bytes() {
+    IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class, () -> PrivateKey.fromPrefixedBytes(UnsignedByteArray.empty())
+    );
+    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+  }
+
+  @Test
+  void testEcFromPrefixedBytesWithLess0Bytes() {
+    IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class, () -> PrivateKey.fromPrefixedBytes(UnsignedByteArray.empty())
+    );
+    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+  }
+
+  @Test
+  void testFromPrefixedBytesWithInvalidPrefix() {
+    final byte[] invalidPrefixBytes = BaseEncoding.base16().decode(
+      "20000000000000000000000000000000" +
+        "00000000000000000000000000000000");
+    IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class, () -> PrivateKey.fromPrefixedBytes(UnsignedByteArray.of(invalidPrefixBytes))
+    );
+    assertThat(exception.getMessage()).isEqualTo(
+      "Constructing a PrivateKey with raw bytes requires a one-byte prefix in front of the 32 natural bytes of a " +
+        "private key. Use the prefix `0xED` for ed25519 private keys, or `0x00` for secp256k1 private keys."
+    );
+  }
+
   ///////////////////
   // Constants
   ///////////////////

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
@@ -280,9 +280,9 @@ class PrivateKeyTest {
       IllegalArgumentException.class, () -> PrivateKey.fromPrefixedBytes(UnsignedByteArray.of(invalidPrefixBytes))
     );
     assertThat(exception.getMessage()).isEqualTo(
-      "Constructing a PrivateKey with raw bytes requires a one-byte prefix in front of the 32 natural bytes of a " +
-        "private key. Use the prefix `0xED` for ed25519 private keys, or `0x00` for secp256k1 private keys. " +
-        "Length was 33 bytes."
+      "PrivateKey construction requires 32 natural bytes plug a one-byte prefix value of either `0xED` for " +
+        "ed25519 private keys or `0x00` for secp256k1 private keys. Input byte length was 33 bytes with a prefixByte " +
+        "value of `0x20`"
     );
   }
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
@@ -307,20 +307,20 @@ class PrivateKeyTest {
   void valueForEd25519() {
     assertThat(TestConstants.getEdPrivateKey().value().hexValue()) // <-- Overtly test .value()
       .isEqualTo(ED_PRIVATE_KEY_WITH_PREFIX_HEX);
-    assertThat(TestConstants.getEdPrivateKey().valueWithPrefixedBytes().hexValue()).isEqualTo(
+    assertThat(TestConstants.getEdPrivateKey().prefixedBytes().hexValue()).isEqualTo(
       ED_PRIVATE_KEY_WITH_PREFIX_HEX
     );
-    assertThat(TestConstants.getEdPrivateKey().valueWithNaturalBytes().hexValue()).isEqualTo(ED_PRIVATE_KEY_HEX);
+    assertThat(TestConstants.getEdPrivateKey().naturalBytes().hexValue()).isEqualTo(ED_PRIVATE_KEY_HEX);
   }
 
   @Test
   void valueForSecp256k1() {
     assertThat(TestConstants.getEcPrivateKey().value().hexValue()) // <-- Overtly test .value()
       .isEqualTo(EC_PRIVATE_KEY_WITH_PREFIX_HEX);
-    assertThat(TestConstants.getEcPrivateKey().valueWithPrefixedBytes().hexValue()).isEqualTo(
+    assertThat(TestConstants.getEcPrivateKey().prefixedBytes().hexValue()).isEqualTo(
       EC_PRIVATE_KEY_WITH_PREFIX_HEX
     );
-    assertThat(TestConstants.getEcPrivateKey().valueWithNaturalBytes().hexValue()).isEqualTo(EC_PRIVATE_KEY_HEX);
+    assertThat(TestConstants.getEcPrivateKey().naturalBytes().hexValue()).isEqualTo(EC_PRIVATE_KEY_HEX);
   }
 
   ///////////////////
@@ -339,36 +339,36 @@ class PrivateKeyTest {
 
   @Test
   void destroy() {
-    PrivateKey privateKey = PrivateKey.fromPrefixedBytes(TestConstants.getEdPrivateKey().valueWithPrefixedBytes());
+    PrivateKey privateKey = PrivateKey.fromPrefixedBytes(TestConstants.getEdPrivateKey().prefixedBytes());
     assertThat(privateKey.isDestroyed()).isFalse();
     privateKey.destroy();
     assertThat(privateKey.isDestroyed()).isTrue();
-    assertThat(privateKey.valueWithPrefixedBytes().hexValue()).isEqualTo("");
+    assertThat(privateKey.prefixedBytes().hexValue()).isEqualTo("");
     privateKey.destroy();
     assertThat(privateKey.isDestroyed()).isTrue();
     assertThat(privateKey.value().hexValue()).isEqualTo(""); // <-- Overtly test .value()
-    assertThat(privateKey.valueWithNaturalBytes().hexValue()).isEqualTo("");
-    assertThat(privateKey.valueWithPrefixedBytes().hexValue()).isEqualTo("");
+    assertThat(privateKey.naturalBytes().hexValue()).isEqualTo("");
+    assertThat(privateKey.prefixedBytes().hexValue()).isEqualTo("");
 
     assertThat(privateKey.value()).isEqualTo(UnsignedByteArray.empty()); // <-- Overtly test .value()
-    assertThat(privateKey.valueWithNaturalBytes()).isEqualTo(UnsignedByteArray.empty());
-    assertThat(privateKey.valueWithPrefixedBytes()).isEqualTo(UnsignedByteArray.empty());
+    assertThat(privateKey.naturalBytes()).isEqualTo(UnsignedByteArray.empty());
+    assertThat(privateKey.prefixedBytes()).isEqualTo(UnsignedByteArray.empty());
 
-    privateKey = PrivateKey.fromPrefixedBytes(TestConstants.getEcPrivateKey().valueWithPrefixedBytes());
+    privateKey = PrivateKey.fromPrefixedBytes(TestConstants.getEcPrivateKey().prefixedBytes());
     assertThat(privateKey.isDestroyed()).isFalse();
     privateKey.destroy();
     assertThat(privateKey.isDestroyed()).isTrue();
-    assertThat(privateKey.valueWithPrefixedBytes().hexValue()).isEqualTo("");
+    assertThat(privateKey.prefixedBytes().hexValue()).isEqualTo("");
     privateKey.destroy();
     assertThat(privateKey.isDestroyed()).isTrue();
 
     assertThat(privateKey.value().hexValue()).isEqualTo(""); // <-- Overtly test .value()
-    assertThat(privateKey.valueWithNaturalBytes().hexValue()).isEqualTo("");
-    assertThat(privateKey.valueWithPrefixedBytes().hexValue()).isEqualTo("");
+    assertThat(privateKey.naturalBytes().hexValue()).isEqualTo("");
+    assertThat(privateKey.prefixedBytes().hexValue()).isEqualTo("");
 
     assertThat(privateKey.value()).isEqualTo(UnsignedByteArray.empty()); // <-- Overtly test .value()
-    assertThat(privateKey.valueWithNaturalBytes()).isEqualTo(UnsignedByteArray.empty());
-    assertThat(privateKey.valueWithPrefixedBytes()).isEqualTo(UnsignedByteArray.empty());
+    assertThat(privateKey.naturalBytes()).isEqualTo(UnsignedByteArray.empty());
+    assertThat(privateKey.prefixedBytes()).isEqualTo(UnsignedByteArray.empty());
   }
 
   @Test
@@ -378,20 +378,20 @@ class PrivateKeyTest {
 
     assertThat(TestConstants.getEdPrivateKey()).isEqualTo(TestConstants.getEdPrivateKey());
     assertThat(TestConstants.getEdPrivateKey()).isEqualTo(
-      PrivateKey.fromPrefixedBytes(TestConstants.getEdPrivateKey().valueWithPrefixedBytes())
+      PrivateKey.fromPrefixedBytes(TestConstants.getEdPrivateKey().prefixedBytes())
     );
     assertThat(TestConstants.getEdPrivateKey()).isEqualTo(
-      PrivateKey.fromNaturalBytes(TestConstants.getEdPrivateKey().valueWithNaturalBytes(), KeyType.ED25519)
+      PrivateKey.fromNaturalBytes(TestConstants.getEdPrivateKey().naturalBytes(), KeyType.ED25519)
     );
     assertThat(TestConstants.getEdPrivateKey()).isNotEqualTo(TestConstants.getEcPrivateKey());
     assertThat(TestConstants.getEcPrivateKey()).isNotEqualTo(new Object());
 
     assertThat(TestConstants.getEcPrivateKey()).isEqualTo(TestConstants.getEcPrivateKey());
     assertThat(TestConstants.getEcPrivateKey()).isEqualTo(
-      PrivateKey.fromPrefixedBytes(TestConstants.getEcPrivateKey().valueWithPrefixedBytes())
+      PrivateKey.fromPrefixedBytes(TestConstants.getEcPrivateKey().prefixedBytes())
     );
     assertThat(TestConstants.getEcPrivateKey()).isEqualTo(
-      PrivateKey.fromNaturalBytes(TestConstants.getEcPrivateKey().valueWithNaturalBytes(), KeyType.SECP256K1)
+      PrivateKey.fromNaturalBytes(TestConstants.getEcPrivateKey().naturalBytes(), KeyType.SECP256K1)
     );
 
     assertThat(TestConstants.getEcPrivateKey()).isNotEqualTo(TestConstants.getEdPrivateKey());

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.crypto.keys;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,36 +21,123 @@ package org.xrpl.xrpl4j.crypto.keys;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.xrpl.xrpl4j.crypto.TestConstants.EC_PRIVATE_KEY;
+import static org.xrpl.xrpl4j.crypto.TestConstants.EC_PRIVATE_KEY_HEX;
 import static org.xrpl.xrpl4j.crypto.TestConstants.ED_PRIVATE_KEY;
+import static org.xrpl.xrpl4j.crypto.TestConstants.ED_PRIVATE_KEY_HEX;
 
+import com.google.common.io.BaseEncoding;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.codec.addresses.Base58;
 import org.xrpl.xrpl4j.codec.addresses.KeyType;
+import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
 import org.xrpl.xrpl4j.crypto.TestConstants;
 
 /**
  * Unit tests for {@link PrivateKey}.
  */
-public class PrivateKeyTest {
+class PrivateKeyTest {
 
   @Test
-  public void valueEd25519() {
+  void testOfWithNull() {
+    assertThrows(NullPointerException.class, () -> PrivateKey.of(null));
+  }
+
+  private static final String EXPECTED_ERROR =
+    "Constructing a PrivateKey with raw bytes requires a one-byte prefix in front of the 32 natural" +
+      " bytes of a private key. Use the prefix `0xED` for ed25519 private keys, or `0x00` for secp256k1 private " +
+      "keys.";
+
+  @Test
+  void testEcOfWithOnly32Bytes() {
+    UnsignedByteArray thirtyThreeBytes = UnsignedByteArray.of(BaseEncoding.base16().decode(EC_PRIVATE_KEY_HEX));
+    assertThat(PrivateKey.of(thirtyThreeBytes)).isEqualTo(EC_PRIVATE_KEY);
+
+    UnsignedByteArray thirtyTwoBytes = UnsignedByteArray.of(thirtyThreeBytes.slice(1, 33).toByteArray());
+    IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class, () -> PrivateKey.of(thirtyTwoBytes)
+    );
+    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+  }
+
+  @Test
+  void testConstants() {
+    assertThat(PrivateKey.ED2559_PREFIX.asInt()).isEqualTo(0xED);
+    assertThat(PrivateKey.ED2559_PREFIX.asByte()).isEqualTo((byte) 0xED);
+
+    assertThat(PrivateKey.SECP256K1_PREFIX.asInt()).isEqualTo(0x00);
+    assertThat(PrivateKey.SECP256K1_PREFIX.asByte()).isEqualTo((byte) 0x00);
+  }
+
+  @Test
+  void testEdOfWithOnly32Bytes() {
+    UnsignedByteArray thirtyThreeBytes = UnsignedByteArray.of(BaseEncoding.base16().decode(ED_PRIVATE_KEY_HEX));
+    assertThat(PrivateKey.of(thirtyThreeBytes)).isEqualTo(ED_PRIVATE_KEY);
+
+    UnsignedByteArray thirtyTwoBytes = UnsignedByteArray.of(thirtyThreeBytes.slice(1, 33).toByteArray());
+    IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class, () -> PrivateKey.of(thirtyTwoBytes)
+    );
+    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+  }
+
+  @Test
+  void testEdOfWithLessThan32Bytes() {
+    UnsignedByteArray twoBytes = UnsignedByteArray.of(new byte[] {(byte) 0xED, (byte) 0xFF});
+    IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class, () -> PrivateKey.of(twoBytes)
+    );
+    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+  }
+
+  @Test
+  void testEcOfWithLessThan32Bytes() {
+    UnsignedByteArray twoBytes = UnsignedByteArray.of(new byte[] {(byte) 0x00, (byte) 0xFF});
+    IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class, () -> PrivateKey.of(twoBytes)
+    );
+    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+  }
+
+  @Test
+  void valueEd25519() {
     assertThat(Base58.encode(ED_PRIVATE_KEY.value().toByteArray())).isEqualTo(TestConstants.ED_PRIVATE_KEY_B58);
   }
 
   @Test
-  public void valueSecp256k1() {
+  void valueSecp256k1() {
     assertThat(Base58.encode(EC_PRIVATE_KEY.value().toByteArray())).isEqualTo(TestConstants.EC_PRIVATE_KEY_B58);
   }
 
   @Test
-  public void keyTypeEd25519() {
+  void valueWithoutPrefixEd25519() {
+    UnsignedByteArray expectedValueWithoutPrefix = UnsignedByteArray.of(
+      BaseEncoding.base16().decode(ED_PRIVATE_KEY_HEX)).slice(1, 33);
+    assertThat(expectedValueWithoutPrefix.length()).isEqualTo(32);
+
+    assertThat(ED_PRIVATE_KEY.value().slice(1, 33)).isEqualTo(expectedValueWithoutPrefix);
+    assertThat(ED_PRIVATE_KEY.valueWithoutPrefix()).isEqualTo(expectedValueWithoutPrefix);
+  }
+
+  @Test
+  void valueWithoutPrefixSecp256k1() {
+    UnsignedByteArray expectedValueWithoutPrefix = UnsignedByteArray.of(
+      BaseEncoding.base16().decode(EC_PRIVATE_KEY_HEX)).slice(1, 33);
+    assertThat(expectedValueWithoutPrefix.length()).isEqualTo(32);
+
+    assertThat(EC_PRIVATE_KEY.value().slice(1, 33)).isEqualTo(expectedValueWithoutPrefix);
+    assertThat(EC_PRIVATE_KEY.valueWithoutPrefix()).isEqualTo(expectedValueWithoutPrefix);
+  }
+
+
+  @Test
+  void keyTypeEd25519() {
     assertThat(ED_PRIVATE_KEY.keyType()).isEqualTo(KeyType.ED25519);
   }
 
   @Test
-  public void keyTypeSecp256k1() {
+  void keyTypeSecp256k1() {
     assertThat(EC_PRIVATE_KEY.keyType()).isEqualTo(KeyType.SECP256K1);
   }
 
@@ -78,10 +165,12 @@ public class PrivateKeyTest {
   @Test
   void equals() {
     assertThat(ED_PRIVATE_KEY).isEqualTo(ED_PRIVATE_KEY);
+    assertThat(ED_PRIVATE_KEY).isEqualTo(PrivateKey.of(ED_PRIVATE_KEY.value()));
     assertThat(ED_PRIVATE_KEY).isNotEqualTo(EC_PRIVATE_KEY);
     assertThat(EC_PRIVATE_KEY).isNotEqualTo(new Object());
 
     assertThat(EC_PRIVATE_KEY).isEqualTo(EC_PRIVATE_KEY);
+    assertThat(EC_PRIVATE_KEY).isEqualTo(PrivateKey.of(EC_PRIVATE_KEY.value()));
     assertThat(EC_PRIVATE_KEY).isNotEqualTo(ED_PRIVATE_KEY);
     assertThat(EC_PRIVATE_KEY).isNotEqualTo(new Object());
   }

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
@@ -39,11 +39,6 @@ import org.xrpl.xrpl4j.crypto.TestConstants;
 @SuppressWarnings("deprecation")
 class PrivateKeyTest {
 
-  private static final String EXPECTED_ERROR =
-    "Constructing a PrivateKey with raw bytes requires a one-byte prefix in front of the 32 natural" +
-      " bytes of a private key. Use the prefix `0xED` for ed25519 private keys, or `0x00` for secp256k1 private " +
-      "keys.";
-
   ////////////////////
   // of
   ////////////////////
@@ -63,7 +58,9 @@ class PrivateKeyTest {
     IllegalArgumentException exception = assertThrows(
       IllegalArgumentException.class, () -> PrivateKey.of(thirtyTwoBytes)
     );
-    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+    assertThat(exception.getMessage()).isEqualTo(
+      "The `fromPrefixedBytes` function requires input length of 33 bytes, but 32 were supplied."
+    );
   }
 
   @Test
@@ -76,7 +73,9 @@ class PrivateKeyTest {
     IllegalArgumentException exception = assertThrows(
       IllegalArgumentException.class, () -> PrivateKey.of(thirtyTwoBytes)
     );
-    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+    assertThat(exception.getMessage()).isEqualTo(
+      "The `fromPrefixedBytes` function requires input length of 33 bytes, but 32 were supplied."
+    );
   }
 
   @Test
@@ -84,16 +83,19 @@ class PrivateKeyTest {
     IllegalArgumentException exception = assertThrows(
       IllegalArgumentException.class, () -> PrivateKey.of(UnsignedByteArray.empty())
     );
-    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+    assertThat(exception.getMessage())
+      .isEqualTo("The `fromPrefixedBytes` function requires input length of 33 bytes, but 0 were supplied.");
   }
 
   @Test
   void testEdOfWithLessThan32Bytes() {
     UnsignedByteArray twoBytes = UnsignedByteArray.of(new byte[] {(byte) 0xED, (byte) 0xFF});
     IllegalArgumentException exception = assertThrows(
-      IllegalArgumentException.class, () -> PrivateKey.of(UnsignedByteArray.empty())
+      IllegalArgumentException.class, () -> PrivateKey.of(twoBytes)
     );
-    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+    assertThat(exception.getMessage()).isEqualTo(
+      "The `fromPrefixedBytes` function requires input length of 33 bytes, but 2 were supplied."
+    );
   }
 
   @Test
@@ -102,7 +104,9 @@ class PrivateKeyTest {
     IllegalArgumentException exception = assertThrows(
       IllegalArgumentException.class, () -> PrivateKey.of(twoBytes)
     );
-    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+    assertThat(exception.getMessage()).isEqualTo(
+      "The `fromPrefixedBytes` function requires input length of 33 bytes, but 2 were supplied."
+    );
   }
 
   ///////////////////
@@ -204,7 +208,9 @@ class PrivateKeyTest {
     IllegalArgumentException exception = assertThrows(
       IllegalArgumentException.class, () -> PrivateKey.fromPrefixedBytes(thirtyTwoBytes)
     );
-    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+    assertThat(exception.getMessage()).isEqualTo(
+      "The `fromPrefixedBytes` function requires input length of 33 bytes, but 32 were supplied."
+    );
   }
 
   @Test
@@ -218,7 +224,9 @@ class PrivateKeyTest {
     IllegalArgumentException exception = assertThrows(
       IllegalArgumentException.class, () -> PrivateKey.fromPrefixedBytes(thirtyTwoBytes)
     );
-    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+    assertThat(exception.getMessage()).isEqualTo(
+      "The `fromPrefixedBytes` function requires input length of 33 bytes, but 32 were supplied."
+    );
   }
 
   @Test
@@ -227,7 +235,9 @@ class PrivateKeyTest {
     IllegalArgumentException exception = assertThrows(
       IllegalArgumentException.class, () -> PrivateKey.fromPrefixedBytes(twoBytes)
     );
-    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+    assertThat(exception.getMessage()).isEqualTo(
+      "The `fromPrefixedBytes` function requires input length of 33 bytes, but 2 were supplied."
+    );
   }
 
   @Test
@@ -236,7 +246,9 @@ class PrivateKeyTest {
     IllegalArgumentException exception = assertThrows(
       IllegalArgumentException.class, () -> PrivateKey.fromPrefixedBytes(twoBytes)
     );
-    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+    assertThat(exception.getMessage()).isEqualTo(
+      "The `fromPrefixedBytes` function requires input length of 33 bytes, but 2 were supplied."
+    );
   }
 
   @Test
@@ -244,7 +256,9 @@ class PrivateKeyTest {
     IllegalArgumentException exception = assertThrows(
       IllegalArgumentException.class, () -> PrivateKey.fromPrefixedBytes(UnsignedByteArray.empty())
     );
-    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+    assertThat(exception.getMessage()).isEqualTo(
+      "The `fromPrefixedBytes` function requires input length of 33 bytes, but 0 were supplied."
+    );
   }
 
   @Test
@@ -252,7 +266,9 @@ class PrivateKeyTest {
     IllegalArgumentException exception = assertThrows(
       IllegalArgumentException.class, () -> PrivateKey.fromPrefixedBytes(UnsignedByteArray.empty())
     );
-    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+    assertThat(exception.getMessage()).isEqualTo(
+      "The `fromPrefixedBytes` function requires input length of 33 bytes, but 0 were supplied."
+    );
   }
 
   @Test
@@ -265,7 +281,8 @@ class PrivateKeyTest {
     );
     assertThat(exception.getMessage()).isEqualTo(
       "Constructing a PrivateKey with raw bytes requires a one-byte prefix in front of the 32 natural bytes of a " +
-        "private key. Use the prefix `0xED` for ed25519 private keys, or `0x00` for secp256k1 private keys."
+        "private key. Use the prefix `0xED` for ed25519 private keys, or `0x00` for secp256k1 private keys. " +
+        "Length was 33 bytes."
     );
   }
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
@@ -22,10 +22,8 @@ package org.xrpl.xrpl4j.crypto.keys;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.xrpl.xrpl4j.crypto.TestConstants.EC_PRIVATE_KEY;
 import static org.xrpl.xrpl4j.crypto.TestConstants.EC_PRIVATE_KEY_HEX;
 import static org.xrpl.xrpl4j.crypto.TestConstants.EC_PRIVATE_KEY_WITH_PREFIX_HEX;
-import static org.xrpl.xrpl4j.crypto.TestConstants.ED_PRIVATE_KEY;
 import static org.xrpl.xrpl4j.crypto.TestConstants.ED_PRIVATE_KEY_HEX;
 import static org.xrpl.xrpl4j.crypto.TestConstants.ED_PRIVATE_KEY_WITH_PREFIX_HEX;
 
@@ -33,6 +31,7 @@ import com.google.common.io.BaseEncoding;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.codec.addresses.KeyType;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
+import org.xrpl.xrpl4j.crypto.TestConstants;
 
 /**
  * Unit tests for {@link PrivateKey}.
@@ -58,7 +57,7 @@ class PrivateKeyTest {
   void testEcOf() {
     UnsignedByteArray thirtyThreeBytes = UnsignedByteArray.of(
       BaseEncoding.base16().decode(EC_PRIVATE_KEY_WITH_PREFIX_HEX));
-    assertThat(PrivateKey.of(thirtyThreeBytes)).isEqualTo(EC_PRIVATE_KEY);
+    assertThat(PrivateKey.of(thirtyThreeBytes)).isEqualTo(TestConstants.getEcPrivateKey());
 
     UnsignedByteArray thirtyTwoBytes = UnsignedByteArray.of(thirtyThreeBytes.slice(1, 33).toByteArray());
     IllegalArgumentException exception = assertThrows(
@@ -71,7 +70,7 @@ class PrivateKeyTest {
   void testEdOf() {
     UnsignedByteArray thirtyThreeBytes = UnsignedByteArray.of(
       BaseEncoding.base16().decode(ED_PRIVATE_KEY_WITH_PREFIX_HEX));
-    assertThat(PrivateKey.of(thirtyThreeBytes)).isEqualTo(ED_PRIVATE_KEY);
+    assertThat(PrivateKey.of(thirtyThreeBytes)).isEqualTo(TestConstants.getEdPrivateKey());
 
     UnsignedByteArray thirtyTwoBytes = UnsignedByteArray.of(thirtyThreeBytes.slice(1, 33).toByteArray());
     IllegalArgumentException exception = assertThrows(
@@ -81,10 +80,18 @@ class PrivateKeyTest {
   }
 
   @Test
+  void testOfWithLessWithEmpty() {
+    IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class, () -> PrivateKey.of(UnsignedByteArray.empty())
+    );
+    assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
+  }
+
+  @Test
   void testEdOfWithLessThan32Bytes() {
     UnsignedByteArray twoBytes = UnsignedByteArray.of(new byte[] {(byte) 0xED, (byte) 0xFF});
     IllegalArgumentException exception = assertThrows(
-      IllegalArgumentException.class, () -> PrivateKey.of(twoBytes)
+      IllegalArgumentException.class, () -> PrivateKey.of(UnsignedByteArray.empty())
     );
     assertThat(exception.getMessage()).isEqualTo(EXPECTED_ERROR);
   }
@@ -109,9 +116,28 @@ class PrivateKeyTest {
   }
 
   @Test
+  void testEcFromNaturalBytesWithEmpty() {
+    IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class, () -> PrivateKey.fromNaturalBytes(UnsignedByteArray.empty(), KeyType.SECP256K1)
+    );
+    assertThat(exception.getMessage())
+      .isEqualTo("Byte values passed to this constructor must be 32 bytes long, with no prefix.");
+  }
+
+  @Test
+  void testEdFromNaturalBytesWithEmpty() {
+    IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class, () -> PrivateKey.fromNaturalBytes(UnsignedByteArray.empty(), KeyType.ED25519)
+    );
+    assertThat(exception.getMessage())
+      .isEqualTo("Byte values passed to this constructor must be 32 bytes long, with no prefix.");
+  }
+
+  @Test
   void testEcFromNaturalBytes() {
     UnsignedByteArray thirtyThreeBytes = UnsignedByteArray.of(
-      BaseEncoding.base16().decode(EC_PRIVATE_KEY_WITH_PREFIX_HEX));
+      BaseEncoding.base16().decode(EC_PRIVATE_KEY_WITH_PREFIX_HEX)
+    );
     IllegalArgumentException exception = assertThrows(
       IllegalArgumentException.class, () -> PrivateKey.fromNaturalBytes(thirtyThreeBytes, KeyType.SECP256K1)
     );
@@ -119,7 +145,9 @@ class PrivateKeyTest {
       .isEqualTo("Byte values passed to this constructor must be 32 bytes long, with no prefix.");
 
     UnsignedByteArray thirtyTwoBytes = UnsignedByteArray.of(thirtyThreeBytes.slice(1, 33).toByteArray());
-    assertThat(PrivateKey.fromNaturalBytes(thirtyTwoBytes, KeyType.SECP256K1)).isEqualTo(EC_PRIVATE_KEY);
+    assertThat(PrivateKey.fromNaturalBytes(thirtyTwoBytes, KeyType.SECP256K1)).isEqualTo(
+      TestConstants.getEcPrivateKey()
+    );
   }
 
   @Test
@@ -133,7 +161,7 @@ class PrivateKeyTest {
       .isEqualTo("Byte values passed to this constructor must be 32 bytes long, with no prefix.");
 
     UnsignedByteArray thirtyTwoBytes = UnsignedByteArray.of(thirtyThreeBytes.slice(1, 33).toByteArray());
-    assertThat(PrivateKey.fromNaturalBytes(thirtyTwoBytes, KeyType.ED25519)).isEqualTo(ED_PRIVATE_KEY);
+    assertThat(PrivateKey.fromNaturalBytes(thirtyTwoBytes, KeyType.ED25519)).isEqualTo(TestConstants.getEdPrivateKey());
   }
 
   @Test
@@ -170,7 +198,7 @@ class PrivateKeyTest {
     UnsignedByteArray thirtyThreeBytes = UnsignedByteArray.of(
       BaseEncoding.base16().decode(EC_PRIVATE_KEY_WITH_PREFIX_HEX)
     );
-    assertThat(PrivateKey.fromPrefixedBytes(thirtyThreeBytes)).isEqualTo(EC_PRIVATE_KEY);
+    assertThat(PrivateKey.fromPrefixedBytes(thirtyThreeBytes)).isEqualTo(TestConstants.getEcPrivateKey());
 
     UnsignedByteArray thirtyTwoBytes = UnsignedByteArray.of(thirtyThreeBytes.slice(1, 33).toByteArray());
     IllegalArgumentException exception = assertThrows(
@@ -184,7 +212,7 @@ class PrivateKeyTest {
     UnsignedByteArray thirtyThreeBytes = UnsignedByteArray.of(
       BaseEncoding.base16().decode(ED_PRIVATE_KEY_WITH_PREFIX_HEX)
     );
-    assertThat(PrivateKey.fromPrefixedBytes(thirtyThreeBytes)).isEqualTo(ED_PRIVATE_KEY);
+    assertThat(PrivateKey.fromPrefixedBytes(thirtyThreeBytes)).isEqualTo(TestConstants.getEdPrivateKey());
 
     UnsignedByteArray thirtyTwoBytes = UnsignedByteArray.of(thirtyThreeBytes.slice(1, 33).toByteArray());
     IllegalArgumentException exception = assertThrows(
@@ -230,16 +258,18 @@ class PrivateKeyTest {
 
   @Test
   void valueForEd25519() {
-    assertThat(ED_PRIVATE_KEY.value().hexValue()).isEqualTo(ED_PRIVATE_KEY_WITH_PREFIX_HEX);
-    assertThat(ED_PRIVATE_KEY.valueWithPrefixedBytes().hexValue()).isEqualTo(ED_PRIVATE_KEY_WITH_PREFIX_HEX);
-    assertThat(ED_PRIVATE_KEY.valueWithNaturalBytes().hexValue()).isEqualTo(ED_PRIVATE_KEY_HEX);
+    assertThat(TestConstants.getEdPrivateKey().value().hexValue()).isEqualTo(ED_PRIVATE_KEY_WITH_PREFIX_HEX);
+    assertThat(TestConstants.getEdPrivateKey().valueWithPrefixedBytes().hexValue()).isEqualTo(
+      ED_PRIVATE_KEY_WITH_PREFIX_HEX);
+    assertThat(TestConstants.getEdPrivateKey().valueWithNaturalBytes().hexValue()).isEqualTo(ED_PRIVATE_KEY_HEX);
   }
 
   @Test
   void valueForSecp256k1() {
-    assertThat(EC_PRIVATE_KEY.value().hexValue()).isEqualTo(EC_PRIVATE_KEY_WITH_PREFIX_HEX);
-    assertThat(EC_PRIVATE_KEY.valueWithPrefixedBytes().hexValue()).isEqualTo(EC_PRIVATE_KEY_WITH_PREFIX_HEX);
-    assertThat(EC_PRIVATE_KEY.valueWithNaturalBytes().hexValue()).isEqualTo(EC_PRIVATE_KEY_HEX);
+    assertThat(TestConstants.getEcPrivateKey().value().hexValue()).isEqualTo(EC_PRIVATE_KEY_WITH_PREFIX_HEX);
+    assertThat(TestConstants.getEcPrivateKey().valueWithPrefixedBytes().hexValue()).isEqualTo(
+      EC_PRIVATE_KEY_WITH_PREFIX_HEX);
+    assertThat(TestConstants.getEcPrivateKey().valueWithNaturalBytes().hexValue()).isEqualTo(EC_PRIVATE_KEY_HEX);
   }
 
   ///////////////////
@@ -248,17 +278,17 @@ class PrivateKeyTest {
 
   @Test
   void keyTypeEd25519() {
-    assertThat(ED_PRIVATE_KEY.keyType()).isEqualTo(KeyType.ED25519);
+    assertThat(TestConstants.getEdPrivateKey().keyType()).isEqualTo(KeyType.ED25519);
   }
 
   @Test
   void keyTypeSecp256k1() {
-    assertThat(EC_PRIVATE_KEY.keyType()).isEqualTo(KeyType.SECP256K1);
+    assertThat(TestConstants.getEcPrivateKey().keyType()).isEqualTo(KeyType.SECP256K1);
   }
 
   @Test
   void destroy() {
-    PrivateKey privateKey = PrivateKey.of(ED_PRIVATE_KEY.value());
+    PrivateKey privateKey = PrivateKey.of(TestConstants.getEdPrivateKey().value());
     assertThat(privateKey.isDestroyed()).isFalse();
     privateKey.destroy();
     assertThat(privateKey.isDestroyed()).isTrue();
@@ -266,8 +296,11 @@ class PrivateKeyTest {
     privateKey.destroy();
     assertThat(privateKey.isDestroyed()).isTrue();
     assertThat(privateKey.value().hexValue()).isEqualTo("");
+    assertThat(privateKey.valueWithNaturalBytes()).isEqualTo(UnsignedByteArray.empty());
+    assertThat(privateKey.valueWithPrefixedBytes()).isEqualTo(UnsignedByteArray.empty());
+    assertThat(privateKey.value()).isEqualTo(UnsignedByteArray.empty());
 
-    privateKey = PrivateKey.of(EC_PRIVATE_KEY.value());
+    privateKey = PrivateKey.of(TestConstants.getEcPrivateKey().value());
     assertThat(privateKey.isDestroyed()).isFalse();
     privateKey.destroy();
     assertThat(privateKey.isDestroyed()).isTrue();
@@ -275,33 +308,36 @@ class PrivateKeyTest {
     privateKey.destroy();
     assertThat(privateKey.isDestroyed()).isTrue();
     assertThat(privateKey.value().hexValue()).isEqualTo("");
+    assertThat(privateKey.valueWithNaturalBytes()).isEqualTo(UnsignedByteArray.empty());
+    assertThat(privateKey.valueWithPrefixedBytes()).isEqualTo(UnsignedByteArray.empty());
+    assertThat(privateKey.value()).isEqualTo(UnsignedByteArray.empty());
   }
 
   @Test
   void equals() {
-    assertThat(ED_PRIVATE_KEY).isEqualTo(ED_PRIVATE_KEY);
-    assertThat(ED_PRIVATE_KEY).isEqualTo(PrivateKey.of(ED_PRIVATE_KEY.value()));
-    assertThat(ED_PRIVATE_KEY).isNotEqualTo(EC_PRIVATE_KEY);
-    assertThat(EC_PRIVATE_KEY).isNotEqualTo(new Object());
+    assertThat(TestConstants.getEdPrivateKey()).isEqualTo(TestConstants.getEdPrivateKey());
+    assertThat(TestConstants.getEdPrivateKey()).isEqualTo(PrivateKey.of(TestConstants.getEdPrivateKey().value()));
+    assertThat(TestConstants.getEdPrivateKey()).isNotEqualTo(TestConstants.getEcPrivateKey());
+    assertThat(TestConstants.getEcPrivateKey()).isNotEqualTo(new Object());
 
-    assertThat(EC_PRIVATE_KEY).isEqualTo(EC_PRIVATE_KEY);
-    assertThat(EC_PRIVATE_KEY).isEqualTo(PrivateKey.of(EC_PRIVATE_KEY.value()));
-    assertThat(EC_PRIVATE_KEY).isNotEqualTo(ED_PRIVATE_KEY);
-    assertThat(EC_PRIVATE_KEY).isNotEqualTo(new Object());
+    assertThat(TestConstants.getEcPrivateKey()).isEqualTo(TestConstants.getEcPrivateKey());
+    assertThat(TestConstants.getEcPrivateKey()).isEqualTo(PrivateKey.of(TestConstants.getEcPrivateKey().value()));
+    assertThat(TestConstants.getEcPrivateKey()).isNotEqualTo(TestConstants.getEdPrivateKey());
+    assertThat(TestConstants.getEcPrivateKey()).isNotEqualTo(new Object());
   }
 
   @Test
   void testHashcode() {
-    assertThat(ED_PRIVATE_KEY.hashCode()).isEqualTo(ED_PRIVATE_KEY.hashCode());
-    assertThat(ED_PRIVATE_KEY.hashCode()).isNotEqualTo(EC_PRIVATE_KEY.hashCode());
+    assertThat(TestConstants.getEdPrivateKey().hashCode()).isEqualTo(TestConstants.getEdPrivateKey().hashCode());
+    assertThat(TestConstants.getEdPrivateKey().hashCode()).isNotEqualTo(TestConstants.getEcPrivateKey().hashCode());
 
-    assertThat(EC_PRIVATE_KEY.hashCode()).isEqualTo(EC_PRIVATE_KEY.hashCode());
-    assertThat(EC_PRIVATE_KEY.hashCode()).isNotEqualTo(ED_PRIVATE_KEY.hashCode());
+    assertThat(TestConstants.getEcPrivateKey().hashCode()).isEqualTo(TestConstants.getEcPrivateKey().hashCode());
+    assertThat(TestConstants.getEcPrivateKey().hashCode()).isNotEqualTo(TestConstants.getEdPrivateKey().hashCode());
   }
 
   @Test
   void testToString() {
-    assertThat(ED_PRIVATE_KEY.toString()).isEqualTo(
+    assertThat(TestConstants.getEdPrivateKey().toString()).isEqualTo(
       "PrivateKey{" +
         "value=[redacted]," +
         "keyType=ED25519," +
@@ -309,7 +345,7 @@ class PrivateKeyTest {
         "}"
     );
 
-    assertThat(EC_PRIVATE_KEY.toString()).isEqualTo(
+    assertThat(TestConstants.getEcPrivateKey().toString()).isEqualTo(
       "PrivateKey{" +
         "value=[redacted]," +
         "keyType=SECP256K1," +

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
@@ -258,8 +258,8 @@ class PrivateKeyTest {
   @Test
   void testFromPrefixedBytesWithInvalidPrefix() {
     final byte[] invalidPrefixBytes = BaseEncoding.base16().decode(
-      "20000000000000000000000000000000" +
-        "00000000000000000000000000000000");
+      "20000000000000000000000000000000" + // <-- 16 bytes
+        "0000000000000000000000000000000000"); // <-- 17 bytes
     IllegalArgumentException exception = assertThrows(
       IllegalArgumentException.class, () -> PrivateKey.fromPrefixedBytes(UnsignedByteArray.of(invalidPrefixBytes))
     );
@@ -345,6 +345,9 @@ class PrivateKeyTest {
 
   @Test
   void equals() {
+    PrivateKey privateKey = TestConstants.getEdPrivateKey();
+    assertThat(privateKey).isEqualTo(privateKey); // <-- To cover reference equality in .equals
+
     assertThat(TestConstants.getEdPrivateKey()).isEqualTo(TestConstants.getEdPrivateKey());
     assertThat(TestConstants.getEdPrivateKey()).isEqualTo(PrivateKey.of(TestConstants.getEdPrivateKey().value()));
     assertThat(TestConstants.getEdPrivateKey()).isNotEqualTo(TestConstants.getEcPrivateKey());

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PrivateKeyTest.java
@@ -305,17 +305,21 @@ class PrivateKeyTest {
 
   @Test
   void valueForEd25519() {
-    assertThat(TestConstants.getEdPrivateKey().value().hexValue()).isEqualTo(ED_PRIVATE_KEY_WITH_PREFIX_HEX);
+    assertThat(TestConstants.getEdPrivateKey().value().hexValue()) // <-- Overtly test .value()
+      .isEqualTo(ED_PRIVATE_KEY_WITH_PREFIX_HEX);
     assertThat(TestConstants.getEdPrivateKey().valueWithPrefixedBytes().hexValue()).isEqualTo(
-      ED_PRIVATE_KEY_WITH_PREFIX_HEX);
+      ED_PRIVATE_KEY_WITH_PREFIX_HEX
+    );
     assertThat(TestConstants.getEdPrivateKey().valueWithNaturalBytes().hexValue()).isEqualTo(ED_PRIVATE_KEY_HEX);
   }
 
   @Test
   void valueForSecp256k1() {
-    assertThat(TestConstants.getEcPrivateKey().value().hexValue()).isEqualTo(EC_PRIVATE_KEY_WITH_PREFIX_HEX);
+    assertThat(TestConstants.getEcPrivateKey().value().hexValue()) // <-- Overtly test .value()
+      .isEqualTo(EC_PRIVATE_KEY_WITH_PREFIX_HEX);
     assertThat(TestConstants.getEcPrivateKey().valueWithPrefixedBytes().hexValue()).isEqualTo(
-      EC_PRIVATE_KEY_WITH_PREFIX_HEX);
+      EC_PRIVATE_KEY_WITH_PREFIX_HEX
+    );
     assertThat(TestConstants.getEcPrivateKey().valueWithNaturalBytes().hexValue()).isEqualTo(EC_PRIVATE_KEY_HEX);
   }
 
@@ -335,29 +339,36 @@ class PrivateKeyTest {
 
   @Test
   void destroy() {
-    PrivateKey privateKey = PrivateKey.of(TestConstants.getEdPrivateKey().value());
+    PrivateKey privateKey = PrivateKey.fromPrefixedBytes(TestConstants.getEdPrivateKey().valueWithPrefixedBytes());
     assertThat(privateKey.isDestroyed()).isFalse();
     privateKey.destroy();
     assertThat(privateKey.isDestroyed()).isTrue();
-    assertThat(privateKey.value().hexValue()).isEqualTo("");
+    assertThat(privateKey.valueWithPrefixedBytes().hexValue()).isEqualTo("");
     privateKey.destroy();
     assertThat(privateKey.isDestroyed()).isTrue();
-    assertThat(privateKey.value().hexValue()).isEqualTo("");
-    assertThat(privateKey.valueWithNaturalBytes()).isEqualTo(UnsignedByteArray.empty());
-    assertThat(privateKey.valueWithPrefixedBytes()).isEqualTo(UnsignedByteArray.empty());
-    assertThat(privateKey.value()).isEqualTo(UnsignedByteArray.empty());
+    assertThat(privateKey.value().hexValue()).isEqualTo(""); // <-- Overtly test .value()
+    assertThat(privateKey.valueWithNaturalBytes().hexValue()).isEqualTo("");
+    assertThat(privateKey.valueWithPrefixedBytes().hexValue()).isEqualTo("");
 
-    privateKey = PrivateKey.of(TestConstants.getEcPrivateKey().value());
+    assertThat(privateKey.value()).isEqualTo(UnsignedByteArray.empty()); // <-- Overtly test .value()
+    assertThat(privateKey.valueWithNaturalBytes()).isEqualTo(UnsignedByteArray.empty());
+    assertThat(privateKey.valueWithPrefixedBytes()).isEqualTo(UnsignedByteArray.empty());
+
+    privateKey = PrivateKey.fromPrefixedBytes(TestConstants.getEcPrivateKey().valueWithPrefixedBytes());
     assertThat(privateKey.isDestroyed()).isFalse();
     privateKey.destroy();
     assertThat(privateKey.isDestroyed()).isTrue();
-    assertThat(privateKey.value().hexValue()).isEqualTo("");
+    assertThat(privateKey.valueWithPrefixedBytes().hexValue()).isEqualTo("");
     privateKey.destroy();
     assertThat(privateKey.isDestroyed()).isTrue();
-    assertThat(privateKey.value().hexValue()).isEqualTo("");
+
+    assertThat(privateKey.value().hexValue()).isEqualTo(""); // <-- Overtly test .value()
+    assertThat(privateKey.valueWithNaturalBytes().hexValue()).isEqualTo("");
+    assertThat(privateKey.valueWithPrefixedBytes().hexValue()).isEqualTo("");
+
+    assertThat(privateKey.value()).isEqualTo(UnsignedByteArray.empty()); // <-- Overtly test .value()
     assertThat(privateKey.valueWithNaturalBytes()).isEqualTo(UnsignedByteArray.empty());
     assertThat(privateKey.valueWithPrefixedBytes()).isEqualTo(UnsignedByteArray.empty());
-    assertThat(privateKey.value()).isEqualTo(UnsignedByteArray.empty());
   }
 
   @Test
@@ -366,12 +377,23 @@ class PrivateKeyTest {
     assertThat(privateKey).isEqualTo(privateKey); // <-- To cover reference equality in .equals
 
     assertThat(TestConstants.getEdPrivateKey()).isEqualTo(TestConstants.getEdPrivateKey());
-    assertThat(TestConstants.getEdPrivateKey()).isEqualTo(PrivateKey.of(TestConstants.getEdPrivateKey().value()));
+    assertThat(TestConstants.getEdPrivateKey()).isEqualTo(
+      PrivateKey.fromPrefixedBytes(TestConstants.getEdPrivateKey().valueWithPrefixedBytes())
+    );
+    assertThat(TestConstants.getEdPrivateKey()).isEqualTo(
+      PrivateKey.fromNaturalBytes(TestConstants.getEdPrivateKey().valueWithNaturalBytes(), KeyType.ED25519)
+    );
     assertThat(TestConstants.getEdPrivateKey()).isNotEqualTo(TestConstants.getEcPrivateKey());
     assertThat(TestConstants.getEcPrivateKey()).isNotEqualTo(new Object());
 
     assertThat(TestConstants.getEcPrivateKey()).isEqualTo(TestConstants.getEcPrivateKey());
-    assertThat(TestConstants.getEcPrivateKey()).isEqualTo(PrivateKey.of(TestConstants.getEcPrivateKey().value()));
+    assertThat(TestConstants.getEcPrivateKey()).isEqualTo(
+      PrivateKey.fromPrefixedBytes(TestConstants.getEcPrivateKey().valueWithPrefixedBytes())
+    );
+    assertThat(TestConstants.getEcPrivateKey()).isEqualTo(
+      PrivateKey.fromNaturalBytes(TestConstants.getEcPrivateKey().valueWithNaturalBytes(), KeyType.SECP256K1)
+    );
+
     assertThat(TestConstants.getEcPrivateKey()).isNotEqualTo(TestConstants.getEdPrivateKey());
     assertThat(TestConstants.getEcPrivateKey()).isNotEqualTo(new Object());
   }

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PublicKeyTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PublicKeyTest.java
@@ -222,4 +222,14 @@ public class PublicKeyTest {
     assertThat(ED_PUBLIC_KEY.deriveAddress().value()).isEqualTo("rwGWYtRR6jJJJq7FKQg74YwtkiPyUqJ466");
     assertThat(EC_PUBLIC_KEY.deriveAddress().value()).isEqualTo("rD8ATvjj9mfnFuYYTGRNb9DygnJW9JNN1C");
   }
+
+  ///////////////////
+  // Constants
+  ///////////////////
+
+  @Test
+  void testConstants() {
+    assertThat(PublicKey.ED2559_PREFIX.asInt()).isEqualTo(0xED);
+    assertThat(PublicKey.ED2559_PREFIX.asByte()).isEqualTo((byte) 0xED);
+  }
 }

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PublicKeyTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/PublicKeyTest.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.crypto.keys;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@ package org.xrpl.xrpl4j.crypto.keys;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.xrpl.xrpl4j.crypto.TestConstants.EC_PUBLIC_KEY;
 import static org.xrpl.xrpl4j.crypto.TestConstants.EC_PUBLIC_KEY_B58;
 import static org.xrpl.xrpl4j.crypto.TestConstants.EC_PUBLIC_KEY_HEX;
@@ -32,6 +33,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.codec.addresses.KeyType;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
+import org.xrpl.xrpl4j.codec.addresses.exceptions.EncodeException;
 import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
 import org.xrpl.xrpl4j.model.transactions.Address;
 
@@ -39,6 +41,15 @@ import org.xrpl.xrpl4j.model.transactions.Address;
  * Unit tests for {@link PublicKey}.
  */
 public class PublicKeyTest {
+
+  @Test
+  public void fromBase58EncodedStringEd25519WithTooFewBytes() {
+    UnsignedByteArray twoBytes = UnsignedByteArray.of(new byte[] {(byte) 0xED, (byte) 0xFF});
+    EncodeException exception = assertThrows(
+      EncodeException.class, () -> PublicKey.fromBase16EncodedPublicKey(twoBytes.hexValue())
+    );
+    assertThat(exception.getMessage()).isEqualTo("Length of bytes does not match expectedLength of 33.");
+  }
 
   @Test
   public void fromBase58EncodedStringEd25519() {
@@ -196,7 +207,7 @@ public class PublicKeyTest {
     PublicKey actual = ObjectMapperFactory.create().readValue(json, PublicKey.class);
     assertThat(actual.base16Value()).isEqualTo("");
   }
-  
+
   @Test
   void jsonSerializeAndDeserializeEc() throws JsonProcessingException {
     String json = ObjectMapperFactory.create().writeValueAsString(EC_PUBLIC_KEY);

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/SeedTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/SeedTest.java
@@ -174,9 +174,9 @@ public class SeedTest {
     final PrivateKey privateKey = ecSeedFor32BytePrivateKey.deriveKeyPair().privateKey();
     assertThat(privateKey.value().hexValue()) // <- Overtly test .value()
       .isEqualTo("007030CBD40D6961E625AD73159A4B463AA42B4E88CC2248AC49E1EDCB50AF2924");
-    assertThat(privateKey.valueWithPrefixedBytes().hexValue())
+    assertThat(privateKey.prefixedBytes().hexValue())
       .isEqualTo("007030CBD40D6961E625AD73159A4B463AA42B4E88CC2248AC49E1EDCB50AF2924");
-    assertThat(privateKey.valueWithNaturalBytes().hexValue())
+    assertThat(privateKey.naturalBytes().hexValue())
       .isEqualTo("7030CBD40D6961E625AD73159A4B463AA42B4E88CC2248AC49E1EDCB50AF2924");
   }
 
@@ -197,9 +197,9 @@ public class SeedTest {
     final PrivateKey privateKey = ecSeedFor32BytePrivateKey.deriveKeyPair().privateKey();
     assertThat(privateKey.value().hexValue()) // <- Overtly test .value()
       .isEqualTo("00FBD60C9C99BA3D4706A449C30E4D61DCC3811E23EF69291F98A886CEC6A8B0B5");
-    assertThat(privateKey.valueWithPrefixedBytes().hexValue())
+    assertThat(privateKey.prefixedBytes().hexValue())
       .isEqualTo("00FBD60C9C99BA3D4706A449C30E4D61DCC3811E23EF69291F98A886CEC6A8B0B5");
-    assertThat(privateKey.valueWithNaturalBytes().hexValue())
+    assertThat(privateKey.naturalBytes().hexValue())
       .isEqualTo("FBD60C9C99BA3D4706A449C30E4D61DCC3811E23EF69291F98A886CEC6A8B0B5");
   }
 
@@ -216,9 +216,9 @@ public class SeedTest {
 
     assertThat(BaseEncoding.base16().decode("53AC3F62A5A6E598C7D1E31AB92587C56823A1BE5C21E53ABE9D9A722E5236").length)
       .isEqualTo(31);
-    assertThat(ecSeedFor31BytePrivateKey.deriveKeyPair().privateKey().valueWithNaturalBytes().toByteArray().length)
+    assertThat(ecSeedFor31BytePrivateKey.deriveKeyPair().privateKey().naturalBytes().toByteArray().length)
       .isEqualTo(32);
-    assertThat(ecSeedFor31BytePrivateKey.deriveKeyPair().privateKey().valueWithPrefixedBytes().toByteArray().length)
+    assertThat(ecSeedFor31BytePrivateKey.deriveKeyPair().privateKey().prefixedBytes().toByteArray().length)
       .isEqualTo(33);
 
     // Assert that all BigIntegers are equivalent (i.e., that the constructor ignores zero-byte pads)
@@ -226,10 +226,10 @@ public class SeedTest {
       BaseEncoding.base16().decode("53AC3F62A5A6E598C7D1E31AB92587C56823A1BE5C21E53ABE9D9A722E5236")
     );
     BigInteger unPaddedBitInt = new BigInteger(
-      ecSeedFor31BytePrivateKey.deriveKeyPair().privateKey().valueWithNaturalBytes().toByteArray()
+      ecSeedFor31BytePrivateKey.deriveKeyPair().privateKey().naturalBytes().toByteArray()
     );
     BigInteger paddedBitInt = new BigInteger(
-      ecSeedFor31BytePrivateKey.deriveKeyPair().privateKey().valueWithPrefixedBytes().toByteArray()
+      ecSeedFor31BytePrivateKey.deriveKeyPair().privateKey().prefixedBytes().toByteArray()
     );
 
     assertThat(shortBigInt).isEqualTo(unPaddedBitInt);
@@ -251,9 +251,9 @@ public class SeedTest {
     final PrivateKey privateKey = ecSeedFor31BytePrivateKey.deriveKeyPair().privateKey();
     assertThat(privateKey.value().hexValue()) // <- Overtly test .value()
       .isEqualTo("000053AC3F62A5A6E598C7D1E31AB92587C56823A1BE5C21E53ABE9D9A722E5236");
-    assertThat(privateKey.valueWithPrefixedBytes().hexValue())
+    assertThat(privateKey.prefixedBytes().hexValue())
       .isEqualTo("000053AC3F62A5A6E598C7D1E31AB92587C56823A1BE5C21E53ABE9D9A722E5236");
-    assertThat(privateKey.valueWithNaturalBytes().hexValue())
+    assertThat(privateKey.naturalBytes().hexValue())
       .isEqualTo("0053AC3F62A5A6E598C7D1E31AB92587C56823A1BE5C21E53ABE9D9A722E5236");
   }
 
@@ -357,7 +357,7 @@ public class SeedTest {
     assertThat(seed.deriveKeyPair().publicKey().base16Value()).isEqualTo(
       "02FD0E8479CE8182ABD35157BB0FA17A469AF27DCB12B5DDED697C61809116A33B"
     );
-    assertThat(seed.deriveKeyPair().privateKey().valueWithPrefixedBytes().hexValue()).isEqualTo(
+    assertThat(seed.deriveKeyPair().privateKey().prefixedBytes().hexValue()).isEqualTo(
       "0027690792130FC12883E83AE85946B018B3BEDE6EEDCDA3452787A94FC0A17438"
     );
     assertThat(seed.deriveKeyPair().publicKey().deriveAddress().value()).isEqualTo(

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/SeedTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/SeedTest.java
@@ -171,7 +171,7 @@ public class SeedTest {
       Entropy.of(BaseEncoding.base16().decode("B7E99C6BB9786494238D2BA84EABE854"))
     );
     final PrivateKey privateKey = ecSeedFor32BytePrivateKey.deriveKeyPair().privateKey();
-    assertThat(privateKey.value().hexValue())
+    assertThat(privateKey.value().hexValue()) // <- Overtly test .value()
       .isEqualTo("007030CBD40D6961E625AD73159A4B463AA42B4E88CC2248AC49E1EDCB50AF2924");
     assertThat(privateKey.valueWithPrefixedBytes().hexValue())
       .isEqualTo("007030CBD40D6961E625AD73159A4B463AA42B4E88CC2248AC49E1EDCB50AF2924");
@@ -194,7 +194,7 @@ public class SeedTest {
       Entropy.of(BaseEncoding.base16().decode("358C75D5AD5E2FF5E19256978F18F0B9"))
     );
     final PrivateKey privateKey = ecSeedFor32BytePrivateKey.deriveKeyPair().privateKey();
-    assertThat(privateKey.value().hexValue())
+    assertThat(privateKey.value().hexValue()) // <- Overtly test .value()
       .isEqualTo("00FBD60C9C99BA3D4706A449C30E4D61DCC3811E23EF69291F98A886CEC6A8B0B5");
     assertThat(privateKey.valueWithPrefixedBytes().hexValue())
       .isEqualTo("00FBD60C9C99BA3D4706A449C30E4D61DCC3811E23EF69291F98A886CEC6A8B0B5");
@@ -239,7 +239,7 @@ public class SeedTest {
     KeyPair keyPair = Seed.DefaultSeed.Ed25519KeyPairService.deriveKeyPair(seed);
 
     KeyPair expectedKeyPair = KeyPair.builder()
-      .privateKey(PrivateKey.of(UnsignedByteArray.of(
+      .privateKey(PrivateKey.fromPrefixedBytes(UnsignedByteArray.of(
         BaseEncoding.base16().decode("ED2F1185B6F5525D7A7D2A22C1D8BAEEBEEFFE597C9010AF916EBB9447BECC5BE6"
         ))))
       .publicKey(
@@ -271,7 +271,7 @@ public class SeedTest {
     Seed seed = Seed.fromBase58EncodedSecret(Base58EncodedSecret.of("sp5fghtJtpUorTwvof1NpDXAzNwf5"));
     KeyPair keyPair = Seed.DefaultSeed.Secp256k1KeyPairService.deriveKeyPair(seed);
     KeyPair expectedKeyPair = KeyPair.builder()
-      .privateKey(PrivateKey.of(UnsignedByteArray.of(
+      .privateKey(PrivateKey.fromPrefixedBytes(UnsignedByteArray.of(
         BaseEncoding.base16().decode("00D78B9735C3F26501C7337B8A5727FD53A6EFDBC6AA55984F098488561F985E23"
         ))))
       .publicKey(
@@ -288,8 +288,9 @@ public class SeedTest {
     Seed seed = Seed.ed25519SeedFromEntropy(entropy);
     assertThat(seed.deriveKeyPair().publicKey()).isEqualTo(
       PublicKey.fromBase16EncodedPublicKey("ED01FA53FA5A7E77798F882ECE20B1ABC00BB358A9E55A202D0D0676BD0CE37A63"));
-    assertThat(seed.deriveKeyPair().privateKey()).isEqualTo(
-      PrivateKey.of(UnsignedByteArray.fromHex("EDB4C4E046826BD26190D09715FC31F4E6A728204EADD112905B08B14B7F15C4F3")));
+    assertThat(seed.deriveKeyPair().privateKey()).isEqualTo(PrivateKey.fromPrefixedBytes(
+      UnsignedByteArray.fromHex("EDB4C4E046826BD26190D09715FC31F4E6A728204EADD112905B08B14B7F15C4F3")
+    ));
     assertThat(seed.deriveKeyPair().publicKey().deriveAddress().value()).isEqualTo(
       "rLUEXYuLiQptky37CqLcm9USQpPiz5rkpD");
   }
@@ -299,10 +300,13 @@ public class SeedTest {
     Entropy entropy = Entropy.of(BaseEncoding.base16().decode("CC4E55BC556DD561CBE990E3D4EF7069"));
     Seed seed = Seed.secp256k1SeedFromEntropy(entropy);
     assertThat(seed.deriveKeyPair().publicKey().base16Value()).isEqualTo(
-      "02FD0E8479CE8182ABD35157BB0FA17A469AF27DCB12B5DDED697C61809116A33B");
-    assertThat(seed.deriveKeyPair().privateKey().value().hexValue()).isEqualTo(
-      "0027690792130FC12883E83AE85946B018B3BEDE6EEDCDA3452787A94FC0A17438");
+      "02FD0E8479CE8182ABD35157BB0FA17A469AF27DCB12B5DDED697C61809116A33B"
+    );
+    assertThat(seed.deriveKeyPair().privateKey().valueWithPrefixedBytes().hexValue()).isEqualTo(
+      "0027690792130FC12883E83AE85946B018B3BEDE6EEDCDA3452787A94FC0A17438"
+    );
     assertThat(seed.deriveKeyPair().publicKey().deriveAddress().value()).isEqualTo(
-      "rByLcEZ7iwTBAK8FfjtpFuT7fCzt4kF4r2");
+      "rByLcEZ7iwTBAK8FfjtpFuT7fCzt4kF4r2"
+    );
   }
 }

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/SeedTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/SeedTest.java
@@ -226,10 +226,10 @@ public class SeedTest {
       BaseEncoding.base16().decode("53AC3F62A5A6E598C7D1E31AB92587C56823A1BE5C21E53ABE9D9A722E5236")
     );
     BigInteger unPaddedBitInt = new BigInteger(
-      ecSeedFor31BytePrivateKey.deriveKeyPair().privateKey().naturalBytes().toByteArray()
+      1, ecSeedFor31BytePrivateKey.deriveKeyPair().privateKey().naturalBytes().toByteArray()
     );
     BigInteger paddedBitInt = new BigInteger(
-      ecSeedFor31BytePrivateKey.deriveKeyPair().privateKey().prefixedBytes().toByteArray()
+      1, ecSeedFor31BytePrivateKey.deriveKeyPair().privateKey().prefixedBytes().toByteArray()
     );
 
     assertThat(shortBigInt).isEqualTo(unPaddedBitInt);

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/SeedTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/SeedTest.java
@@ -32,7 +32,6 @@ import org.xrpl.xrpl4j.codec.addresses.exceptions.DecodeException;
 import org.xrpl.xrpl4j.crypto.keys.Seed.DefaultSeed;
 
 import java.math.BigInteger;
-
 import javax.security.auth.DestroyFailedException;
 
 /**

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtilsTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtilsTest.java
@@ -56,9 +56,9 @@ class BcKeyUtilsTest {
 
     // To PrivateKey
     PrivateKey privateKey = BcKeyUtils.toPrivateKey(ed25519PrivateKeyParameters);
-    assertThat(Base58.encode(privateKey.valueWithPrefixedBytes().toByteArray()))
+    assertThat(Base58.encode(privateKey.prefixedBytes().toByteArray()))
       .isEqualTo("pDcQTi2uFBAzQ7cY2mYQtk9QuQBoLU6rJypEf8EYPQoouh");
-    assertThat(BaseEncoding.base16().encode(privateKey.valueWithPrefixedBytes().toByteArray()))
+    assertThat(BaseEncoding.base16().encode(privateKey.prefixedBytes().toByteArray()))
       .isEqualTo("ED" + ED_PRIVATE_KEY_HEX);
 
     // Convert back
@@ -74,9 +74,9 @@ class BcKeyUtilsTest {
 
     // To PrivateKey
     PrivateKey privateKey = BcKeyUtils.toPrivateKey(ecPrivateKeyParameters);
-    assertThat(Base58.encode(privateKey.valueWithPrefixedBytes().toByteArray()))
+    assertThat(Base58.encode(privateKey.prefixedBytes().toByteArray()))
       .isEqualTo("rEnYwxojogCYKG3F5Bf7zvcZjo76pEqKwG9wGH14JngcV");
-    assertThat(BaseEncoding.base16().encode(privateKey.valueWithPrefixedBytes().toByteArray()))
+    assertThat(BaseEncoding.base16().encode(privateKey.prefixedBytes().toByteArray()))
       .isEqualTo("00D12D2FACA9AD92828D89683778CB8DFCCDBD6C9E92F6AB7D6065E8AACC1FF6D6");
     assertThat(BcKeyUtils.toEcPrivateKeyParams(privateKey)).usingRecursiveComparison()
       .isEqualTo(ecPrivateKeyParameters);

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtilsTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtilsTest.java
@@ -56,9 +56,10 @@ class BcKeyUtilsTest {
 
     // To PrivateKey
     PrivateKey privateKey = BcKeyUtils.toPrivateKey(ed25519PrivateKeyParameters);
-    assertThat(Base58.encode(privateKey.value().toByteArray()))
+    assertThat(Base58.encode(privateKey.valueWithPrefixedBytes().toByteArray()))
       .isEqualTo("pDcQTi2uFBAzQ7cY2mYQtk9QuQBoLU6rJypEf8EYPQoouh");
-    assertThat(BaseEncoding.base16().encode(privateKey.value().toByteArray())).isEqualTo("ED" + ED_PRIVATE_KEY_HEX);
+    assertThat(BaseEncoding.base16().encode(privateKey.valueWithPrefixedBytes().toByteArray()))
+      .isEqualTo("ED" + ED_PRIVATE_KEY_HEX);
 
     // Convert back
     Ed25519PrivateKeyParameters converted = BcKeyUtils.toEd25519PrivateKeyParams(privateKey);
@@ -73,9 +74,9 @@ class BcKeyUtilsTest {
 
     // To PrivateKey
     PrivateKey privateKey = BcKeyUtils.toPrivateKey(ecPrivateKeyParameters);
-    assertThat(Base58.encode(privateKey.value().toByteArray()))
+    assertThat(Base58.encode(privateKey.valueWithPrefixedBytes().toByteArray()))
       .isEqualTo("rEnYwxojogCYKG3F5Bf7zvcZjo76pEqKwG9wGH14JngcV");
-    assertThat(BaseEncoding.base16().encode(privateKey.value().toByteArray()))
+    assertThat(BaseEncoding.base16().encode(privateKey.valueWithPrefixedBytes().toByteArray()))
       .isEqualTo("00D12D2FACA9AD92828D89683778CB8DFCCDBD6C9E92F6AB7D6065E8AACC1FF6D6");
     assertThat(BcKeyUtils.toEcPrivateKeyParams(privateKey)).usingRecursiveComparison()
       .isEqualTo(ecPrivateKeyParameters);

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtilsTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/bc/BcKeyUtilsTest.java
@@ -74,9 +74,9 @@ class BcKeyUtilsTest {
     // To PrivateKey
     PrivateKey privateKey = BcKeyUtils.toPrivateKey(ecPrivateKeyParameters);
     assertThat(Base58.encode(privateKey.value().toByteArray()))
-      .isEqualTo("EnYwxojogCYKG3F5Bf7zvcZjo76pEqKwG9wGH14JngcV");
+      .isEqualTo("rEnYwxojogCYKG3F5Bf7zvcZjo76pEqKwG9wGH14JngcV");
     assertThat(BaseEncoding.base16().encode(privateKey.value().toByteArray()))
-      .isEqualTo("D12D2FACA9AD92828D89683778CB8DFCCDBD6C9E92F6AB7D6065E8AACC1FF6D6");
+      .isEqualTo("00D12D2FACA9AD92828D89683778CB8DFCCDBD6C9E92F6AB7D6065E8AACC1FF6D6");
     assertThat(BcKeyUtils.toEcPrivateKeyParams(privateKey)).usingRecursiveComparison()
       .isEqualTo(ecPrivateKeyParameters);
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/AbstractSignatureServiceTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/AbstractSignatureServiceTest.java
@@ -193,12 +193,12 @@ public class AbstractSignatureServiceTest {
   @Test
   public void signWithNullTransaction() {
     assertThrows(NullPointerException.class,
-      () -> signatureService.sign(TestConstants.ED_PRIVATE_KEY, (Transaction) null));
+      () -> signatureService.sign(TestConstants.getEdPrivateKey(), (Transaction) null));
   }
 
   @Test
   public void signEd25519() {
-    signatureService.sign(TestConstants.ED_PRIVATE_KEY, transactionMock);
+    signatureService.sign(TestConstants.getEdPrivateKey(), transactionMock);
 
     verify(signatureUtilsMock, times(0)).toMultiSignableBytes(any(), any());
     verify(signatureUtilsMock).toSignableBytes(transactionMock);
@@ -208,7 +208,7 @@ public class AbstractSignatureServiceTest {
 
   @Test
   public void signSecp256k1() {
-    signatureService.sign(TestConstants.EC_PRIVATE_KEY, transactionMock);
+    signatureService.sign(TestConstants.getEcPrivateKey(), transactionMock);
 
     verify(signatureUtilsMock, times(0)).toMultiSignableBytes(any(), any());
     verify(signatureUtilsMock).toSignableBytes(transactionMock);
@@ -220,7 +220,7 @@ public class AbstractSignatureServiceTest {
   void multiSignEd25519() {
     when(signedTransactionMock.signature()).thenReturn(ed25519SignatureMock);
 
-    final Signature signature = signatureService.multiSign(TestConstants.ED_PRIVATE_KEY, transactionMock);
+    final Signature signature = signatureService.multiSign(TestConstants.getEdPrivateKey(), transactionMock);
     assertThat(signature).isEqualTo(ed25519SignatureMock);
 
     verify(signatureUtilsMock).toMultiSignableBytes(transactionMock, TestConstants.ED_ADDRESS);
@@ -232,7 +232,7 @@ public class AbstractSignatureServiceTest {
   void multiSignSecp256k1() {
     when(signedTransactionMock.signature()).thenReturn(secp256k1SignatureMock);
 
-    final Signature signature = signatureService.multiSign(TestConstants.EC_PRIVATE_KEY, transactionMock);
+    final Signature signature = signatureService.multiSign(TestConstants.getEcPrivateKey(), transactionMock);
     assertThat(signature).isEqualTo(secp256k1SignatureMock);
 
     verify(signatureUtilsMock).toMultiSignableBytes(transactionMock, TestConstants.EC_ADDRESS);
@@ -252,7 +252,7 @@ public class AbstractSignatureServiceTest {
   @Test
   public void signUnsignedClaimWithNullUnsignedClaim() {
     assertThrows(NullPointerException.class,
-      () -> signatureService.sign(TestConstants.ED_PRIVATE_KEY, (UnsignedClaim) null));
+      () -> signatureService.sign(TestConstants.getEdPrivateKey(), (UnsignedClaim) null));
   }
 
   @Test
@@ -260,7 +260,7 @@ public class AbstractSignatureServiceTest {
     UnsignedClaim unsignedClaimMock = mock(UnsignedClaim.class);
     when(signatureUtilsMock.toSignableBytes(unsignedClaimMock)).thenReturn(UnsignedByteArray.empty());
 
-    Signature actualSignature = signatureService.sign(TestConstants.ED_PRIVATE_KEY, unsignedClaimMock);
+    Signature actualSignature = signatureService.sign(TestConstants.getEdPrivateKey(), unsignedClaimMock);
     assertThat(actualSignature).isEqualTo(ed25519SignatureMock);
 
     verify(signatureUtilsMock, times(0)).toMultiSignableBytes(any(), any());
@@ -350,7 +350,7 @@ public class AbstractSignatureServiceTest {
 
   @Test
   public void edDsaSign() {
-    Signature actual = signatureService.edDsaSign(TestConstants.ED_PRIVATE_KEY, UnsignedByteArray.empty());
+    Signature actual = signatureService.edDsaSign(TestConstants.getEdPrivateKey(), UnsignedByteArray.empty());
 
     assertThat(actual).isEqualTo(ed25519SignatureMock);
     assertThat(ed25519VerifyCalled.get()).isFalse();
@@ -364,7 +364,7 @@ public class AbstractSignatureServiceTest {
 
   @Test
   public void ecDsaSign() {
-    Signature actual = signatureService.ecDsaSign(TestConstants.EC_PRIVATE_KEY, UnsignedByteArray.empty());
+    Signature actual = signatureService.ecDsaSign(TestConstants.getEcPrivateKey(), UnsignedByteArray.empty());
 
     assertThat(actual).isEqualTo(secp256k1SignatureMock);
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/bc/Secp256k1Test.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/bc/Secp256k1Test.java
@@ -1,0 +1,277 @@
+package org.xrpl.xrpl4j.crypto.signing.bc;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.common.io.BaseEncoding;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.xrpl.xrpl4j.codec.addresses.UnsignedByte;
+import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
+
+import java.math.BigInteger;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+/**
+ * Unit tests for {@link Secp256k1}.
+ */
+class Secp256k1Test {
+
+  /////////
+  // toUnsignedByteArray(BigInteger)
+  /////////
+
+  @Test
+  void fromBigIntegerWithInvalidInputs() {
+    assertThrows(NullPointerException.class, () -> Secp256k1.toUnsignedByteArray(
+      null, // <-- The crux of the test
+      0
+    ));
+    assertThrows(IllegalArgumentException.class, () -> Secp256k1.toUnsignedByteArray(
+      BigInteger.valueOf(-1L), // <-- The crux of the test
+      0
+    ));
+    assertThrows(IllegalArgumentException.class, () -> Secp256k1.toUnsignedByteArray(
+      BigInteger.valueOf(1L),
+      -1 // <-- The crux of the test
+    ));
+  }
+
+  @Test
+  void fromBigIntegerWithZeroLength() {
+    Assertions.assertThat(Secp256k1.toUnsignedByteArray(
+        BigInteger.valueOf(1L),
+        0 // <-- The crux of the test
+      )
+      .hexValue()).isEqualTo("01");
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(BigIntegerByteEncodingsProvider.class)
+  void fromBigIntegerWithZeroPaddingBytes(
+    final String amountString,
+    final String amountToString16,
+    final String amountToByteArrayHexUnpadded,
+    final String amountToByteArrayHexPrefixPadded
+  ) {
+    final BigInteger amount = new BigInteger(amountString);
+    // NOTE `amount.toString(16)` strips off all leading 0s, even in a nibble (beware of using this in actual impl code)
+    Assertions.assertThat(amount.toString(16).toUpperCase(Locale.ENGLISH)).isEqualTo(amountToString16);
+    Assertions.assertThat(BaseEncoding.base16().encode(amount.toByteArray())).isEqualTo(amountToByteArrayHexUnpadded);
+    Assertions.assertThat(Secp256k1.toUnsignedByteArray(amount, 33).hexValue())
+      .isEqualTo(amountToByteArrayHexPrefixPadded);
+  }
+
+  @Test
+  void fromBigIntegerWithNumberGreaterThan33Bytes() {
+    final BigInteger amount = new BigInteger(
+      "194815934319126504488398097255143744553440248783815166056530734282223472643" +
+        "194815934319126504488398097255143744553440248783815166056530734282223472643");
+    // NOTE `amount.toString(16)` strips off all leading 0s, even in a nibble (beware of using this in actual impl code)
+    Assertions.assertThat(amount.toString(16).toUpperCase(Locale.ENGLISH)).isEqualTo(
+      "F3C607BB6CA7C4C335A24D0302484D16956259AC4510289E3E77A87BD72F36D1EED47F97D33F05F1715F603B45E83748DE37C087" +
+        "9DDE6060821AAAAD5003"
+    );
+    Assertions.assertThat(BaseEncoding.base16().encode(amount.toByteArray())).isEqualTo(
+      "00F3C607BB6CA7C4C335A24D0302484D16956259AC4510289E3E77A87BD72F36D1EED47F97D33F05F1715F603B45E83748DE37C087" +
+        "9DDE6060821AAAAD5003");
+    Assertions.assertThat(Secp256k1.toUnsignedByteArray(amount, 33).hexValue()).isEqualTo(
+      "00F3C607BB6CA7C4C335A24D0302484D16956259AC4510289E3E77A87BD72F36D1EED47F97D33F05F1715F603B45E83748DE37C087" +
+        "9DDE6060821AAAAD5003");
+  }
+
+  /////////////////////////
+  // withZeroPrefixPadding(UnsignedByteArray)
+  /////////////////////////
+
+  @Test
+  void withZeroPrefixPaddingWithUnsignedByteArrayWithInvalidInputs() {
+    UnsignedByteArray nullUba = null;
+    assertThrows(NullPointerException.class, () -> Secp256k1.withZeroPrefixPadding(
+      nullUba, // <-- The crux of the test
+      0
+    ));
+
+    assertThat(Secp256k1.withZeroPrefixPadding(
+      UnsignedByteArray.of(BigInteger.valueOf(-1L).toByteArray()), // <-- The crux of the test
+      0
+    )).isEqualTo(UnsignedByteArray.of(UnsignedByte.of(255)));
+
+    assertThrows(IllegalArgumentException.class, () -> Secp256k1.withZeroPrefixPadding(
+      UnsignedByteArray.of(BigInteger.valueOf(1L).toByteArray()),
+      -1 // <-- The crux of the test
+    ));
+  }
+
+  @Test
+  void withZeroPrefixPaddingWithUnsignedByteArrayWithZeroLength() {
+    Assertions.assertThat(Secp256k1.withZeroPrefixPadding(
+        UnsignedByteArray.of(BigInteger.valueOf(1L).toByteArray()),
+        0 // <-- The crux of the test
+      )
+      .hexValue()).isEqualTo("01");
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(BigIntegerByteEncodingsProvider.class)
+  void withZeroPrefixPaddingWithUnsignedByteArray(
+    final String amountString,
+    final String amountToString16,
+    final String amountToByteArrayHexUnpadded,
+    final String amountToByteArrayHexPrefixPadded
+  ) {
+    final BigInteger amount = new BigInteger(amountString);
+    // NOTE `amount.toString(16)` strips off all leading 0s, even in a nibble (beware of using this in actual impl code)
+    Assertions.assertThat(amount.toString(16).toUpperCase(Locale.ENGLISH)).isEqualTo(amountToString16);
+    Assertions.assertThat(BaseEncoding.base16().encode(amount.toByteArray())).isEqualTo(amountToByteArrayHexUnpadded);
+
+    UnsignedByteArray uba = UnsignedByteArray.of(amount.toByteArray());
+    Assertions.assertThat(Secp256k1.withZeroPrefixPadding(uba, 33).hexValue())
+      .isEqualTo(amountToByteArrayHexPrefixPadded);
+  }
+
+  @Test
+  void withZeroPrefixPaddingWithUnsignedByteArrayExtend32() {
+    final byte[] bytes32 = new byte[32];
+    final UnsignedByteArray uba32 = UnsignedByteArray.of(bytes32);
+    final byte[] bytes33 = new byte[33];
+    final UnsignedByteArray uba33 = UnsignedByteArray.of(bytes33);
+
+    assertThrows(IllegalArgumentException.class, () -> Secp256k1.withZeroPrefixPadding(uba32, -1));
+    assertThat(Secp256k1.withZeroPrefixPadding(uba32, 0)).isEqualTo(uba32);
+    assertThat(Secp256k1.withZeroPrefixPadding(uba32, 1)).isEqualTo(uba32);
+    assertThat(Secp256k1.withZeroPrefixPadding(uba32, 32)).isEqualTo(uba32);
+    assertThat(Secp256k1.withZeroPrefixPadding(uba32, 33)).isEqualTo(uba33);
+  }
+
+  /////////////////////////
+  // withZeroPrefixPadding(byte[])
+  /////////////////////////
+
+  @Test
+  void withZeroPrefixPaddingWithByteArrayWithInvalidInputs() {
+    byte[] nullByteArray = null;
+    assertThrows(NullPointerException.class, () -> Secp256k1.withZeroPrefixPadding(
+      nullByteArray, // <-- The crux of the test
+      0
+    ));
+
+    assertThat(Secp256k1.withZeroPrefixPadding(
+      BigInteger.valueOf(-1L).toByteArray(), // <-- The crux of the test
+      0
+    )).isEqualTo(UnsignedByteArray.of(UnsignedByte.of(255)));
+
+    assertThrows(IllegalArgumentException.class, () -> Secp256k1.withZeroPrefixPadding(
+      BigInteger.valueOf(1L).toByteArray(),
+      -1 // <-- The crux of the test
+    ));
+  }
+
+  @Test
+  void withZeroPrefixPaddingWithByteArrayWithZeroLength() {
+    Assertions.assertThat(Secp256k1.withZeroPrefixPadding(
+        BigInteger.valueOf(1L).toByteArray(),
+        0 // <-- The crux of the test
+      )
+      .hexValue()).isEqualTo("01");
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(BigIntegerByteEncodingsProvider.class)
+  void withZeroPrefixPaddingWithByteArray(
+    final String amountString,
+    final String amountToString16,
+    final String amountToByteArrayHexUnpadded,
+    final String amountToByteArrayHexPrefixPadded
+  ) {
+    final BigInteger amount = new BigInteger(amountString);
+    // NOTE `amount.toString(16)` strips off all leading 0s, even in a nibble (beware of using this in actual impl code)
+    Assertions.assertThat(amount.toString(16).toUpperCase(Locale.ENGLISH)).isEqualTo(amountToString16);
+    Assertions.assertThat(BaseEncoding.base16().encode(amount.toByteArray())).isEqualTo(amountToByteArrayHexUnpadded);
+    Assertions.assertThat(Secp256k1.withZeroPrefixPadding(amount.toByteArray(), 33).hexValue())
+      .isEqualTo(amountToByteArrayHexPrefixPadded);
+  }
+
+  @Test
+  void withZeroPrefixPaddingWithByteArrayExtend32() {
+    final byte[] bytes32 = new byte[32];
+    final UnsignedByteArray uba32 = UnsignedByteArray.of(bytes32);
+    final byte[] bytes33 = new byte[33];
+    final UnsignedByteArray uba33 = UnsignedByteArray.of(bytes33);
+
+    assertThrows(IllegalArgumentException.class, () -> Secp256k1.withZeroPrefixPadding(bytes32, -1));
+    assertThat(Secp256k1.withZeroPrefixPadding(bytes32, 0)).isEqualTo(uba32);
+    assertThat(Secp256k1.withZeroPrefixPadding(bytes32, 1)).isEqualTo(uba32);
+    assertThat(Secp256k1.withZeroPrefixPadding(bytes32, 32)).isEqualTo(uba32);
+    assertThat(Secp256k1.withZeroPrefixPadding(bytes32, 33)).isEqualTo(uba33);
+  }
+
+  /**
+   * An {@link ArgumentsProvider} that provides expected binary encodings for a variety of BigInteger representations.
+   */
+  static class BigIntegerByteEncodingsProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+        // A BigInteger comprised of 33 Bytes; toByteArray has 33 bytes; 0 extra padding added
+        Arguments.of(
+          "107371972967791294617431936514364612285184717182742299921102689634201232605691", // BigInt
+          "ED6262116F8D51F1FDD98C184F74CA48DDA7B049CB741F1F7A0564B88FE601FB", // .toString(16)
+          "00ED6262116F8D51F1FDD98C184F74CA48DDA7B049CB741F1F7A0564B88FE601FB", // .toByteArray()
+          "00ED6262116F8D51F1FDD98C184F74CA48DDA7B049CB741F1F7A0564B88FE601FB" // <-- Padded to 33 bytes
+        ),
+        // A BigInteger comprised of 33 Bytes; toByteArray has 33 bytes; 0 extra padding added
+        Arguments.of(
+          "84513109120471239583994879976286018548016554258021069224677925571161262209437", // BigInt
+          "BAD8B981A239980B1EC4CB901D698DDE7AA15F264D9537C7D141EE119DD5399D", // .toString(16)
+          "00BAD8B981A239980B1EC4CB901D698DDE7AA15F264D9537C7D141EE119DD5399D", // .toByteArray()
+          "00BAD8B981A239980B1EC4CB901D698DDE7AA15F264D9537C7D141EE119DD5399D" // <-- BigInteger Hex, Padded to 33 bytes
+        ),
+        // A BigInteger comprised of 32 Bytes; toByteArray has 32 bytes; 1 extra padding added
+        Arguments.of(
+          "8427551091932113544047724072139537481003293113704693219824523888925672289487", // BigInt
+          "12A1D32B744B18FA0186A44F32D9241869FA0A05B5B831F188831A07163534CF", // .toString(16)
+          "12A1D32B744B18FA0186A44F32D9241869FA0A05B5B831F188831A07163534CF", // .toByteArray()
+          "0012A1D32B744B18FA0186A44F32D9241869FA0A05B5B831F188831A07163534CF"// <-- BigInteger Hex, Padded to 33 bytes
+        ),
+        // A BigInteger comprised of 32 Bytes; toByteArray has 32 bytes; 1 extra padding added
+        Arguments.of("49026876502144691037964633390198098042987098960613207831256521276903508291997", // BigInt
+          "6C643A8EB51D365F3FF5B08C575DEA44B0D3CA5795BDD7B080A7057ABB9A319D", // .toString(16)
+          "6C643A8EB51D365F3FF5B08C575DEA44B0D3CA5795BDD7B080A7057ABB9A319D", // .toByteArray()
+          "006C643A8EB51D365F3FF5B08C575DEA44B0D3CA5795BDD7B080A7057ABB9A319D"// <-- BigInteger Hex, Padded to 33 bytes
+        ),
+        // A BigInteger comprised of 31 Bytes; toByteArray has 31 bytes; 2 extra padding added
+        Arguments.of("125364023161033659590032058970590371956067907570302268576097734468145372487", // BigInt
+          "46F41A0ECE7D0C61B5B36EA377E20621E23C13BD0ABBAEF80754180E9DDD47", // .toString(16)
+          "46F41A0ECE7D0C61B5B36EA377E20621E23C13BD0ABBAEF80754180E9DDD47", // .toByteArray()
+          "000046F41A0ECE7D0C61B5B36EA377E20621E23C13BD0ABBAEF80754180E9DDD47"// <-- BigInteger Hex, Padded to 33 bytes
+        ),
+        // A BigInteger comprised of 31 Bytes; toByteArray has 31 bytes; 2 extra padding added
+        Arguments.of("194815934319126504488398097255143744553440248783815166056530734282223472643", // BigInt
+          "6E430C9E47DFB2194C97385CC85C406DC69773145AE5DE6060821AAAAD5003", // .toString(16)
+          "6E430C9E47DFB2194C97385CC85C406DC69773145AE5DE6060821AAAAD5003", // .toByteArray()
+          "00006E430C9E47DFB2194C97385CC85C406DC69773145AE5DE6060821AAAAD5003"// <-- BigInteger Hex, Padded to 33 bytes
+        ),
+        // A BigInteger comprised of 30 Bytes; toByteArray has 30 bytes; 3 extra padding added
+        Arguments.of("116983811426126878045574354873599490265363256342001470285420476536129339", // BigInt
+          "10F32BB4E0B8B00469196EDACCCAA87A55409FF1C66330D7590449C7073B", // .toString(16)
+          "10F32BB4E0B8B00469196EDACCCAA87A55409FF1C66330D7590449C7073B", // .toByteArray()
+          "00000010F32BB4E0B8B00469196EDACCCAA87A55409FF1C66330D7590449C7073B" // <-- BigInteger Hex, Padded to 33 bytes
+        ),
+        // A BigInteger comprised of 30 Bytes; toByteArray has 30 bytes; 3 extra padding added
+        Arguments.of("95191719494323154714287471792160232496133380576373117355131561137428728", // BigInt
+          "DCADB6BD9E78F0ECE39BB26928F8E4B2A5C7F9CF62C15C1C554B5F458F8", // .toString(16)
+          "0DCADB6BD9E78F0ECE39BB26928F8E4B2A5C7F9CF62C15C1C554B5F458F8", // .toByteArray()
+          "0000000DCADB6BD9E78F0ECE39BB26928F8E4B2A5C7F9CF62C15C1C554B5F458F8" // <-- BigInteger Hex, Padded to 33 bytes
+        )
+      );
+    }
+  }
+}


### PR DESCRIPTION
1. Add a precondition to PrivateKey.of that enforces the length to 33 bytes (starting with either  0x00 or 0xED).
2. Update BCKeyUtils to add/remove the padding for secp keys (the way we do for Ed keys).
3. Add a new function to PrivateKey called `valueWithoutPrefix` which returns the natural 32 private key bytes.
4. Update Secp256k1KeyPairService in Seed.java to prefix with private keys with 0x00 if only 32 bytes.
5. Validate that `PrivateKey.keyType()` works properly via unit tests.