### PR TITLE
Point Reporting Mode tests to xrplcluster

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/ReportingMainnetEnvironment.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/ReportingMainnetEnvironment.java
@@ -30,7 +30,7 @@ import org.xrpl.xrpl4j.model.transactions.Address;
  */
 public class ReportingMainnetEnvironment extends MainnetEnvironment {
 
-  private final XrplClient xrplClient = new XrplClient(HttpUrl.parse("https://s2-reporting.ripple.com:51234"));
+  private final XrplClient xrplClient = new XrplClient(HttpUrl.parse("https://xrplcluster.com"));
 
   @Override
   public XrplClient getXrplClient() {


### PR DESCRIPTION
`ReportingModeMainnetEnvironment` was previously pointed at `https://s2-reporting.riple.com` which was recently shut down. `https://xrplcluster.com` is powered by reporting mode servers, so this PR changes `ReportingModeMainnetEnvironment` to point to `xrplcluster.com`
