### PR TITLE
Revert logback-classic to 1.3.X to work with JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,10 +66,11 @@
         <artifactId>jackson-datatype-cryptoconditions</artifactId>
         <version>${cryptoconditions.version}</version>
       </dependency>
+      <!--   This is the highest version we can use if we want to support Java 8. See https://logback.qos.ch/download.html   -->
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.4.12</version>
+        <version>1.3.8</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -291,7 +292,7 @@
     <cryptoconditions.version>1.0.4</cryptoconditions.version>
     <jackson.version>2.14.2</jackson.version>
     <feign.version>12.3</feign.version>
-    <slf4j.version>1.7.36</slf4j.version>
+    <slf4j.version>2.0.7</slf4j.version>
     <junit-jupiter.version>5.10.0</junit-jupiter.version>
     <guava.version>32.1.1-jre</guava.version>
   </properties>


### PR DESCRIPTION
I noticed after dependabot bumped `logback-classic` from 1.3.x to 1.4.x that logging stopped working and I saw this warning: `Failed to load class org.slf4j.impl.StaticLoggerBinder`. According to https://www.slf4j.org/codes.html#StaticLoggerBinder, logback-classic 1.4.x targets slf4j v2.x.x, so I tried to bump slf4j to v2.0.9 and logback-classic to 1.4.x. However, logback-classic 1.4.x supports JDK 11 and up, not JDK 8, which we try to support in xrpl4j. Therefore, I downgraded logback-classic to the latest 1.3.x and bumped slf4j to v2.0.7 based on https://logback.qos.ch/download.html