### PR TITLE
Fixes #474

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/types/AmountType.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/types/AmountType.java
@@ -158,7 +158,7 @@ class AmountType extends SerializedType<AmountType> {
           UnsignedLong
             .valueOf(isValueNegative ? value.asText().substring(1) : value.asText())
             .toString(16),
-          16 // <-- 64 / 16
+          16 // <-- 64 / 4
         )
       );
       final byte[] rawBytes = number.toByteArray();

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/types/AmountType.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/types/AmountType.java
@@ -92,11 +92,11 @@ class AmountType extends SerializedType<AmountType> {
     if (!value.equals(BigDecimal.ZERO)) {
       if (value.signum() < 0) { // `value` is negative
         if (value.compareTo(MAX_NEGATIVE_XRP) > 0 || value.compareTo(MIN_DROPS) < 0) {
-          throw new IllegalArgumentException(amount + " is an illegal amount");
+          throw new IllegalArgumentException(String.format("%s is an illegal amount", amount));
         }
       } else { // `value` is positive
         if (value.compareTo(MIN_XRP) < 0 || value.compareTo(MAX_DROPS) > 0) {
-          throw new IllegalArgumentException(amount + " is an illegal amount");
+          throw new IllegalArgumentException(String.format("%s is an illegal amount", amount));
         }
       }
     }
@@ -181,9 +181,7 @@ class AmountType extends SerializedType<AmountType> {
     result.append(currency);
     result.append(issuer);
 
-    return new
-
-      AmountType(result);
+    return new AmountType(result);
   }
 
   private UnsignedByteArray getAmountBytes(BigDecimal number) {

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/types/AmountType.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/types/AmountType.java
@@ -162,9 +162,7 @@ class AmountType extends SerializedType<AmountType> {
         )
       );
       final byte[] rawBytes = number.toByteArray();
-      if (isValueNegative) {
-        rawBytes[0] |= 0x00;
-      } else {
+      if (!isValueNegative) {
         rawBytes[0] |= 0x40;
       }
       return new AmountType(UnsignedByteArray.of(rawBytes));

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmount.java
@@ -20,6 +20,7 @@ package org.xrpl.xrpl4j.model.transactions;
  * =========================LICENSE_END==================================
  */
 
+import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -34,9 +35,17 @@ public interface CurrencyAmount {
   long ONE_XRP_IN_DROPS = 1_000_000L;
   long MAX_XRP = 100_000_000_000L; // <-- per https://xrpl.org/rippleapi-reference.html#value
   long MAX_XRP_IN_DROPS = MAX_XRP * ONE_XRP_IN_DROPS;
+  BigDecimal MAX_XRP_BD = BigDecimal.valueOf(MAX_XRP);
 
   /**
-   * Handle this {@link CurrencyAmount} depending on its actual polymorphic sub-type.
+   * Indicates whether this amount is positive or negative.
+   *
+   * @return {@code true} if this amount is negative; {@code false} otherwise (i.e., if the value is 0 or positive).
+   */
+  boolean isNegative();
+
+  /**
+   * Handle this {@link CurrencyAmount} depending on its actual polymorphic subtype.
    *
    * @param xrpCurrencyAmountHandler     A {@link Consumer} that is called if this instance is of type
    *                                     {@link XrpCurrencyAmount}.
@@ -60,7 +69,7 @@ public interface CurrencyAmount {
   }
 
   /**
-   * Map this {@link CurrencyAmount} to an instance of {@link R}, depending on its actualy polymorphic sub-type.
+   * Map this {@link CurrencyAmount} to an instance of {@link R}, depending on its actual polymorphic subtype.
    *
    * @param xrpCurrencyAmountMapper    A {@link Function} that is called if this instance is of type
    *                                   {@link XrpCurrencyAmount}.

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/IssuedCurrencyAmount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/IssuedCurrencyAmount.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.transactions;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,9 +20,12 @@ package org.xrpl.xrpl4j.model.transactions;
  * =========================LICENSE_END==================================
  */
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Derived;
 
 /**
  * A {@link CurrencyAmount} for Issued Currencies on the XRP Ledger.
@@ -45,14 +48,14 @@ public interface IssuedCurrencyAmount extends CurrencyAmount {
   String MIN_VALUE = "-9999999999999999e80";
 
   /**
-   * The smallest possible positive value that an {@link IssuedCurrencyAmount} can have. Put another way,
-   * this value is the closest an {@link IssuedCurrencyAmount}'s {@link #value()} can be to zero if it is positive.
+   * The smallest possible positive value that an {@link IssuedCurrencyAmount} can have. Put another way, this value is
+   * the closest an {@link IssuedCurrencyAmount}'s {@link #value()} can be to zero if it is positive.
    */
   String MIN_POSITIVE_VALUE = "1000000000000000e-96";
 
   /**
-   * The largest possible negative value that an {@link IssuedCurrencyAmount} can have. Put another way,
-   * this value is the closest an {@link IssuedCurrencyAmount}'s {@link #value()} can be to zero if it is negative.
+   * The largest possible negative value that an {@link IssuedCurrencyAmount} can have. Put another way, this value is
+   * the closest an {@link IssuedCurrencyAmount}'s {@link #value()} can be to zero if it is negative.
    */
   String MAX_NEGATIVE_VALUE = "-1000000000000000e-96";
 
@@ -67,10 +70,10 @@ public interface IssuedCurrencyAmount extends CurrencyAmount {
 
   /**
    * Quoted decimal representation of the amount of currency. This can include scientific notation, such as 1.23e11
-   * meaning 123,000,000,000. Both e and E may be used. Note that while this implementation merely holds a {@link
-   * String} with no value restrictions, the XRP Ledger does not tolerate unlimited precision values. Instead, non-XRP
-   * values (i.e., values held in this object) can have up to 16 decimal digits of precision, with a maximum value of
-   * 9999999999999999e80. The smallest positive non-XRP value is 1e-81.
+   * meaning 123,000,000,000. Both e and E may be used. Note that while this implementation merely holds a
+   * {@link String} with no value restrictions, the XRP Ledger does not tolerate unlimited precision values. Instead,
+   * non-XRP values (i.e., values held in this object) can have up to 16 decimal digits of precision, with a maximum
+   * value of 9999999999999999e80. The smallest positive non-XRP value is 1e-81.
    *
    * @return A {@link String} containing the amount of this issued currency.
    */
@@ -90,5 +93,16 @@ public interface IssuedCurrencyAmount extends CurrencyAmount {
    * @return The {@link Address} of the account of the issuer of this currency.
    */
   Address issuer();
+
+  /**
+   * Indicates whether this amount is positive or negative.
+   *
+   * @return {@code true} if this amount is negative; {@code false} otherwise (i.e., if the value is 0 or positive).
+   */
+  @Derived
+  @JsonIgnore // <-- This is not actually part of the binary serialization format, so exclude from JSON
+  default boolean isNegative() {
+    return value().startsWith("-");
+  }
 
 }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/IssuedCurrencyAmount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/IssuedCurrencyAmount.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
+import org.immutables.value.Value.Auxiliary;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Derived;
 
@@ -101,6 +102,7 @@ public interface IssuedCurrencyAmount extends CurrencyAmount {
    */
   @Derived
   @JsonIgnore // <-- This is not actually part of the binary serialization format, so exclude from JSON
+  @Auxiliary
   default boolean isNegative() {
     return value().startsWith("-");
   }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -333,11 +333,7 @@ public class Wrappers {
 
     @Override
     public String toString() {
-      if (isNegative()) {
-        return "-" + this.value().toString();
-      } else {
-        return this.value().toString();
-      }
+      return String.format("%s%s", isNegative() ? "-" : "", this.value().toString());
     }
 
     /**

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -264,6 +264,13 @@ public class Wrappers {
 
     /**
      * Indicates whether this amount is positive or negative.
+     * <p/>
+     * Note that this is suitable to declare as the default value for a few reasons. First, deserialization will parse
+     * the payload properly, setting this value correctly (despite this default settings). Second, using a default value
+     * here will not break legacy code that is using a build to construct an {@link XrpCurrencyAmount} correctly (i.e.,
+     * we assume that no developer is constructing a negative XRP amount because the {@link UnsignedLong} preconditions
+     * would not allow them to do such a thing without throwing. Finally, due to the way we've constructed the static
+     * builders of this class, legacy code should continue to work normally.
      *
      * @return {@code true} if this amount is negative; {@code false} otherwise (i.e., if the value is 0 or positive).
      */

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -267,7 +267,7 @@ public class Wrappers {
      *
      * <p>Note that the use of the `@Default` annotation and the default implementation are suitable for a few
      * reasons. First, deserialization will parse the payload properly, setting this value correctly (despite this
-     * default settings). Second, using a default value here will not break legacy code that is using a builder¬ to
+     * default settings). Second, using a default value here will not break legacy code that is using a builder to
      * construct an {@link XrpCurrencyAmount} correctly (i.e., we assume that no developer is constructing a negative
      * XRP amount because the {@link UnsignedLong} precondition in any legacy code would not allow them to do such a
      * thing without throwing an exception). Finally, due to the way this class merely adds new static builders to

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -247,11 +247,11 @@ public class Wrappers {
       // Whether positive or negative, ensure the amount is not too small and not too big.
       Preconditions.checkArgument(
         FluentCompareTo.is(absAmount).greaterThanEqualTo(SMALLEST_XRP),
-        String.format("Amount must be greater-than %s", SMALLEST_XRP)
+        String.format("Amount must be greater-than-or-equal-to %s", SMALLEST_XRP)
       );
       Preconditions.checkArgument(
         FluentCompareTo.is(absAmount).lessThanOrEqualTo(MAX_XRP_BD),
-        String.format("Amount must be less-than-or-equal to %s", MAX_XRP_BD)
+        String.format("Amount must be less-than-or-equal-to %s", MAX_XRP_BD)
       );
 
       if (amount.signum() == 0) { // zero

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -265,12 +265,13 @@ public class Wrappers {
     /**
      * Indicates whether this amount is positive or negative.
      *
-     * <p>Note that this is suitable to declare as the default value for a few reasons. First, deserialization will
-     * parse the payload properly, setting this value correctly (despite this default settings). Second, using a default
-     * value here will not break legacy code that is using a build to construct an {@link XrpCurrencyAmount} correctly
-     * (i.e., we assume that no developer is constructing a negative XRP amount because the {@link UnsignedLong}
-     * preconditions would not allow them to do such a thing without throwing. Finally, due to the way we've constructed
-     * the static builders of this class, legacy code should continue to work normally.
+     * <p>Note that the use of the `@Default` annotation and the default implementation are suitable for a few
+     * reasons. First, deserialization will parse the payload properly, setting this value correctly (despite this
+     * default settings). Second, using a default value here will not break legacy code that is using a builder¬ to
+     * construct an {@link XrpCurrencyAmount} correctly (i.e., we assume that no developer is constructing a negative
+     * XRP amount because the {@link UnsignedLong} precondition in any legacy code would not allow them to do such a
+     * thing without throwing an exception). Finally, due to the way this class merely adds new static builders to
+     * augment existing code, legacy code should continue to work normally.
      *
      * @return {@code true} if this amount is negative; {@code false} otherwise (i.e., if the value is 0 or positive).
      */

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -277,7 +277,9 @@ public class Wrappers {
      */
     @Default
     @Override
-    @JsonIgnore // <-- This is not actually part of the binary serialization format, so exclude from JSON
+    // No `@JsonIgnore` because isNegative isn't a "serializable field" in the definitions.json file, so this won't
+    // get serialized even if it's included in the JSON. Rationale for including in the generated JSON is so that
+    // any software using the JSON variant of an XrpCurrencyAmount will have this information available.
     public boolean isNegative() {
       return false;
     }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -189,7 +189,7 @@ public class Wrappers {
      */
     public static XrpCurrencyAmount ofDrops(final long drops) {
       if (drops < 0) {
-        // Normalize the drops value to be a positive number; indicated negativity via property.
+        // Normalize the drops value to be a positive number; indicate negativity via property.
         return ofDrops(UnsignedLong.valueOf(Math.abs(drops)), true);
       } else {
         // Default to positive number and negativity indicator of `false`. No need for Math.abs(drops) because negative
@@ -300,8 +300,8 @@ public class Wrappers {
     public XrpCurrencyAmount plus(XrpCurrencyAmount other) {
       // Convert each value to a long (positive or negative works)
       long result =
-        this.value().longValue() * (this.isNegative() ? -1 : 1) +
-          other.value().longValue() * (other.isNegative() ? -1 : 1);
+        (this.value().longValue() * (this.isNegative() ? -1 : 1)) +
+          (other.value().longValue() * (other.isNegative() ? -1 : 1));
       return XrpCurrencyAmount.ofDrops(result);
     }
 
@@ -315,8 +315,8 @@ public class Wrappers {
     public XrpCurrencyAmount minus(XrpCurrencyAmount other) {
       // Convert each value to a long (positive or negative works)
       long result =
-        this.value().longValue() * (this.isNegative() ? -1 : 1) -
-          other.value().longValue() * (other.isNegative() ? -1 : 1);
+        (this.value().longValue() * (this.isNegative() ? -1 : 1)) -
+          (other.value().longValue() * (other.isNegative() ? -1 : 1));
       return XrpCurrencyAmount.ofDrops(result);
     }
 

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -264,13 +264,13 @@ public class Wrappers {
 
     /**
      * Indicates whether this amount is positive or negative.
-     * <p/>
-     * Note that this is suitable to declare as the default value for a few reasons. First, deserialization will parse
-     * the payload properly, setting this value correctly (despite this default settings). Second, using a default value
-     * here will not break legacy code that is using a build to construct an {@link XrpCurrencyAmount} correctly (i.e.,
-     * we assume that no developer is constructing a negative XRP amount because the {@link UnsignedLong} preconditions
-     * would not allow them to do such a thing without throwing. Finally, due to the way we've constructed the static
-     * builders of this class, legacy code should continue to work normally.
+     *
+     * <p>Note that this is suitable to declare as the default value for a few reasons. First, deserialization will
+     * parse the payload properly, setting this value correctly (despite this default settings). Second, using a default
+     * value here will not break legacy code that is using a build to construct an {@link XrpCurrencyAmount} correctly
+     * (i.e., we assume that no developer is constructing a negative XRP amount because the {@link UnsignedLong}
+     * preconditions would not allow them to do such a thing without throwing. Finally, due to the way we've constructed
+     * the static builders of this class, legacy code should continue to work normally.
      *
      * @return {@code true} if this amount is negative; {@code false} otherwise (i.e., if the value is 0 or positive).
      */

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -336,7 +336,10 @@ public class Wrappers {
      * @return The product of this amount and the {@code other} amount, as an {@link XrpCurrencyAmount}.
      */
     public XrpCurrencyAmount times(XrpCurrencyAmount other) {
-      return XrpCurrencyAmount.ofDrops(this.value().times(other.value()), this.isNegative() | other.isNegative());
+      return XrpCurrencyAmount.ofDrops(
+        this.value().times(other.value()),
+        this.isNegative() || other.isNegative()
+      );
     }
 
     @Override

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/metadata/MetaLedgerObject.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/metadata/MetaLedgerObject.java
@@ -21,7 +21,7 @@ package org.xrpl.xrpl4j.model.transactions.metadata;
  */
 
 /**
- * Market interface for XRP Ledger Objects as represented in transaction metadata. Unlike descendants of
+ * Marker interface for XRP Ledger Objects as represented in transaction metadata. Unlike descendants of
  * {@link org.xrpl.xrpl4j.model.ledger.LedgerObject}, all descendants of this interface will have all fields typed as
  * {@link java.util.Optional} because ledger objects represented in transaction metadata often do not contain
  * all fields of the ledger object.

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/types/AmountTypeTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/types/AmountTypeTest.java
@@ -23,7 +23,6 @@ package org.xrpl.xrpl4j.codec.binary.types;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.Arguments;
@@ -38,8 +37,7 @@ class AmountTypeTest extends BaseSerializerTypeTest {
 
   private static final AmountType codec = new AmountType();
 
-  // Appears unused but is used by junit
-  private static Stream<Arguments> dataDrivenFixtures() throws IOException {
+  static Stream<Arguments> dataDrivenFixtures() throws IOException {
     return dataDrivenFixturesForType(codec);
   }
 
@@ -124,19 +122,33 @@ class AmountTypeTest extends BaseSerializerTypeTest {
 
   @Test
   void encodeOutOfBounds() {
-    // Positive
+    // Positive (too big)
     {
       IllegalArgumentException thrownError = assertThrows(
         IllegalArgumentException.class, () -> codec.fromJson("100000000000000001")
       );
       assertThat(thrownError.getMessage()).isEqualTo("100000000000000001 is an illegal amount");
     }
-    // Negative
+    // Positive (too small)
+    {
+      IllegalArgumentException thrownError = assertThrows(
+        IllegalArgumentException.class, () -> codec.fromJson("0.0000005") // <-- 0.000001 is smallest positive XRP
+      );
+      assertThat(thrownError.getMessage()).isEqualTo("5.0E-7 is an illegal amount");
+    }
+    // Negative (too small)
     {
       IllegalArgumentException thrownError = assertThrows(
         IllegalArgumentException.class, () -> codec.fromJson("-100000000000000001")
       );
       assertThat(thrownError.getMessage()).isEqualTo("-100000000000000001 is an illegal amount");
+    }
+    // Negative (too big)
+    {
+      IllegalArgumentException thrownError = assertThrows(
+        IllegalArgumentException.class, () -> codec.fromJson("-0.0000005") // <-- 0.000001 is largest negative XRP
+      );
+      assertThat(thrownError.getMessage()).isEqualTo("-5.0E-7 is an illegal amount");
     }
   }
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/types/AmountTypeTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/types/AmountTypeTest.java
@@ -23,6 +23,7 @@ package org.xrpl.xrpl4j.codec.binary.types;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.Arguments;
@@ -124,9 +125,19 @@ class AmountTypeTest extends BaseSerializerTypeTest {
   @Test
   void encodeOutOfBounds() {
     // Positive
-    assertThrows(IllegalArgumentException.class, () -> codec.fromJson("416345785D8A0001"));
+    {
+      IllegalArgumentException thrownError = assertThrows(
+        IllegalArgumentException.class, () -> codec.fromJson("100000000000000001")
+      );
+      assertThat(thrownError.getMessage()).isEqualTo("100000000000000001 is an illegal amount");
+    }
     // Negative
-    assertThrows(IllegalArgumentException.class, () -> codec.fromJson("-416345785D8A0001"));
+    {
+      IllegalArgumentException thrownError = assertThrows(
+        IllegalArgumentException.class, () -> codec.fromJson("-100000000000000001")
+      );
+      assertThat(thrownError.getMessage()).isEqualTo("-100000000000000001 is an illegal amount");
+    }
   }
 
   @Test

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmountTest.java
@@ -32,12 +32,33 @@ import org.xrpl.xrpl4j.codec.addresses.ByteUtils;
 import org.xrpl.xrpl4j.codec.binary.XrplBinaryCodec;
 import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
 
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 
 /**
  * Unit tests for {@link CurrencyAmount}.
  */
 public class CurrencyAmountTest {
+
+  @Test
+  public void isNegative() {
+    // Not negative
+    CurrencyAmount currencyAmount = new CurrencyAmount() {
+      @Override
+      public boolean isNegative() {
+        return false;
+      }
+    };
+    assertThat(currencyAmount.isNegative()).isFalse();
+    // Negative
+    currencyAmount = new CurrencyAmount() {
+      @Override
+      public boolean isNegative() {
+        return true;
+      }
+    };
+    assertThat(currencyAmount.isNegative()).isTrue();
+  }
 
   @Test
   public void handleXrp() {
@@ -59,13 +80,11 @@ public class CurrencyAmountTest {
     );
 
     // Unhandled...
-    CurrencyAmount currencyAmount = new CurrencyAmount() {
-    };
+    CurrencyAmount currencyAmount = () -> false;
     assertThrows(IllegalStateException.class, () ->
       currencyAmount.handle(($) -> new Object(), ($) -> new Object())
     );
   }
-
 
   @Test
   public void handleIssuance() {
@@ -110,8 +129,7 @@ public class CurrencyAmountTest {
     );
 
     // Unhandled...
-    CurrencyAmount currencyAmount = new CurrencyAmount() {
-    };
+    CurrencyAmount currencyAmount = () -> false;
     assertThrows(IllegalStateException.class, () ->
       currencyAmount.map(($) -> new Object(), ($) -> new Object())
     );
@@ -220,5 +238,6 @@ public class CurrencyAmountTest {
     assertThat(CurrencyAmount.ONE_XRP_IN_DROPS).isEqualTo(1_000_000L);
     assertThat(CurrencyAmount.MAX_XRP).isEqualTo(100_000_000_000L);
     assertThat(CurrencyAmount.MAX_XRP_IN_DROPS).isEqualTo(100_000_000_000_000_000L);
+    assertThat(CurrencyAmount.MAX_XRP_BD).isEqualTo(new BigDecimal(100_000_000_000L));
   }
 }

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/IssuedCurrencyAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/IssuedCurrencyAmountTest.java
@@ -1,0 +1,51 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link IssuedCurrencyAmount}.
+ */
+class IssuedCurrencyAmountTest {
+
+  @Test
+  void toStringIssuedCurrentAmount() {
+    // Negative values.
+    IssuedCurrencyAmount issuedCurrency = IssuedCurrencyAmount.builder()
+      .currency("USD")
+      .issuer(Address.of("rP9JR5JTEqaVYbXHtiqR5YvBeoWQeMBipS"))
+      .value("-1.00")
+      .build();
+    assertThat(issuedCurrency.toString()).isEqualTo(
+      "IssuedCurrencyAmount{" +
+        "value=-1.00, " +
+        "currency=USD, " +
+        "issuer=rP9JR5JTEqaVYbXHtiqR5YvBeoWQeMBipS, " +
+        "isNegative=true" +
+        "}"
+    );
+    assertThat(issuedCurrency.isNegative()).isTrue();
+
+    // Positive values
+    issuedCurrency = IssuedCurrencyAmount.builder()
+      .currency("USD")
+      .issuer(Address.of("rP9JR5JTEqaVYbXHtiqR5YvBeoWQeMBipS"))
+      .value("1.00")
+      .build();
+    assertThat(issuedCurrency.toString()).isEqualTo(
+      "IssuedCurrencyAmount{" +
+        "value=1.00, " +
+        "currency=USD, " +
+        "issuer=rP9JR5JTEqaVYbXHtiqR5YvBeoWQeMBipS, " +
+        "isNegative=false" +
+        "}"
+    );
+    assertThat(issuedCurrency.isNegative()).isFalse();
+
+  }
+
+  @Test
+  void isNegative() {
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/IssuedCurrencyAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/IssuedCurrencyAmountTest.java
@@ -21,8 +21,7 @@ class IssuedCurrencyAmountTest {
       "IssuedCurrencyAmount{" +
         "value=-1.00, " +
         "currency=USD, " +
-        "issuer=rP9JR5JTEqaVYbXHtiqR5YvBeoWQeMBipS, " +
-        "isNegative=true" +
+        "issuer=rP9JR5JTEqaVYbXHtiqR5YvBeoWQeMBipS" +
         "}"
     );
     assertThat(issuedCurrency.isNegative()).isTrue();
@@ -37,8 +36,7 @@ class IssuedCurrencyAmountTest {
       "IssuedCurrencyAmount{" +
         "value=1.00, " +
         "currency=USD, " +
-        "issuer=rP9JR5JTEqaVYbXHtiqR5YvBeoWQeMBipS, " +
-        "isNegative=false" +
+        "issuer=rP9JR5JTEqaVYbXHtiqR5YvBeoWQeMBipS" +
         "}"
     );
     assertThat(issuedCurrency.isNegative()).isFalse();
@@ -47,5 +45,34 @@ class IssuedCurrencyAmountTest {
 
   @Test
   void isNegative() {
+    // Negative
+    {
+      final IssuedCurrencyAmount issuedCurrency = IssuedCurrencyAmount.builder()
+        .currency("USD")
+        .issuer(Address.of("rP9JR5JTEqaVYbXHtiqR5YvBeoWQeMBipS"))
+        .value("-1.00")
+        .build();
+      assertThat(issuedCurrency.isNegative()).isTrue();
+    }
+
+    // Positive
+    {
+      final IssuedCurrencyAmount issuedCurrency = IssuedCurrencyAmount.builder()
+        .currency("USD")
+        .issuer(Address.of("rP9JR5JTEqaVYbXHtiqR5YvBeoWQeMBipS"))
+        .value("1.00")
+        .build();
+      assertThat(issuedCurrency.isNegative()).isFalse();
+    }
+
+    // Zero
+    {
+      final IssuedCurrencyAmount issuedCurrency = IssuedCurrencyAmount.builder()
+        .currency("USD")
+        .issuer(Address.of("rP9JR5JTEqaVYbXHtiqR5YvBeoWQeMBipS"))
+        .value("0")
+        .build();
+      assertThat(issuedCurrency.isNegative()).isFalse();
+    }
   }
 }

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/NegativeTransactionMetadataTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/NegativeTransactionMetadataTest.java
@@ -81,34 +81,18 @@ class NegativeTransactionMetadataTest {
    * This test validates that the ledger 87704323 and all of its transactions and metadata are handled correctly, even
    * in the presence of negative XRP or IOU amounts.
    */
-  @Test
-  void deserializeOfferCreateWithNegativeValues() throws IOException {
-    File jsonFile = new File(
-      "src/test/resources/negative-balance-ledgers/txresult-offercreate-withnegatives.json"
-    );
-
-    TransactionResult<OfferCreate> transactionResult = objectMapper.readValue(
-      jsonFile, objectMapper.getTypeFactory().constructParametricType(TransactionResult.class, OfferCreate.class)
-    );
-
-    assertThat(transactionResult.metadata().isPresent()).isTrue();
-    transactionResult.metadata().ifPresent(this::handleTransactionMetadata);
-  }
-
-  /**
-   * This test validates that the ledger 87704323 and all of its transactions and metadata are handled correctly, even
-   * in the presence of negative XRP or IOU amounts.
-   */
   @ParameterizedTest
   @ValueSource(strings = {
-    "ledger-result-346610.json",
-    "ledger-result-340231.json",
-    "ledger-result-346610.json",
-    "ledger-result-350621.json",
-    "ledger-result-353674.json",
-    "ledger-result-354496.json",
-    "ledger-result-354575.json",
-    "ledger-result-354579.json",
+    "ledger-result-309936.json", // <-- See https://github.com/XRPLF/xrpl4j/issues/473
+    "ledger-result-309937.json", // <-- See https://github.com/XRPLF/xrpl4j/issues/473
+    "ledger-result-329212.json", // <-- See https://github.com/XRPLF/xrpl4j/issues/474
+    "ledger-result-340231.json", // <-- See https://github.com/XRPLF/xrpl4j/issues/474
+    "ledger-result-346610.json", // <-- See https://github.com/XRPLF/xrpl4j/issues/474
+    "ledger-result-350621.json", // <-- See https://github.com/XRPLF/xrpl4j/issues/474
+    "ledger-result-353674.json", // <-- See https://github.com/XRPLF/xrpl4j/issues/474
+    "ledger-result-354496.json", // <-- See https://github.com/XRPLF/xrpl4j/issues/474
+    "ledger-result-354575.json", // <-- See https://github.com/XRPLF/xrpl4j/issues/474
+    "ledger-result-354579.json", // <-- See https://github.com/XRPLF/xrpl4j/issues/474
     "ledger-result-87704323.json",
     "ledger-result-90150378.json",
     "ledger-result-90156059.json"
@@ -126,6 +110,24 @@ class NegativeTransactionMetadataTest {
       assertThat(transactionResult.metadata().isPresent()).isTrue();
       transactionResult.metadata().ifPresent(this::handleTransactionMetadata);
     });
+  }
+
+  /**
+   * This test validates that the ledger 87704323 and all of its transactions and metadata are handled correctly, even
+   * in the presence of negative XRP or IOU amounts.
+   */
+  @Test
+  void deserializeOfferCreateWithNegativeValues() throws IOException {
+    File jsonFile = new File(
+      "src/test/resources/negative-balance-ledgers/txresult-offercreate-withnegatives.json"
+    );
+
+    TransactionResult<OfferCreate> transactionResult = objectMapper.readValue(
+      jsonFile, objectMapper.getTypeFactory().constructParametricType(TransactionResult.class, OfferCreate.class)
+    );
+
+    assertThat(transactionResult.metadata().isPresent()).isTrue();
+    transactionResult.metadata().ifPresent(this::handleTransactionMetadata);
   }
 
   private void handleTransactionMetadata(final TransactionMetadata transactionMetadata) {

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/NegativeTransactionMetadataTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/NegativeTransactionMetadataTest.java
@@ -1,0 +1,283 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xrpl.xrpl4j.model.client.ledger.LedgerResult;
+import org.xrpl.xrpl4j.model.client.transactions.TransactionResult;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.transactions.metadata.MetaAccountRootObject;
+import org.xrpl.xrpl4j.model.transactions.metadata.MetaLedgerEntryType;
+import org.xrpl.xrpl4j.model.transactions.metadata.MetaLedgerObject;
+import org.xrpl.xrpl4j.model.transactions.metadata.MetaOfferObject;
+import org.xrpl.xrpl4j.model.transactions.metadata.MetaRippleStateObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * An IT that loads data from various files containing XRPL mainnet ledger data, and verifies that all data can be
+ * deserialized, in particular negative XRP and IOU amounts.
+ *
+ * @see "https://github.com/XRPLF/xrpl4j/issues/527"
+ */
+class NegativeTransactionMetadataTest {
+
+  Logger logger = LoggerFactory.getLogger(NegativeTransactionMetadataTest.class);
+
+  ObjectMapper objectMapper = ObjectMapperFactory.create();
+
+  /**
+   * This test validates that the ledger specified in Github issue #527 actually deserializes properly, despite having
+   * negative XRP values.
+   *
+   * @see "https://github.com/XRPLF/xrpl4j/issues/527"
+   */
+  @Test
+  void deserializeLedger354575() throws IOException {
+
+    File jsonFile = new File(
+      "src/test/resources/negative-balance-ledgers/ledger-354575-metadata.json"
+    );
+
+    TransactionMetadata metaData = objectMapper.readValue(jsonFile, TransactionMetadata.class);
+
+    // Send this through the general test mechanism....
+    this.handleTransactionMetadata(metaData);
+
+    // Also check that the decimal deserializes properly.
+    metaData.affectedNodes().get(0).handle(
+      (createdNode) -> {
+        throw new RuntimeException("Should not be called");
+      },
+      (modifiedNode) -> {
+        assertThat(modifiedNode.previousFields().isPresent()).isTrue();
+        modifiedNode.previousFields()
+          .map($ -> (MetaAccountRootObject) $)
+          .ifPresent(metaAccountRootObject -> {
+            assertThat(metaAccountRootObject.balance().isPresent()).isTrue();
+            metaAccountRootObject.balance().ifPresent(balance -> {
+              assertThat(balance.isNegative()).isTrue();
+              assertThat(balance.toXrp()).isEqualTo(new BigDecimal("-2298.00005"));
+            });
+          });
+      },
+      (deletedNode) -> {
+        throw new RuntimeException("Should not be called");
+      }
+    );
+  }
+
+  /**
+   * This test validates that the ledger 87704323 and all of its transactions and metadata are handled correctly, even
+   * in the presence of negative XRP or IOU amounts.
+   */
+  @Test
+  void deserializeOfferCreateWithNegativeValues() throws IOException {
+    File jsonFile = new File(
+      "src/test/resources/negative-balance-ledgers/txresult-offercreate-withnegatives.json"
+    );
+
+    TransactionResult<OfferCreate> transactionResult = objectMapper.readValue(
+      jsonFile, objectMapper.getTypeFactory().constructParametricType(TransactionResult.class, OfferCreate.class)
+    );
+
+    assertThat(transactionResult.metadata().isPresent()).isTrue();
+    transactionResult.metadata().ifPresent(this::handleTransactionMetadata);
+  }
+
+  /**
+   * This test validates that the ledger 87704323 and all of its transactions and metadata are handled correctly, even
+   * in the presence of negative XRP or IOU amounts.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "ledger-result-346610.json",
+    "ledger-result-340231.json",
+    "ledger-result-346610.json",
+    "ledger-result-350621.json",
+    "ledger-result-353674.json",
+    "ledger-result-354496.json",
+    "ledger-result-354575.json",
+    "ledger-result-354579.json",
+    "ledger-result-87704323.json"
+  })
+  void deserializeLedgerResultWithNegativeAmounts(String ledgerResultFileName) throws IOException {
+    Objects.requireNonNull(ledgerResultFileName);
+
+    File jsonFile = new File(
+      "src/test/resources/negative-balance-ledgers/" + ledgerResultFileName
+    );
+
+    LedgerResult ledgerResult = objectMapper.readValue(jsonFile, LedgerResult.class);
+
+    ledgerResult.ledger().transactions().forEach(transactionResult -> {
+      assertThat(transactionResult.metadata().isPresent()).isTrue();
+      transactionResult.metadata().ifPresent(this::handleTransactionMetadata);
+    });
+  }
+
+  private void handleTransactionMetadata(final TransactionMetadata transactionMetadata) {
+    Objects.requireNonNull(transactionMetadata);
+
+    transactionMetadata.affectedNodes().forEach(affectedNode -> {
+      affectedNode.handle(
+        (createdNode) -> {
+          final MetaLedgerEntryType ledgerEntryType = createdNode.ledgerEntryType();
+          if (ledgerEntryType.equals(MetaLedgerEntryType.OFFER)) {
+            handleMetaLedgerObject((MetaOfferObject) createdNode.newFields());
+          } else if (ledgerEntryType.equals(MetaLedgerEntryType.ACCOUNT_ROOT)) {
+            handleMetaLedgerObject((MetaAccountRootObject) createdNode.newFields());
+          } else {
+            if (ledgerEntryType.equals(MetaLedgerEntryType.DIRECTORY_NODE)) {
+              logger.warn("Ignoring ledger entry type {}", ledgerEntryType);
+            } else {
+              throw new RuntimeException("Unhandled ledger entry type: " + ledgerEntryType);
+            }
+          }
+        },
+        (modifiedNode) -> {
+          modifiedNode.previousFields()
+            .ifPresent(metaLedgerObject -> {
+
+              final MetaLedgerEntryType ledgerEntryType = modifiedNode.ledgerEntryType();
+              if (ledgerEntryType.equals(MetaLedgerEntryType.OFFER)) {
+                handleMetaLedgerObject((MetaOfferObject) metaLedgerObject);
+              } else if (ledgerEntryType.equals(MetaLedgerEntryType.ACCOUNT_ROOT)) {
+                handleMetaLedgerObject((MetaAccountRootObject) metaLedgerObject);
+              } else if (ledgerEntryType.equals(MetaLedgerEntryType.RIPPLE_STATE)) {
+                handleMetaLedgerObject((MetaRippleStateObject) metaLedgerObject);
+              } else {
+                throw new RuntimeException("Unhandled ledger entry type: " + ledgerEntryType);
+              }
+            });
+
+          modifiedNode.finalFields()
+            .ifPresent(metaLedgerObject -> {
+              final MetaLedgerEntryType ledgerEntryType = modifiedNode.ledgerEntryType();
+              if (ledgerEntryType.equals(MetaLedgerEntryType.OFFER)) {
+                handleMetaLedgerObject((MetaOfferObject) metaLedgerObject);
+              } else if (ledgerEntryType.equals(MetaLedgerEntryType.ACCOUNT_ROOT)) {
+                handleMetaLedgerObject((MetaAccountRootObject) metaLedgerObject);
+              } else if (ledgerEntryType.equals(MetaLedgerEntryType.RIPPLE_STATE)) {
+                handleMetaLedgerObject((MetaRippleStateObject) metaLedgerObject);
+              } else {
+                if (ledgerEntryType.equals(MetaLedgerEntryType.DIRECTORY_NODE)) {
+                  logger.warn("Ignoring ledger entry type {}", ledgerEntryType);
+                } else {
+                  throw new RuntimeException("Unhandled ledger entry type: " + ledgerEntryType);
+                }
+              }
+            });
+        },
+        (deletedNode) -> {
+          deletedNode.previousFields()
+            .ifPresent(metaLedgerObject -> {
+
+              final MetaLedgerEntryType ledgerEntryType = deletedNode.ledgerEntryType();
+              if (ledgerEntryType.equals(MetaLedgerEntryType.OFFER)) {
+                handleMetaLedgerObject((MetaOfferObject) metaLedgerObject);
+              } else if (ledgerEntryType.equals(MetaLedgerEntryType.ACCOUNT_ROOT)) {
+                handleMetaLedgerObject((MetaAccountRootObject) metaLedgerObject);
+              } else if (ledgerEntryType.equals(MetaLedgerEntryType.RIPPLE_STATE)) {
+                handleMetaLedgerObject((MetaRippleStateObject) metaLedgerObject);
+              } else {
+                throw new RuntimeException("Unhandled ledger entry type: " + ledgerEntryType);
+              }
+            });
+
+          final MetaLedgerObject finalFields = deletedNode.finalFields();
+
+          final MetaLedgerEntryType ledgerEntryType = deletedNode.ledgerEntryType();
+          if (ledgerEntryType.equals(MetaLedgerEntryType.OFFER)) {
+            handleMetaLedgerObject((MetaOfferObject) finalFields);
+          } else if (ledgerEntryType.equals(MetaLedgerEntryType.ACCOUNT_ROOT)) {
+            handleMetaLedgerObject((MetaAccountRootObject) finalFields);
+          } else if (ledgerEntryType.equals(MetaLedgerEntryType.RIPPLE_STATE)) {
+            handleMetaLedgerObject((MetaRippleStateObject) finalFields);
+          } else if (ledgerEntryType.equals(MetaLedgerEntryType.TICKET)) {
+            logger.info("Ignoring ledger entry type {} because it has no currency values for negative checking",
+              ledgerEntryType);
+          } else {
+            if (ledgerEntryType.equals(MetaLedgerEntryType.DIRECTORY_NODE)) {
+              logger.warn("Ignoring ledger entry type {}", ledgerEntryType);
+            } else {
+              throw new RuntimeException("Unhandled ledger entry type: " + ledgerEntryType);
+            }
+          }
+        }
+      );
+    });
+  }
+
+  private void handleMetaLedgerObject(MetaRippleStateObject metaRippleStateObject) {
+    assertThat(metaRippleStateObject.balance().isPresent()).isTrue();
+
+    metaRippleStateObject.balance().ifPresent(balance -> {
+      if (balance.value().startsWith("-")) {
+        assertThat(balance.isNegative()).isTrue();
+      } else {
+        assertThat(balance.isNegative()).isFalse();
+      }
+    });
+
+    metaRippleStateObject.lowLimit().ifPresent(lowLimit -> {
+      if (lowLimit.value().startsWith("-")) {
+        assertThat(lowLimit.isNegative()).isTrue();
+      } else {
+        assertThat(lowLimit.isNegative()).isFalse();
+      }
+    });
+
+    metaRippleStateObject.highLimit().ifPresent(highLimit -> {
+      if (highLimit.value().startsWith("-")) {
+        assertThat(highLimit.isNegative()).isTrue();
+      } else {
+        assertThat(highLimit.isNegative()).isFalse();
+      }
+    });
+  }
+
+  private void handleMetaLedgerObject(MetaAccountRootObject metaAccountRootObject) {
+    assertThat(metaAccountRootObject.balance().isPresent()).isTrue();
+    metaAccountRootObject.balance().ifPresent(balance -> {
+      if (balance.toXrp().signum() < 0) {
+        assertThat(balance.isNegative()).isTrue();
+      } else {
+        assertThat(balance.isNegative()).isFalse();
+      }
+    });
+  }
+
+  private void handleMetaLedgerObject(MetaOfferObject metaOfferObject) {
+    assertThat(metaOfferObject.takerPays().isPresent()).isTrue();
+    assertThat(metaOfferObject.takerGets().isPresent()).isTrue();
+
+    metaOfferObject.takerPays().ifPresent(takerPays -> {
+      takerPays.handle(
+        xrpCurrencyAmount -> {
+          if (xrpCurrencyAmount.toXrp().signum() < 0) {
+            assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+          } else {
+            assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+          }
+        },
+        issuedCurrencyAmount -> {
+          if (issuedCurrencyAmount.value().startsWith("-")) {
+            assertThat(issuedCurrencyAmount.isNegative()).isTrue();
+          } else {
+            assertThat(issuedCurrencyAmount.isNegative()).isFalse();
+          }
+        }
+      );
+    });
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
@@ -36,7 +36,9 @@ import java.math.BigDecimal;
  */
 public class XrpCurrencyAmountTest {
 
+  private static final long NEGATIVE_HALF_XRP_IN_DROPS = -500_000L;
   private static final long HALF_XRP_IN_DROPS = 500_000L;
+  private static final long NEGATIVE_TWO_XRP_IN_DROPS = -2_000_000L;
   private static final long TWO_XRP_IN_DROPS = 2_000_000L;
 
   @Test
@@ -97,8 +99,7 @@ public class XrpCurrencyAmountTest {
 
     // Too big
     assertThrows(IllegalStateException.class,
-      () -> XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(MAX_XRP_IN_DROPS + 1))
-    );
+      () -> XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(MAX_XRP_IN_DROPS + 1)));
   }
 
   @Test
@@ -121,8 +122,7 @@ public class XrpCurrencyAmountTest {
 
     // Too big
     assertThrows(IllegalStateException.class,
-      () -> XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(MAX_XRP_IN_DROPS + 1), true)
-    );
+      () -> XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(MAX_XRP_IN_DROPS + 1), true));
   }
 
   @Test
@@ -240,38 +240,54 @@ public class XrpCurrencyAmountTest {
 
   @Test
   public void plusXrp() {
-    // Positive
-    assertThat(
-      XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS)
-        .plus(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS))
-    ).isEqualTo(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS));
-    // Negative
-    assertThat(
-      XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS * -1)
-        .plus(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS * -1))
-    ).isEqualTo(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1));
+    // First Positive, Second Positive
+    {
+      XrpCurrencyAmount result = XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS)
+        .plus(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS));
+      assertThat(result).isEqualTo(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS));
+      assertThat(result.value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
+      assertThat(result.isNegative()).isFalse();
+    }
 
-    // Positive
-    assertThat(
-      XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001"))
-        .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001")))
-    ).isEqualTo(XrpCurrencyAmount.ofDrops(2L));
-    // Negative
-    assertThat(
-      XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001"))
-        .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001")))
-    ).isEqualTo(XrpCurrencyAmount.ofDrops(2L));
+    // First Positive, Second Negative
+    {
+      XrpCurrencyAmount result = XrpCurrencyAmount.ofDrops(NEGATIVE_HALF_XRP_IN_DROPS)
+        .plus(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS));
+      assertThat(result).isEqualTo(XrpCurrencyAmount.ofDrops(0L));
+      assertThat(result.value()).isEqualTo(UnsignedLong.ZERO);
+      assertThat(result.isNegative()).isFalse();
+    }
 
-    // Positive
-    assertThat(
-      XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001"))
-        .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001")))
-    ).isEqualTo(XrpCurrencyAmount.ofDrops(0L));
-    // Negative
-    assertThat(
-      XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001"))
-        .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("+0.000001")))
-    ).isEqualTo(XrpCurrencyAmount.ofDrops(0L));
+    // First Negative, Second Positive
+    {
+      XrpCurrencyAmount result = XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS)
+        .plus(XrpCurrencyAmount.ofDrops(NEGATIVE_HALF_XRP_IN_DROPS));
+      assertThat(result).isEqualTo(XrpCurrencyAmount.ofDrops(0L));
+      assertThat(result.value()).isEqualTo(UnsignedLong.ZERO);
+      assertThat(result.isNegative()).isFalse();
+    }
+
+    // First Negative, Second Negative
+    {
+      XrpCurrencyAmount result = XrpCurrencyAmount.ofDrops(NEGATIVE_HALF_XRP_IN_DROPS)
+        .plus(XrpCurrencyAmount.ofDrops(NEGATIVE_HALF_XRP_IN_DROPS));
+      assertThat(result).isEqualTo(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1));
+      assertThat(result.value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
+      assertThat(result.isNegative()).isTrue();
+    }
+
+    // Decimals (first positive, second positive)
+    assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001"))
+      .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001")))).isEqualTo(XrpCurrencyAmount.ofDrops(2L));
+    // Decimals (first positive, second negative)
+    assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001"))
+      .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001")))).isEqualTo(XrpCurrencyAmount.ofDrops(0L));
+    // Decimals (first negative, second positive)
+    assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001"))
+      .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("+0.000001")))).isEqualTo(XrpCurrencyAmount.ofDrops(0L));
+    // Decimals (first negative, second negative)
+    assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001"))
+      .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001")))).isEqualTo(XrpCurrencyAmount.ofDrops(2L));
 
     // Overflow
     assertThrows(IllegalStateException.class, () -> {
@@ -282,62 +298,115 @@ public class XrpCurrencyAmountTest {
 
   @Test
   public void minusXrp() {
-    // Positive
-    assertThat(
-      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS)
-        .minus(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS))
-    ).isEqualTo(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS));
-    // Negative
-    assertThat(
-      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1)
-        .minus(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS * -1))
-    ).isEqualTo(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS * -1));
+    // First Positive, Second Positive
+    {
+      XrpCurrencyAmount result = XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS)
+        .minus(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS));
+      assertThat(result).isEqualTo(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS));
+      assertThat(result.value()).isEqualTo(UnsignedLong.valueOf(500_000));
+      assertThat(result.isNegative()).isFalse();
+    }
 
-    // Positive
-    assertThat(
-      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS)
-        .minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS))
-    ).isEqualTo((XrpCurrencyAmount.ofDrops(0L)));
-    // Negative
-    assertThat(
-      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1)
-        .minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1))
-    ).isEqualTo((XrpCurrencyAmount.ofDrops(0L)));
-    assertThat(
-      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1)
-        .minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1))
-    ).isEqualTo((XrpCurrencyAmount.ofDrops(0L)));
+    // First Positive, Second Negative
+    {
+      XrpCurrencyAmount result = XrpCurrencyAmount.ofDrops(NEGATIVE_HALF_XRP_IN_DROPS)
+        .minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1));
+      assertThat(result).isEqualTo(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS));
+      assertThat(result.value()).isEqualTo(UnsignedLong.valueOf(500_000L));
+      assertThat(result.isNegative()).isFalse();
+    }
 
-    assertThat(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS).minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS)))
-      .isEqualTo((XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(500_000L), true)));
-    assertThat(
-      XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS * -1).minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1)))
-      .isEqualTo((XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(500_000L), false)));
+    // First Negative, Second Positive
+    {
+      XrpCurrencyAmount result = XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS)
+        .minus(XrpCurrencyAmount.ofDrops(NEGATIVE_HALF_XRP_IN_DROPS));
+      assertThat(result).isEqualTo(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS));
+      assertThat(result.value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
+      assertThat(result.isNegative()).isFalse();
+    }
+
+    // First Negative, Second Negative
+    {
+      XrpCurrencyAmount result = XrpCurrencyAmount.ofDrops(NEGATIVE_HALF_XRP_IN_DROPS)
+        .minus(XrpCurrencyAmount.ofDrops(NEGATIVE_HALF_XRP_IN_DROPS));
+      assertThat(result).isEqualTo(XrpCurrencyAmount.ofDrops(0));
+      assertThat(result.value()).isEqualTo(UnsignedLong.ZERO);
+      assertThat(result.isNegative()).isFalse();
+    }
+
+    // Decimals (first positive, second positive)
+    assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001"))
+      .minus(XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001")))).isEqualTo(XrpCurrencyAmount.ofDrops(0L));
+    // Decimals (first positive, second negative)
+    assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001"))
+      .minus(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001")))).isEqualTo(XrpCurrencyAmount.ofDrops(2L));
+    // Decimals (first negative, second positive)
+    assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001"))
+      .minus(XrpCurrencyAmount.ofXrp(new BigDecimal("+0.000001")))).isEqualTo(XrpCurrencyAmount.ofDrops(-2L));
+    // Decimals (first negative, second negative)
+    assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001"))
+      .minus(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001")))).isEqualTo(XrpCurrencyAmount.ofDrops(0L));
 
     // Overflow
     assertThrows(IllegalStateException.class, () -> {
-      XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS * -1) // <-- Min drops
-        .minus(XrpCurrencyAmount.ofDrops(1L)); // <-- minus just one more
+      XrpCurrencyAmount.ofDrops(UnsignedLong.MAX_VALUE, true) // <-- Min drops
+        .minus(XrpCurrencyAmount.ofDrops(1L)); // <-- plus just one more
     });
+
+    assertThat(
+      XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS).minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS))).isEqualTo(
+      (XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(500_000L), true)));
+    assertThat(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS * -1)
+      .minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1))).isEqualTo(
+      (XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(500_000L), false)));
   }
 
   @Test
   public void timesXrp() {
     assertThat(
-      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS)
-        .times(XrpCurrencyAmount.ofDrops(TWO_XRP_IN_DROPS))
-    ).isEqualTo(XrpCurrencyAmount.ofDrops(TWO_XRP_IN_DROPS * ONE_XRP_IN_DROPS));
+      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS).times(XrpCurrencyAmount.ofDrops(TWO_XRP_IN_DROPS))).isEqualTo(
+      XrpCurrencyAmount.ofDrops(TWO_XRP_IN_DROPS * ONE_XRP_IN_DROPS));
 
-    assertThat(
-      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS)
-        .times(XrpCurrencyAmount.ofDrops(0L))
-    ).isEqualTo(XrpCurrencyAmount.ofDrops(0L));
+    assertThat(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS).times(XrpCurrencyAmount.ofDrops(0L))).isEqualTo(
+      XrpCurrencyAmount.ofDrops(0L));
 
     // Overflow
     assertThrows(IllegalStateException.class, () -> {
       XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS) // <-- Max drops
         .times(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS));
     });
+
+    // Neither Negative
+    {
+      final XrpCurrencyAmount value = XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(2L), false)
+        .times(XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(3L), false));
+      assertThat(value.value()).isEqualTo(UnsignedLong.valueOf(6L));
+      assertThat(value.isNegative()).isFalse();
+    }
+
+    // First Negative
+    {
+      final XrpCurrencyAmount value = XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(2L), false)
+        .times(XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(3L), true));
+      assertThat(value.value()).isEqualTo(UnsignedLong.valueOf(6L));
+      assertThat(value.isNegative()).isTrue();
+    }
+
+    {
+      // Second Negative
+      final XrpCurrencyAmount value = XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(2L), true)
+        .times(XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(3L), false));
+      assertThat(value.value()).isEqualTo(UnsignedLong.valueOf(6L));
+      assertThat(value.isNegative()).isTrue();
+    }
+
+    {
+      // Both Negative
+      final XrpCurrencyAmount value = XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(2L), true)
+        .times(XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(3L), true));
+      assertThat(value.value()).isEqualTo(UnsignedLong.valueOf(6L));
+      assertThat(value.isNegative()).isTrue();
+    }
   }
 
   @Test

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.transactions;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,86 +41,288 @@ public class XrpCurrencyAmountTest {
 
   @Test
   public void ofDropsLong() {
-    assertThat(XrpCurrencyAmount.ofDrops(0L).value()).isEqualTo(UnsignedLong.ZERO);
-    assertThat(XrpCurrencyAmount.ofDrops(1L).value()).isEqualTo(UnsignedLong.ONE);
-    assertThat(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS).value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
-    assertThat(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS).value()).isEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS));
+    XrpCurrencyAmount xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(0L);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.ZERO);
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(1L);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.ONE);
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS));
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
     assertThrows(IllegalStateException.class, () -> XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS + 1));
   }
 
   @Test
+  public void ofDropsLongNegative() {
+    XrpCurrencyAmount xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(-1L);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.ONE);
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS * -1);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS));
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    assertThrows(IllegalStateException.class, () -> XrpCurrencyAmount.ofDrops((MAX_XRP_IN_DROPS * -1) - 1));
+  }
+
+  @Test
   public void ofDropsUnsignedLong() {
-    assertThat(XrpCurrencyAmount.ofDrops(UnsignedLong.ZERO).value()).isEqualTo(UnsignedLong.ZERO);
-    assertThat(XrpCurrencyAmount.ofDrops(UnsignedLong.ONE).value()).isEqualTo(UnsignedLong.ONE);
-    assertThat(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS).value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
-    assertThat(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS).value()).isEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS));
+    XrpCurrencyAmount xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(UnsignedLong.ZERO);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.ZERO);
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(UnsignedLong.ONE);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.ONE);
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS));
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
 
     // Too big
     assertThrows(IllegalStateException.class,
-      () -> XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(MAX_XRP_IN_DROPS + 1)));
-  }
-
-  @Test
-  public void ofXrpBigDecimal() {
-    assertThat(XrpCurrencyAmount.ofXrp(BigDecimal.ZERO).value()).isEqualTo(UnsignedLong.ZERO);
-    assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001")).value()).isEqualTo(UnsignedLong.ONE);
-    assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("0.1")).value()).isEqualTo(UnsignedLong.valueOf(100000));
-    assertThat(XrpCurrencyAmount.ofXrp(BigDecimal.ONE).value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
-    assertThat(XrpCurrencyAmount.ofXrp(BigDecimal.valueOf(MAX_XRP)).value())
-      .isEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS));
-
-    // Too big
-    assertThrows(IllegalStateException.class, () -> XrpCurrencyAmount.ofXrp(BigDecimal.valueOf(MAX_XRP + 1)));
-    // Too small
-    assertThrows(IllegalArgumentException.class, () -> XrpCurrencyAmount.ofXrp(new BigDecimal("0.0000001")));
-  }
-
-  @Test
-  public void toXrp() {
-    assertThat(XrpCurrencyAmount.ofDrops(0L).toXrp()).isEqualTo(BigDecimal.ZERO);
-    assertThat(XrpCurrencyAmount.ofDrops(1L).toXrp()).isEqualTo(new BigDecimal("0.000001"));
-    assertThat(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS).toXrp()).isEqualTo(BigDecimal.ONE);
-    assertThat(XrpCurrencyAmount.ofDrops(33).toXrp()).isEqualTo(new BigDecimal("0.000033"));
-    assertThat(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS).toXrp()).isEqualTo(new BigDecimal(MAX_XRP));
-
-    // Too small (the largest number with the largest decimal component (99B plus nearly 1 drop)).
-    assertThat(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS - 1).toXrp()).isEqualTo(new BigDecimal("99999999999.999999"));
-  }
-
-  @Test
-  public void plusXrp() {
-    assertThat(
-      XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS)
-        .plus(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS))
-    ).isEqualTo(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS));
-
-    assertThat(
-      XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001"))
-        .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001")))
-    ).isEqualTo(XrpCurrencyAmount.ofDrops(2L));
-  }
-
-  @Test
-  public void minusXrp() {
-    assertThat(
-      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS)
-        .minus(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS))
-    ).isEqualTo(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS));
-
-    assertThat(
-      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS)
-        .minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS))
-    ).isEqualTo((XrpCurrencyAmount.ofDrops(0L)));
-
-    assertThrows(IllegalStateException.class,
-      () -> XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS)
-        .minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS))
+      () -> XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(MAX_XRP_IN_DROPS + 1))
     );
   }
 
   @Test
-  public void timesXrp() {
+  public void ofDropsUnsignedLongNegative() {
+    XrpCurrencyAmount xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(UnsignedLong.ZERO, true);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.ZERO);
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
 
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(UnsignedLong.ONE, true);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.ONE);
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS * -1);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS));
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    // Too big
+    assertThrows(IllegalStateException.class,
+      () -> XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(MAX_XRP_IN_DROPS + 1), true)
+    );
+  }
+
+  @Test
+  public void ofXrpBigDecimal() {
+    XrpCurrencyAmount xrpCurrencyAmount = XrpCurrencyAmount.ofXrp(BigDecimal.ZERO);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.ZERO);
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001"));
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.ONE);
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofXrp(new BigDecimal("0.1"));
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(100000));
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofXrp(BigDecimal.ONE);
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofXrp(BigDecimal.valueOf(MAX_XRP));
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS));
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    // Too big (positive)
+    assertThrows(IllegalArgumentException.class, () -> XrpCurrencyAmount.ofXrp(BigDecimal.valueOf(MAX_XRP + 1)));
+
+    // Too small (positive)
+    assertThrows(IllegalArgumentException.class, () -> XrpCurrencyAmount.ofXrp(new BigDecimal("0.0000001")));
+  }
+
+  @Test
+  public void ofXrpBigDecimalNegative() {
+    XrpCurrencyAmount xrpCurrencyAmount = XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001"));
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.ONE);
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofXrp(new BigDecimal("-0.1"));
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(100000));
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofXrp(BigDecimal.ONE.negate());
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(ONE_XRP_IN_DROPS));
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofXrp(BigDecimal.valueOf(MAX_XRP).negate());
+    assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.valueOf(MAX_XRP_IN_DROPS));
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    // Too small (negative)
+    assertThrows(IllegalArgumentException.class, () -> XrpCurrencyAmount.ofXrp(BigDecimal.valueOf((MAX_XRP * -1) - 1)));
+    // Too big (positive)
+    assertThrows(IllegalArgumentException.class, () -> XrpCurrencyAmount.ofXrp(new BigDecimal("-0.0000001")));
+  }
+
+  @Test
+  public void toXrp() {
+
+    // ////////////////
+    // Zero Value
+    // ////////////////
+
+    XrpCurrencyAmount xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(0L);
+    assertThat(xrpCurrencyAmount.toXrp()).isEqualTo(BigDecimal.ZERO);
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    // ////////////////
+    // Positive Values
+    // ////////////////
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(1L);
+    assertThat(xrpCurrencyAmount.toXrp()).isEqualTo(new BigDecimal("0.000001"));
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS);
+    assertThat(xrpCurrencyAmount.toXrp()).isEqualTo(BigDecimal.ONE);
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(33);
+    assertThat(xrpCurrencyAmount.toXrp()).isEqualTo(new BigDecimal("0.000033"));
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS);
+    assertThat(xrpCurrencyAmount.toXrp()).isEqualTo(new BigDecimal(MAX_XRP));
+    assertThat(xrpCurrencyAmount.isNegative()).isFalse();
+
+    // Too small (the largest number with the largest decimal component (99B plus nearly 1 drop)).
+    assertThat(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS - 1).toXrp()).isEqualTo(new BigDecimal("99999999999.999999"));
+
+    // ////////////////
+    // Negative Values
+    // ////////////////
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(-1L);
+    assertThat(xrpCurrencyAmount.toXrp()).isEqualTo(new BigDecimal("-0.000001"));
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1);
+    assertThat(xrpCurrencyAmount.toXrp()).isEqualTo(BigDecimal.ONE.negate());
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(-33);
+    assertThat(xrpCurrencyAmount.toXrp()).isEqualTo(new BigDecimal("-0.000033"));
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS * -1);
+    assertThat(xrpCurrencyAmount.toXrp()).isEqualTo(new BigDecimal(MAX_XRP * -1));
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+
+    // Too small (the largest number with the largest decimal component (99B plus nearly 1 drop)).
+    xrpCurrencyAmount = XrpCurrencyAmount.ofDrops((MAX_XRP_IN_DROPS * -1) + 1);
+    assertThat(xrpCurrencyAmount.toXrp()).isEqualTo(new BigDecimal("-99999999999.999999"));
+    assertThat(xrpCurrencyAmount.isNegative()).isTrue();
+  }
+
+  @Test
+  public void plusXrp() {
+    // Positive
+    assertThat(
+      XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS)
+        .plus(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS))
+    ).isEqualTo(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS));
+    // Negative
+    assertThat(
+      XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS * -1)
+        .plus(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS * -1))
+    ).isEqualTo(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1));
+
+    // Positive
+    assertThat(
+      XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001"))
+        .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001")))
+    ).isEqualTo(XrpCurrencyAmount.ofDrops(2L));
+    // Negative
+    assertThat(
+      XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001"))
+        .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001")))
+    ).isEqualTo(XrpCurrencyAmount.ofDrops(2L));
+
+    // Positive
+    assertThat(
+      XrpCurrencyAmount.ofXrp(new BigDecimal("0.000001"))
+        .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001")))
+    ).isEqualTo(XrpCurrencyAmount.ofDrops(0L));
+    // Negative
+    assertThat(
+      XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001"))
+        .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("+0.000001")))
+    ).isEqualTo(XrpCurrencyAmount.ofDrops(0L));
+
+    // Overflow
+    assertThrows(IllegalStateException.class, () -> {
+      XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS) // <-- Max drops
+        .plus(XrpCurrencyAmount.ofDrops(1L)); // <-- plus just one more
+    });
+  }
+
+  @Test
+  public void minusXrp() {
+    // Positive
+    assertThat(
+      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS)
+        .minus(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS))
+    ).isEqualTo(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS));
+    // Negative
+    assertThat(
+      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1)
+        .minus(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS * -1))
+    ).isEqualTo(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS * -1));
+
+    // Positive
+    assertThat(
+      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS)
+        .minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS))
+    ).isEqualTo((XrpCurrencyAmount.ofDrops(0L)));
+    // Negative
+    assertThat(
+      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1)
+        .minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1))
+    ).isEqualTo((XrpCurrencyAmount.ofDrops(0L)));
+    assertThat(
+      XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1)
+        .minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1))
+    ).isEqualTo((XrpCurrencyAmount.ofDrops(0L)));
+
+    assertThat(XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS).minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS)))
+      .isEqualTo((XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(500_000L), true)));
+    assertThat(
+      XrpCurrencyAmount.ofDrops(HALF_XRP_IN_DROPS * -1).minus(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1)))
+      .isEqualTo((XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(500_000L), false)));
+
+    // Overflow
+    assertThrows(IllegalStateException.class, () -> {
+      XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS * -1) // <-- Min drops
+        .minus(XrpCurrencyAmount.ofDrops(1L)); // <-- minus just one more
+    });
+  }
+
+  @Test
+  public void timesXrp() {
     assertThat(
       XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS)
         .times(XrpCurrencyAmount.ofDrops(TWO_XRP_IN_DROPS))
@@ -130,11 +332,26 @@ public class XrpCurrencyAmountTest {
       XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS)
         .times(XrpCurrencyAmount.ofDrops(0L))
     ).isEqualTo(XrpCurrencyAmount.ofDrops(0L));
+
+    // Overflow
+    assertThrows(IllegalStateException.class, () -> {
+      XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS) // <-- Max drops
+        .times(XrpCurrencyAmount.ofDrops(MAX_XRP_IN_DROPS));
+    });
   }
 
   @Test
   public void toStringXrp() {
+    // Negative values.
+    assertThat(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS * -1).toString()).isEqualTo("-1000000");
+    assertThat(XrpCurrencyAmount.ofDrops(-2L).toString()).isEqualTo("-2");
+    assertThat(XrpCurrencyAmount.ofDrops(-1L).toString()).isEqualTo("-1");
+    assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("-1")).toString()).isEqualTo("-1000000");
+    assertThat(XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(123456789L), true).toString()).isEqualTo("-123456789");
+
+    // Positive values
     assertThat(XrpCurrencyAmount.ofDrops(ONE_XRP_IN_DROPS).toString()).isEqualTo("1000000");
+    assertThat(XrpCurrencyAmount.ofDrops(2L).toString()).isEqualTo("2");
     assertThat(XrpCurrencyAmount.ofDrops(1L).toString()).isEqualTo("1");
     assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("1")).toString()).isEqualTo("1000000");
     assertThat(XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(123456789L)).toString()).isEqualTo("123456789");

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-354575-metadata.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-354575-metadata.json
@@ -1,0 +1,44 @@
+{
+  "AffectedNodes": [
+    {
+      "ModifiedNode": {
+        "FinalFields": {
+          "Account": "r9dshc2F8SqBdqXSmQHjsSoPN42PLB37ud",
+          "Balance": "1000000450",
+          "Flags": 0,
+          "OwnerCount": 1,
+          "Sequence": 6
+        },
+        "LedgerEntryType": "AccountRoot",
+        "LedgerIndex": "638D03EB088FD660785B1EC9083DBD08DEBF2C40EE50BB805F22E620A99A7B8C",
+        "PreviousFields": {
+          "Balance": "-2298000050"
+        },
+        "PreviousTxnID": "2A52150DF74CD4AA0EBACB2114ED2AA3DEFBF6AA551F6C492E3E0D8BCB3A1CC7",
+        "PreviousTxnLgrSeq": 350621
+      }
+    },
+    {
+      "ModifiedNode": {
+        "FinalFields": {
+          "Account": "rf8kg7r5Fc8cCszGdD2jeUZt2FrgQd76BS",
+          "Balance": "28919651745",
+          "Flags": 0,
+          "OwnerCount": 6,
+          "Sequence": 177
+        },
+        "LedgerEntryType": "AccountRoot",
+        "LedgerIndex": "AD03851218E2ABA52029946E24F17B825EBFD5B51A896FAA20F773DB2944E6EB",
+        "PreviousFields": {
+          "Balance": "32217652255",
+          "Sequence": 176
+        },
+        "PreviousTxnID": "6A26F6A82369C46AC830481B24F51A1D4FC2FF01CEEB83256DED312D996B9857",
+        "PreviousTxnLgrSeq": 354496
+      }
+    }
+  ],
+  "TransactionIndex": 0,
+  "TransactionResult": "tesSUCCESS",
+  "delivered_amount": "unavailable"
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-309936.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-309936.json
@@ -1,0 +1,332 @@
+{
+  "ledger_hash": "03C83A4DA96E1E55F8BE7617CDD405C5A967CE4DFE935602632DFEEF34B20021",
+  "ledger_index": 309936,
+  "validated": true,
+  "ledger": {
+    "account_hash": "9EDFDCFE3349430ED26A250D2AFF44417111C90581C49A4DC3B00C4B35E91EC3",
+    "close_flags": 0,
+    "close_time": 415733640,
+    "close_time_human": "2013-Mar-04 17:34:00.000000000 UTC",
+    "close_time_resolution": 10,
+    "close_time_iso": "2013-03-04T17:34:00Z",
+    "ledger_hash": "03C83A4DA96E1E55F8BE7617CDD405C5A967CE4DFE935602632DFEEF34B20021",
+    "parent_close_time": 415733630,
+    "parent_hash": "7284AE15F5C4345612F2AC5F346AE8D2DB587E73444A45A58F4321605A862AD2",
+    "total_coins": "99999999999810000",
+    "transaction_hash": "B4BD780A1F99BABD9BF4D81CC5E52810E438F67DB36DF7E22A51E53917D58C19",
+    "ledger_index": "309936",
+    "closed": true,
+    "transactions": [
+      {
+        "Account": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+        "Fee": "10",
+        "Flags": 0,
+        "Sequence": 166,
+        "SigningPubKey": "035F89BB1F8E4E302D2BEEA706212E522C3A768FB518F699D033FE2FEAFDF3CA5C",
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "29950"
+        },
+        "TakerPays": "41930000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3046022100980A3F31490873489F9E94B05E70C0F58289959BA90F9E621EDD760E7EB9ECE4022100EFA82611F2DA152A0114F8561D5096BF1312970709C37AD211BA52B6242F3C2E",
+        "hash": "2AEFB8AE33E908C711CBF5887CA2AD19D8B04416EDE9B497520E91A184DE8015",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "BTC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.5996838787749999"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "BTC",
+                    "issuer": "rnfP45Y8G24MaD3Atr2Gt1rYMJFRKbLrpu",
+                    "value": "1"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "BTC",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "1F3D403B78E949DD5911584B35330225E4BD633F575CE8618D045352E59E086D",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "BTC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.4996838787749999"
+                  }
+                },
+                "PreviousTxnID": "B8380B530CE430E4B7476CADB4CE4145236E70F00024CC83433FD6C0C2C54EA1",
+                "PreviousTxnLgrSeq": 309607
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4a13a0d525b2c32f",
+                  "Flags": 0,
+                  "RootIndex": "37AAC93D336021AE94310D0430FFA090F7137C97D473488C4A13A0D525B2C32F",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000004254430000000000",
+                  "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "37AAC93D336021AE94310D0430FFA090F7137C97D473488C4A13A0D525B2C32F"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "BTC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-2.332763112703519"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "BTC",
+                    "issuer": "rPXh6UrSBuLzzqKksZchqM4nC67EhfNnAW",
+                    "value": "0.1"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "BTC",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "9"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "4031F9A72C03C070270CE083A2B926162CCBFD3E509A9DC7063485794040717B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "BTC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.003319535029101"
+                  }
+                },
+                "PreviousTxnID": "015241498F278E64BA5D33B6595ED1A234FCC91E2A0AE5D132F88FDC5B5C5C33",
+                "PreviousTxnLgrSeq": 309609
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rPXh6UrSBuLzzqKksZchqM4nC67EhfNnAW",
+                  "Balance": "1758975750",
+                  "Flags": 0,
+                  "OwnerCount": 7,
+                  "Sequence": 26
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "5116B46EED2C19A05A46225744E5EE6F3FD0F86107D0C303EDEE6B46CAF5251C",
+                "PreviousFields": {
+                  "Balance": "43688975750"
+                },
+                "PreviousTxnID": "8DBE416DCDAEB79D1D32E010044706810439CA5983C5DCFA255FBBDBE6813F72",
+                "PreviousTxnLgrSeq": 309855
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rnfP45Y8G24MaD3Atr2Gt1rYMJFRKbLrpu",
+                  "Balance": "68329222332",
+                  "Flags": 0,
+                  "OwnerCount": 3,
+                  "Sequence": 71
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "7449AA8C7C7C675DF1907EFB7EBD5A06F29E5C9380731E88034D023FED6004C4",
+                "PreviousFields": {
+                  "Balance": "70139222332",
+                  "OwnerCount": 4
+                },
+                "PreviousTxnID": "7E6D9C711E369ED617AD6944C257FE3E0BB9808FCE4882453C4DDA9A1050E6FD",
+                "PreviousTxnLgrSeq": 309894
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5B04F94AE6AF8000",
+                "NewFields": {
+                  "ExchangeRate": "5b04f94ae6af8000",
+                  "RootIndex": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5B04F94AE6AF8000",
+                  "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                  "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rPXh6UrSBuLzzqKksZchqM4nC67EhfNnAW",
+                  "BookDirectory": "37AAC93D336021AE94310D0430FFA090F7137C97D473488C4A13BCBF1834817D",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "Sequence": 25,
+                  "TakerGets": "1070000000",
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0.059444422325582"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "8A79FC48D391DA203FE23F3D18B5EA93C0C7B0309A7642DAA3C635E53DCB0C96",
+                "PreviousFields": {
+                  "TakerGets": "43000000000",
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "2.388888"
+                  }
+                },
+                "PreviousTxnID": "8DBE416DCDAEB79D1D32E010044706810439CA5983C5DCFA255FBBDBE6813F72",
+                "PreviousTxnLgrSeq": 309855
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+                  "RootIndex": "A4CCF7BB3C483549CA8561763E47B8B79602905883BA37ED1CDFCAAACA610032"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "A4CCF7BB3C483549CA8561763E47B8B79602905883BA37ED1CDFCAAACA610032"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rnfP45Y8G24MaD3Atr2Gt1rYMJFRKbLrpu",
+                  "RootIndex": "A5AD177280C7143C208F43CFE55FB532C1F0EDB1ABD0A2EDDD87E4F6C33964B4"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "A5AD177280C7143C208F43CFE55FB532C1F0EDB1ABD0A2EDDD87E4F6C33964B4"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+                  "Balance": "57490014944",
+                  "Flags": 0,
+                  "OwnerCount": 14,
+                  "Sequence": 167
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B0E0E6C5CD61C2AD3CBD1A9A0A9CE75BE6C954B60463C9CB00A1440847DA2A26",
+                "PreviousFields": {
+                  "Balance": "13750014954",
+                  "OwnerCount": 13,
+                  "Sequence": 166
+                },
+                "PreviousTxnID": "2755DADE8153D4B2B55BC2ADCA574FF43F34FD5E8980B5BDEBDA89C519DB32A8",
+                "PreviousTxnLgrSeq": 309935
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "BTC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.242525153474098"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "BTC",
+                    "issuer": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+                    "value": "5"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "BTC",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "C7FC433CE4271915E7FFC4A965CF901091BB64CE438EF4E659F336DF9E684082",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "BTC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-2.676827618303865"
+                  }
+                },
+                "PreviousTxnID": "9EDBA2F5A60AF8B4BAABDE16A62CB7C352231C6603BB0636DF0F40B96565B084",
+                "PreviousTxnLgrSeq": 309911
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "D4DA83BF5667C43FBA4B7088C9A68EBBD1FA623E1BFE26178EA4CDD44C9CD199",
+                "NewFields": {
+                  "Account": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+                  "BookDirectory": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5B04F94AE6AF8000",
+                  "Sequence": 166,
+                  "TakerGets": {
+                    "currency": "BTC",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "29944.7465447634"
+                  },
+                  "TakerPays": "-1810000000"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rnfP45Y8G24MaD3Atr2Gt1rYMJFRKbLrpu",
+                  "BookDirectory": "37AAC93D336021AE94310D0430FFA090F7137C97D473488C4A13A0D525B2C32F",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "7E6D9C711E369ED617AD6944C257FE3E0BB9808FCE4882453C4DDA9A1050E6FD",
+                  "PreviousTxnLgrSeq": 309894,
+                  "Sequence": 70,
+                  "TakerGets": "0",
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "EC379273CDABE3130B7D463E45B7FAE02F4EDC0BA063852C70EA67D2154FDDC3",
+                "PreviousFields": {
+                  "TakerGets": "1810000000",
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0.1"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS"
+        }
+      }
+    ]
+  }
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-309937.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-309937.json
@@ -1,0 +1,107 @@
+{
+  "ledger_hash": "E74BBAF2073EA15CA82C167FA5B9B40D74E5391C218E8473CBF90FEB9C6540DC",
+  "ledger_index": 309937,
+  "validated": true,
+  "ledger": {
+    "account_hash": "2262FF0B721EB1FDFC240C7B46C448154331F999C6F9217042A5B4EC07994E74",
+    "close_flags": 0,
+    "close_time": 415733650,
+    "close_time_human": "2013-Mar-04 17:34:10.000000000 UTC",
+    "close_time_resolution": 10,
+    "close_time_iso": "2013-03-04T17:34:10Z",
+    "ledger_hash": "E74BBAF2073EA15CA82C167FA5B9B40D74E5391C218E8473CBF90FEB9C6540DC",
+    "parent_close_time": 415733640,
+    "parent_hash": "03C83A4DA96E1E55F8BE7617CDD405C5A967CE4DFE935602632DFEEF34B20021",
+    "total_coins": "99999999999809990",
+    "transaction_hash": "DAC1BA6E728658E2F32CC90EB3BB2F8960A01E40FCE74DDA9F85EE67F73BA5ED",
+    "ledger_index": "309937",
+    "closed": true,
+    "transactions": [
+      {
+        "Account": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+        "Fee": "10",
+        "Flags": 0,
+        "OfferSequence": 166,
+        "Sequence": 167,
+        "SigningPubKey": "035F89BB1F8E4E302D2BEEA706212E522C3A768FB518F699D033FE2FEAFDF3CA5C",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "3046022100BD846F2D421026297F7B45F02404DE46D1FFAD9F7D5DE2450713EA9634ECDACA022100C2007DBCCC9F5BD0DFDD20E7CF41B60C4AE64A21E71A66E61FFD6FAC5A17CBDF",
+        "hash": "C4831F0E45EE145DA0B22C012205AB02752F09E5D389B797B9274333B2C96F58",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5b04f94ae6af8000",
+                  "Flags": 0,
+                  "RootIndex": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5B04F94AE6AF8000",
+                  "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                  "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5B04F94AE6AF8000"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+                  "RootIndex": "A4CCF7BB3C483549CA8561763E47B8B79602905883BA37ED1CDFCAAACA610032"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "A4CCF7BB3C483549CA8561763E47B8B79602905883BA37ED1CDFCAAACA610032"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+                  "Balance": "57490014934",
+                  "Flags": 0,
+                  "OwnerCount": 13,
+                  "Sequence": 168
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B0E0E6C5CD61C2AD3CBD1A9A0A9CE75BE6C954B60463C9CB00A1440847DA2A26",
+                "PreviousFields": {
+                  "Balance": "57490014944",
+                  "OwnerCount": 14,
+                  "Sequence": 167
+                },
+                "PreviousTxnID": "2AEFB8AE33E908C711CBF5887CA2AD19D8B04416EDE9B497520E91A184DE8015",
+                "PreviousTxnLgrSeq": 309936
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+                  "BookDirectory": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5B04F94AE6AF8000",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "2AEFB8AE33E908C711CBF5887CA2AD19D8B04416EDE9B497520E91A184DE8015",
+                  "PreviousTxnLgrSeq": 309936,
+                  "Sequence": 166,
+                  "TakerGets": {
+                    "currency": "BTC",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "29944.7465447634"
+                  },
+                  "TakerPays": "-1810000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "D4DA83BF5667C43FBA4B7088C9A68EBBD1FA623E1BFE26178EA4CDD44C9CD199"
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS"
+        }
+      }
+    ]
+  }
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-329212.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-329212.json
@@ -1,0 +1,203 @@
+{
+  "ledger_hash": "ED4395F2C503963E0E9A37F36F5ACC8A60DD9911A1F9E61F71AF555003C1F53B",
+  "ledger_index": 329212,
+  "validated": true,
+  "ledger": {
+    "account_hash": "E74590C886C899E143BB11CED6603320FBE37C2615BE39C64745009F493593BB",
+    "close_flags": 0,
+    "close_time": 416079130,
+    "close_time_human": "2013-Mar-08 17:32:10.000000000 UTC",
+    "close_time_resolution": 10,
+    "close_time_iso": "2013-03-08T17:32:10Z",
+    "ledger_hash": "ED4395F2C503963E0E9A37F36F5ACC8A60DD9911A1F9E61F71AF555003C1F53B",
+    "parent_close_time": 416079130,
+    "parent_hash": "0E2E633067E5E84DE356B24C6BD013EAC3B3282314C15804F84E70D9A1775AD9",
+    "total_coins": "99999999999735980",
+    "transaction_hash": "300F0418146C4D327224DCEDD086BE1BE6D295306E5C21AFD73C3093075D6AB0",
+    "ledger_index": "329212",
+    "closed": true,
+    "transactions": [
+      {
+        "Account": "r9K1rn69htFHPfqnKK4oj9HNVAxbcwntKY",
+        "Amount": {
+          "currency": "USD",
+          "issuer": "r9YcKijXfPWsKrgEP9Ekq3HDCVy53fELDk",
+          "value": "1"
+        },
+        "Destination": "r9YcKijXfPWsKrgEP9Ekq3HDCVy53fELDk",
+        "Fee": "10",
+        "Flags": 0,
+        "Paths": [
+          [
+            {
+              "currency": "USD",
+              "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "type": 48
+            },
+            {
+              "account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "currency": "USD",
+              "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "type": 49
+            }
+          ]
+        ],
+        "SendMax": "1113222000",
+        "Sequence": 3,
+        "SigningPubKey": "0356A4FF55139D6C1DFB2A6E8CB254256034116B0EB154BF7499A7F73B4BA29829",
+        "TransactionType": "Payment",
+        "TxnSignature": "3045022073D9A407B1F17EA885351C065A6F62A4C511AE9F5A51A3B2821E00F2E40ABFF0022100BCCE1E06D16859D7FA2BA363F43D53F2E6E359FE2F7DE43ACECCBC87352B0934",
+        "hash": "601BF344A13AEC8189F72AA4CF8BA89D77D1765BAB2DD85C8A328BDF7F3CE7B8",
+        "DeliverMax": {
+          "currency": "USD",
+          "issuer": "r9YcKijXfPWsKrgEP9Ekq3HDCVy53fELDk",
+          "value": "1"
+        },
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9K1rn69htFHPfqnKK4oj9HNVAxbcwntKY",
+                  "Balance": "-102200030",
+                  "Flags": 0,
+                  "OwnerCount": 1,
+                  "Sequence": 4
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "5330BDBCEF33A1B8F54B879DF09E1FA001AE987C52F41F2ACA41B24AA6314CC7",
+                "PreviousFields": {
+                  "Balance": "999999980",
+                  "Sequence": 3
+                },
+                "PreviousTxnID": "0FAA7703D7E4C15C41427B34E0B70CA2A38427DA02D1BA7613FDC73FF407F929",
+                "PreviousTxnLgrSeq": 329203
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "r9YcKijXfPWsKrgEP9Ekq3HDCVy53fELDk",
+                    "value": "10"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "b"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "552943CD4C3DED0D06935CA5111C7773AD39560325274CAF1E23F976266FD991",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  }
+                },
+                "PreviousTxnID": "B27055EB30D301E7F7604063FED22A8827AE1FBFCA58BEC99D649E6C89695FE9",
+                "PreviousTxnLgrSeq": 327407
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
+                  "BookDirectory": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5E03E871B540C000",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "Sequence": 2,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "7.998"
+                  },
+                  "TakerPays": "8797800000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "590F3478571467150339972AFEDC0AAD35A1D0F6A74902665108BCD8745AC7AA",
+                "PreviousFields": {
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "9"
+                  },
+                  "TakerPays": "9900000000"
+                },
+                "PreviousTxnID": "D39D577069D749C32DBCDDC367266514BA48C0332BDA389BCD1895A7953C3C00",
+                "PreviousTxnLgrSeq": 328425
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
+                  "Balance": "2523199970",
+                  "Flags": 0,
+                  "OwnerCount": 3,
+                  "Sequence": 4
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "F3E119AAA87AF3607CF87F5523BB8278A83BCB4142833288305D767DD30C392A",
+                "PreviousFields": {
+                  "Balance": "1420999970"
+                },
+                "PreviousTxnID": "F37CEB93C0364AEBFD8755D33317F7EDD7B88C3DBA973CC4F36243AA0ED78B18",
+                "PreviousTxnLgrSeq": 329057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-872.166"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
+                    "value": "1000"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "FA1255C2E0407F1945BCF9351257C7C5C28B0F5F09BB81C08D35A03E9F0136BC",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-873.168"
+                  }
+                },
+                "PreviousTxnID": "79DC17C542DBD12849148B2B2E5884CEAC037B1EF58B9A2E3BF18E3F106659A9",
+                "PreviousTxnLgrSeq": 329068
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "unavailable"
+        }
+      }
+    ]
+  }
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-340231.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-340231.json
@@ -1,0 +1,80 @@
+{
+  "ledger_hash": "3FA4E5A1B2DA2F27FD2E3DD3AB7487441F65F4349126F4AFC9F67FD07ECB7D3D",
+  "ledger_index": 340231,
+  "validated": true,
+  "ledger": {
+    "account_hash": "7C25A90966B3A8A2347ED7EB55D3279C25522D07499B960E0D7D72341222E81F",
+    "close_flags": 0,
+    "close_time": 416283500,
+    "close_time_human": "2013-Mar-11 02:18:20.000000000 UTC",
+    "close_time_resolution": 10,
+    "close_time_iso": "2013-03-11T02:18:20Z",
+    "ledger_hash": "3FA4E5A1B2DA2F27FD2E3DD3AB7487441F65F4349126F4AFC9F67FD07ECB7D3D",
+    "parent_close_time": 416283490,
+    "parent_hash": "39AC350BB15FAE233077ED9E3BB6CEEC29D482974EFD6EA259421D885371B4C2",
+    "total_coins": "99999999999703040",
+    "transaction_hash": "7014D5176623A0AB93EC35D9B68356057643A107B51FEE55DA6593D554D09DD1",
+    "ledger_index": "340231",
+    "closed": true,
+    "transactions": [
+      {
+        "Account": "r9YcKijXfPWsKrgEP9Ekq3HDCVy53fELDk",
+        "Amount": "1000000000",
+        "Destination": "r9K1rn69htFHPfqnKK4oj9HNVAxbcwntKY",
+        "Fee": "10",
+        "Flags": 0,
+        "Sequence": 74,
+        "SigningPubKey": "03301ED3A284753C7E35A1F6618C9DACB48F286EF1C34FE61A65DBBF2110B5A280",
+        "TransactionType": "Payment",
+        "TxnSignature": "304402205A8C67F2924943F388A4C109FC84D9569AA9346C4086FAC07511194A1FE19EE30220623A164FFD12FBBDD925A89C924744A0DA437BFBF850F1DF1F2B7011377F6C89",
+        "hash": "7B398C8B381B1E41A1A8703FD628E77EF4F4348BD738061B59F12D4A177AF31F",
+        "DeliverMax": "1000000000",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9YcKijXfPWsKrgEP9Ekq3HDCVy53fELDk",
+                  "Balance": "55848159460",
+                  "Flags": 0,
+                  "OwnerCount": 11,
+                  "Sequence": 75
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "269EECA8308E63FE1250025CBCE8E4E40ED582BCDB14C589900343FBA64DC09B",
+                "PreviousFields": {
+                  "Balance": "56848159470",
+                  "Sequence": 74
+                },
+                "PreviousTxnID": "F46BE9657132EEF71C2D0EBA592C9EBA114410C7C0611CA57A7FBB0F8CD67D5E",
+                "PreviousTxnLgrSeq": 340225
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9K1rn69htFHPfqnKK4oj9HNVAxbcwntKY",
+                  "Balance": "897799970",
+                  "Flags": 0,
+                  "OwnerCount": 1,
+                  "Sequence": 4
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "5330BDBCEF33A1B8F54B879DF09E1FA001AE987C52F41F2ACA41B24AA6314CC7",
+                "PreviousFields": {
+                  "Balance": "-102200030"
+                },
+                "PreviousTxnID": "601BF344A13AEC8189F72AA4CF8BA89D77D1765BAB2DD85C8A328BDF7F3CE7B8",
+                "PreviousTxnLgrSeq": 329212
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "unavailable"
+        }
+      }
+    ]
+  },
+  "status": "success"
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-346610.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-346610.json
@@ -1,0 +1,264 @@
+{
+  "ledger_hash": "D840709E9075A5DC5D2C6D7E45728B76102B3A5CD22BCF4793C47959A3ECEC2A",
+  "ledger_index": 346610,
+  "validated": true,
+  "ledger": {
+    "account_hash": "F22B9796A09B12AE9D7E5D6D41DFDDFE94DA46A3E09F41F342B2A15DB64E8D2A",
+    "close_flags": 0,
+    "close_time": 416404570,
+    "close_time_human": "2013-Mar-12 11:56:10.000000000 UTC",
+    "close_time_resolution": 10,
+    "close_time_iso": "2013-03-12T11:56:10Z",
+    "ledger_hash": "D840709E9075A5DC5D2C6D7E45728B76102B3A5CD22BCF4793C47959A3ECEC2A",
+    "parent_close_time": 416404570,
+    "parent_hash": "3528263F7ABD403C271D4228B98C63E9338B2CC2D216FA416F3FDF4E6B1B5290",
+    "total_coins": "99999999999694430",
+    "transaction_hash": "EEDE419E84D760D70DA07132E8A1945348484DEBB88892F3CA60DA750CE30288",
+    "ledger_index": "346610",
+    "closed": true,
+    "transactions": [
+      {
+        "Account": "rUaJuLc3UXFVjeCuTcy8hhHAjQGwX2E4cS",
+        "Amount": {
+          "currency": "USD",
+          "issuer": "rD1jovjQeEpvaDwn9wKaYokkXXrqo4D23x",
+          "value": "1"
+        },
+        "Destination": "rD1jovjQeEpvaDwn9wKaYokkXXrqo4D23x",
+        "Fee": "10",
+        "Flags": 0,
+        "Paths": [
+          [
+            {
+              "currency": "USD",
+              "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "type": 48
+            },
+            {
+              "account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "currency": "USD",
+              "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "type": 49
+            },
+            {
+              "account": "rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY",
+              "currency": "USD",
+              "issuer": "rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY",
+              "type": 49
+            }
+          ],
+          [
+            {
+              "currency": "USD",
+              "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "type": 48
+            },
+            {
+              "account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "currency": "USD",
+              "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "type": 49
+            },
+            {
+              "account": "r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH",
+              "currency": "USD",
+              "issuer": "r3PDtZSa5LiYp1Ysn1vMuMzB59RzV3W9QH",
+              "type": 49
+            }
+          ]
+        ],
+        "SendMax": "1062621000",
+        "Sequence": 34,
+        "SigningPubKey": "03D4D51B99A9F075A5BEF4E40D251D53103568479DBB490DD2A9D67ECB77E8918E",
+        "TransactionType": "Payment",
+        "TxnSignature": "3045022079AD753AEF2B985089E7CCFABDE83B320321053C7C929C33CE6E2BC2CE451535022100FABBA6BE4436451E1161D0074706D58E39CF3460ECA5D9AD534B13B514E97CC1",
+        "hash": "A0FA864A311D21136D006C7FC7C994E3AB4B2E0279A86D4C5EEE85BEB31A20CF",
+        "DeliverMax": {
+          "currency": "USD",
+          "issuer": "rD1jovjQeEpvaDwn9wKaYokkXXrqo4D23x",
+          "value": "1"
+        },
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUaJuLc3UXFVjeCuTcy8hhHAjQGwX2E4cS",
+                  "Balance": "-751100340",
+                  "Flags": 0,
+                  "OwnerCount": 2,
+                  "Sequence": 35
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "3D7D26A8C51CBC71A9B843CDDA5F893C7F7E38EADC329FBA13DC73E927A61353",
+                "PreviousFields": {
+                  "Balance": "300999670",
+                  "Sequence": 34
+                },
+                "PreviousTxnID": "1F16E6D4ECA7D6248630E67AA1301EDC9FB81EF2BAF95C9A433A343B7524B07B",
+                "PreviousTxnLgrSeq": 346593
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
+                  "BookDirectory": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5E03BAF82D03A000",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "Sequence": 33,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "13.99800002"
+                  },
+                  "TakerPays": "14697900021"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "5EB1066661B05E10F5BD96F64C14180F8045686C48AAAB43F36D7007A3B47B91",
+                "PreviousFields": {
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "15.00000002"
+                  },
+                  "TakerPays": "15750000021"
+                },
+                "PreviousTxnID": "54A0B1129FDBF2E081EF122F61ACE5204C84AA3DD96C6F2B883715D58271FC33",
+                "PreviousTxnLgrSeq": 346566
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rD1jovjQeEpvaDwn9wKaYokkXXrqo4D23x",
+                    "value": "1"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "CB48ED45188BA8E09D16DFF7A56F769A5A74A7A835A0329227FB0629C92FCAEC",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  }
+                },
+                "PreviousTxnID": "C70F6FBAC6F037500E70B3A15CE191DB4CC594804D42F64156BAF95540427C53",
+                "PreviousTxnLgrSeq": 124563
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-473.4592726085959"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY",
+                    "value": "2000"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "E5EB96387A096DC950C07EBD61CA7D60CC8813A03E5186A64BD0B902B680544D",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-472.4592726085959"
+                  }
+                },
+                "PreviousTxnID": "5B2006DAD0B3130F57ACF7CC5CCAC2EEBCD4B57AAA091A6FD0A24B073D08ABB8",
+                "PreviousTxnLgrSeq": 343703
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
+                  "Balance": "509109299609",
+                  "Flags": 0,
+                  "OwnerCount": 7,
+                  "Sequence": 38
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "F3E119AAA87AF3607CF87F5523BB8278A83BCB4142833288305D767DD30C392A",
+                "PreviousFields": {
+                  "Balance": "508057199609"
+                },
+                "PreviousTxnID": "54A0B1129FDBF2E081EF122F61ACE5204C84AA3DD96C6F2B883715D58271FC33",
+                "PreviousTxnLgrSeq": 346566
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-370.15800401364"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
+                    "value": "1000"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "FA1255C2E0407F1945BCF9351257C7C5C28B0F5F09BB81C08D35A03E9F0136BC",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-371.16000401364"
+                  }
+                },
+                "PreviousTxnID": "54A0B1129FDBF2E081EF122F61ACE5204C84AA3DD96C6F2B883715D58271FC33",
+                "PreviousTxnLgrSeq": 346566
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "unavailable"
+        }
+      }
+    ]
+  },
+  "status": "success"
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-350621.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-350621.json
@@ -1,0 +1,203 @@
+{
+  "ledger_hash": "3E6571E1869FD143E6558251007F511CDF008EBA62F585E2B3FFD51191ED4B44",
+  "ledger_index": 350621,
+  "validated": true,
+  "ledger": {
+    "account_hash": "35533F5C97175A8D1FFFA36B128A17467AE5781C761A2D97938634D8C286D160",
+    "close_flags": 0,
+    "close_time": 416481540,
+    "close_time_human": "2013-Mar-13 09:19:00.000000000 UTC",
+    "close_time_resolution": 10,
+    "close_time_iso": "2013-03-13T09:19:00Z",
+    "ledger_hash": "3E6571E1869FD143E6558251007F511CDF008EBA62F585E2B3FFD51191ED4B44",
+    "parent_close_time": 416481530,
+    "parent_hash": "FC7EF5B3579C0BA2A0301156E7788E65768196638517EDABD8400CF9816C8A16",
+    "total_coins": "99999999999689580",
+    "transaction_hash": "1B23E8852E2572A063AEACC46098A77E1C1EC37EEFC3234E203A0F2E5CD886FB",
+    "ledger_index": "350621",
+    "closed": true,
+    "transactions": [
+      {
+        "Account": "r9dshc2F8SqBdqXSmQHjsSoPN42PLB37ud",
+        "Amount": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "3"
+        },
+        "Destination": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+        "DestinationTag": 31,
+        "Fee": "10",
+        "Flags": 0,
+        "Paths": [
+          [
+            {
+              "currency": "USD",
+              "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "type": 48
+            }
+          ],
+          [
+            {
+              "currency": "USD",
+              "issuer": "r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X",
+              "type": 48
+            },
+            {
+              "account": "r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X",
+              "currency": "USD",
+              "issuer": "r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X",
+              "type": 49
+            },
+            {
+              "account": "rJzmMjPrqXW4jjfYvzM6wLkLTmKtd8o8TK",
+              "currency": "USD",
+              "issuer": "rJzmMjPrqXW4jjfYvzM6wLkLTmKtd8o8TK",
+              "type": 49
+            }
+          ],
+          [
+            {
+              "currency": "USD",
+              "issuer": "r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X",
+              "type": 48
+            },
+            {
+              "account": "r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X",
+              "currency": "USD",
+              "issuer": "r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X",
+              "type": 49
+            },
+            {
+              "account": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+              "currency": "USD",
+              "issuer": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+              "type": 49
+            }
+          ]
+        ],
+        "SendMax": "3329970000",
+        "Sequence": 5,
+        "SigningPubKey": "02507E76AF0C75C20ECB7F9DF49F0C2CC9E08B3C6FA87641CC721501C40F23C9B4",
+        "TransactionType": "Payment",
+        "TxnSignature": "304402201E8EC903B7CF3B73E445C2A74DC4D1B503DDF5357AF87B3E863313CB4332204C022052902483992ECDCFBC1BC7535981709972BB8AAEE0DEE8E52303150F7C140544",
+        "hash": "2A52150DF74CD4AA0EBACB2114ED2AA3DEFBF6AA551F6C492E3E0D8BCB3A1CC7",
+        "DeliverMax": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "3"
+        },
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
+                  "BookDirectory": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5E03E788E09BB000",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "Sequence": 58,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "2.648998"
+                  },
+                  "TakerPays": "2911248802"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "3CFB3C79D4F1BDB1EE5245259372576D926D9A875713422F7169A6CC60AFA68B",
+                "PreviousFields": {
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "5.648998"
+                  },
+                  "TakerPays": "6208248802"
+                },
+                "PreviousTxnID": "F4AB442A6D4CBB935D66E1DA7309A5FC71C7143ED4049053EC14E3875B0CF9BF",
+                "PreviousTxnLgrSeq": 348860
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9dshc2F8SqBdqXSmQHjsSoPN42PLB37ud",
+                  "Balance": "-2298000050",
+                  "Flags": 0,
+                  "OwnerCount": 1,
+                  "Sequence": 6
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "638D03EB088FD660785B1EC9083DBD08DEBF2C40EE50BB805F22E620A99A7B8C",
+                "PreviousFields": {
+                  "Balance": "998999960",
+                  "Sequence": 5
+                },
+                "PreviousTxnID": "07D90A1104C2E9F15FC5128A61D6305909D1F63769A88995D8AF07296F19B730",
+                "PreviousTxnLgrSeq": 347590
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
+                  "Balance": "915992302618",
+                  "Flags": 0,
+                  "OwnerCount": 10,
+                  "Sequence": 59
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "F3E119AAA87AF3607CF87F5523BB8278A83BCB4142833288305D767DD30C392A",
+                "PreviousFields": {
+                  "Balance": "912695302618"
+                },
+                "PreviousTxnID": "F4AB442A6D4CBB935D66E1DA7309A5FC71C7143ED4049053EC14E3875B0CF9BF",
+                "PreviousTxnLgrSeq": 348860
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-2.5541638883365"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "r9tGqzZgKxVFvzKFdUqXAqTzazWBUia8Qr",
+                    "value": "1000"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "FA1255C2E0407F1945BCF9351257C7C5C28B0F5F09BB81C08D35A03E9F0136BC",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-5.5541638883365"
+                  }
+                },
+                "PreviousTxnID": "F4AB442A6D4CBB935D66E1DA7309A5FC71C7143ED4049053EC14E3875B0CF9BF",
+                "PreviousTxnLgrSeq": 348860
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "unavailable"
+        }
+      }
+    ]
+  },
+  "status": "success"
+}
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-353674.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-353674.json
@@ -1,0 +1,243 @@
+{
+  "ledger_hash": "892B13707B9031258D57ED9F42BAAC2BD63EC553E177F5DE0F63BD1EE124F24A",
+  "ledger_index": 353674,
+  "validated": true,
+  "ledger": {
+    "account_hash": "72DC7763A9FA2CB5085F0FC03849C14072327E8039327C40A4AD46D846CBCE10",
+    "close_flags": 0,
+    "close_time": 416538380,
+    "close_time_human": "2013-Mar-14 01:06:20.000000000 UTC",
+    "close_time_resolution": 10,
+    "close_time_iso": "2013-03-14T01:06:20Z",
+    "ledger_hash": "892B13707B9031258D57ED9F42BAAC2BD63EC553E177F5DE0F63BD1EE124F24A",
+    "parent_close_time": 416538370,
+    "parent_hash": "88A2EF96EE7501E7C4D5EB3BBF72A76CD477FC7135D2BEE92C743D887AE8B2AB",
+    "total_coins": "99999999999685040",
+    "transaction_hash": "D788C12C6639EEF2F5979B2BFC9522423AE391D0121874B9AF0F46E2DB71684B",
+    "ledger_index": "353674",
+    "closed": true,
+    "transactions": [
+      {
+        "Account": "rUrdFHbrEKWNQQ444zcTLrThjcnHCw2FPu",
+        "Amount": {
+          "currency": "USD",
+          "issuer": "r3CxMDQFX1Atq1vQN5sqVsjm3rawGSwd32",
+          "value": "1"
+        },
+        "Destination": "r3CxMDQFX1Atq1vQN5sqVsjm3rawGSwd32",
+        "Fee": "10",
+        "Flags": 0,
+        "Paths": [
+          [
+            {
+              "currency": "USD",
+              "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "type": 48
+            },
+            {
+              "account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "currency": "USD",
+              "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "type": 49
+            }
+          ],
+          [
+            {
+              "currency": "USD",
+              "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "type": 48
+            },
+            {
+              "account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "currency": "USD",
+              "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+              "type": 49
+            },
+            {
+              "account": "rGwUWgN5BEg3QGNY3RX2HfYowjUTZdid3E",
+              "currency": "USD",
+              "issuer": "rGwUWgN5BEg3QGNY3RX2HfYowjUTZdid3E",
+              "type": 49
+            }
+          ],
+          [
+            {
+              "currency": "USD",
+              "issuer": "r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X",
+              "type": 48
+            },
+            {
+              "account": "r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X",
+              "currency": "USD",
+              "issuer": "r9vbV3EHvXWjSkeQ6CAcYVPGeq7TuiXY2X",
+              "type": 49
+            },
+            {
+              "account": "rUrdFHbrEKWNQQ444zcTLrThjcnHCw2FPu",
+              "currency": "USD",
+              "issuer": "rUrdFHbrEKWNQQ444zcTLrThjcnHCw2FPu",
+              "type": 49
+            }
+          ]
+        ],
+        "SendMax": "2833656000",
+        "Sequence": 86,
+        "SigningPubKey": "02D9F014E50D5170E1A0BF1C6AD2DF4BE58F2494AAA93FB434E49751249A34BEC2",
+        "TransactionType": "Payment",
+        "TxnSignature": "3045022100DDC847FE6F7B20A81154A8A7166C53C986D746D83AC9DF98773EC53B54D91B3502203F71376384ADF3C1149091A897EE5EA5605871A19E155E021518C91E7F4B2F26",
+        "hash": "9FA055C9881AB3A75754ABD1D58BE9428984CBA04C819CD22425CB37FF12C5A7",
+        "DeliverMax": {
+          "currency": "USD",
+          "issuer": "r3CxMDQFX1Atq1vQN5sqVsjm3rawGSwd32",
+          "value": "1"
+        },
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-68.9898627051293"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+                    "value": "550"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "7"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "06767B34F2F4A94EFE1DB316D77C4224693553509CFF41C96836889C803FF270",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-69.9918627051293"
+                  }
+                },
+                "PreviousTxnID": "DD5CA7C0DF6C11F1DA4CCCC25ED505153E0159454F9F05AC9ADBED04EE57024A",
+                "PreviousTxnLgrSeq": 353550
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1.1"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "r3CxMDQFX1Atq1vQN5sqVsjm3rawGSwd32",
+                    "value": "10"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "1"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "4BD739A825FCF568F9B07C1F21C87FE3AD09C357382B6A260B9CE22B790A31AD",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.1"
+                  }
+                },
+                "PreviousTxnID": "688BA771B2E3F37322498752AE3FD38704C629F76369B59E118863C2ECE10753",
+                "PreviousTxnLgrSeq": 353670
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+                  "BookDirectory": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5E09F295CD5F0000",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "Sequence": 535,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "48.998"
+                  },
+                  "TakerPays": "137194400000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "968615101FBEB9AB92F16CE2D2695A6D4B2E23E760562B9A658C4FC49E10FE53",
+                "PreviousFields": {
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "50"
+                  },
+                  "TakerPays": "140000000000"
+                },
+                "PreviousTxnID": "01A750CB169D2694400705D2D49F12CB4ADB3E756B3E25DBF20F52F34ED62F1A",
+                "PreviousTxnLgrSeq": 353281
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9uVRhJEKsJVaxsU3c3rimzLWKYRmDUcX2",
+                  "Balance": "203699293039",
+                  "Flags": 0,
+                  "OwnerCount": 17,
+                  "Sequence": 539
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B0E0E6C5CD61C2AD3CBD1A9A0A9CE75BE6C954B60463C9CB00A1440847DA2A26",
+                "PreviousFields": {
+                  "Balance": "200893693039"
+                },
+                "PreviousTxnID": "C0AF5F753DDCD9235A4CEBFC1A80B047F566ED5A45924B89D326342DDC6C3EB1",
+                "PreviousTxnLgrSeq": 353672
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUrdFHbrEKWNQQ444zcTLrThjcnHCw2FPu",
+                  "Balance": "-1925600140",
+                  "Flags": 0,
+                  "OwnerCount": 7,
+                  "Sequence": 87
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E618B57684430D15BEF53C52337E42E7C0F9D63D29BC54204E2255279F74D8F0",
+                "PreviousFields": {
+                  "Balance": "879999870",
+                  "Sequence": 86
+                },
+                "PreviousTxnID": "15108EFBF1032C659EC45FA194FCAFAE2F580EC66F7581907BA37B9BDEF78EFF",
+                "PreviousTxnLgrSeq": 353667
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "unavailable"
+        }
+      }
+    ]
+  },
+  "status": "success"
+}
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-354496.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-354496.json
@@ -1,0 +1,81 @@
+{
+  "ledger_hash": "BD93D52FDDE2E57825FC038B6CE8B19F22388FC2D96161AB75844A5D793113AE",
+  "ledger_index": 354496,
+  "validated": true,
+  "ledger": {
+    "account_hash": "0B5C50B5114C972A12FA4C7E0A09EDE99E0D276022300D2EE336DAA519A0F5C9",
+    "close_flags": 0,
+    "close_time": 416554300,
+    "close_time_human": "2013-Mar-14 05:31:40.000000000 UTC",
+    "close_time_resolution": 10,
+    "close_time_iso": "2013-03-14T05:31:40Z",
+    "ledger_hash": "BD93D52FDDE2E57825FC038B6CE8B19F22388FC2D96161AB75844A5D793113AE",
+    "parent_close_time": 416554290,
+    "parent_hash": "28C8B0747E1130472DF604608D81F18AF296EDE9AC5AA1B5CDBCE34A59F6D5D5",
+    "total_coins": "99999999999684600",
+    "transaction_hash": "2C3E4E32DD3232FFC48D939AEDB5796260E8BBD84840372D216BFCF7F0EF5D84",
+    "ledger_index": "354496",
+    "closed": true,
+    "transactions": [
+      {
+        "Account": "rf8kg7r5Fc8cCszGdD2jeUZt2FrgQd76BS",
+        "Amount": "2805600000",
+        "Destination": "rUrdFHbrEKWNQQ444zcTLrThjcnHCw2FPu",
+        "Fee": "10",
+        "Flags": 0,
+        "Sequence": 175,
+        "SigningPubKey": "0253634FDEC7DB331E6BB257D8064C627A5502356ECE1EDCD2EA49980BA519D89E",
+        "TransactionType": "Payment",
+        "TxnSignature": "304502204F69E22AE00BC29DAA4D0987476947B649D3C3CDA20A6C08602710A50F8D935C02210080ABBEA45479E94FBD7D89810586F84C04501E75C8112AAEE407D0A7BA7D4139",
+        "hash": "6A26F6A82369C46AC830481B24F51A1D4FC2FF01CEEB83256DED312D996B9857",
+        "DeliverMax": "2805600000",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rf8kg7r5Fc8cCszGdD2jeUZt2FrgQd76BS",
+                  "Balance": "32217652255",
+                  "Flags": 0,
+                  "OwnerCount": 6,
+                  "Sequence": 176
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AD03851218E2ABA52029946E24F17B825EBFD5B51A896FAA20F773DB2944E6EB",
+                "PreviousFields": {
+                  "Balance": "35023252265",
+                  "Sequence": 175
+                },
+                "PreviousTxnID": "04FE7B2FA375BBE1F0A5AD4EC820596DC27F0BC5E1F292CE487C32DAA965396F",
+                "PreviousTxnLgrSeq": 343923
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUrdFHbrEKWNQQ444zcTLrThjcnHCw2FPu",
+                  "Balance": "879999860",
+                  "Flags": 0,
+                  "OwnerCount": 7,
+                  "Sequence": 87
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E618B57684430D15BEF53C52337E42E7C0F9D63D29BC54204E2255279F74D8F0",
+                "PreviousFields": {
+                  "Balance": "-1925600140"
+                },
+                "PreviousTxnID": "9FA055C9881AB3A75754ABD1D58BE9428984CBA04C819CD22425CB37FF12C5A7",
+                "PreviousTxnLgrSeq": 353674
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "unavailable"
+        }
+      }
+    ]
+  },
+  "status": "success"
+}
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-354575.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-354575.json
@@ -1,0 +1,81 @@
+{
+  "ledger_hash": "4D08EE303097D13775C22674672527055625E8115635C0A0FF8BA714F9474286",
+  "ledger_index": 354575,
+  "validated": true,
+  "ledger": {
+    "account_hash": "ED11EF4CBBBB152C2F45A07EFA1FC86C29068519211D8443EAFD1C4F3C0A352D",
+    "close_flags": 0,
+    "close_time": 416555790,
+    "close_time_human": "2013-Mar-14 05:56:30.000000000 UTC",
+    "close_time_resolution": 10,
+    "close_time_iso": "2013-03-14T05:56:30Z",
+    "ledger_hash": "4D08EE303097D13775C22674672527055625E8115635C0A0FF8BA714F9474286",
+    "parent_close_time": 416555780,
+    "parent_hash": "F85AB637EBDA8B1E9D4DD356E33191F6CAF4C674B85DA413BAB644184320FBC8",
+    "total_coins": "99999999999684550",
+    "transaction_hash": "6F180DBF7FD1CD412ACEC8CFFC39F451392060E1592FCCDF23E3C3DBEB527F86",
+    "ledger_index": "354575",
+    "closed": true,
+    "transactions": [
+      {
+        "Account": "rf8kg7r5Fc8cCszGdD2jeUZt2FrgQd76BS",
+        "Amount": "3298000500",
+        "Destination": "r9dshc2F8SqBdqXSmQHjsSoPN42PLB37ud",
+        "Fee": "10",
+        "Flags": 0,
+        "Sequence": 176,
+        "SigningPubKey": "0253634FDEC7DB331E6BB257D8064C627A5502356ECE1EDCD2EA49980BA519D89E",
+        "TransactionType": "Payment",
+        "TxnSignature": "3045022100BED9B7F2430B50E2B908BCF42AE83ACA3929F306CF88305B4D469BBB1444FCA302202BC2979255BEFF49D4017712032136E9D40BDE719D8001526EF9C436B16A4FFF",
+        "hash": "54288E8EF04C365E0B54DF99D77D443A87949D194620182AD110781BD02C8A33",
+        "DeliverMax": "3298000500",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9dshc2F8SqBdqXSmQHjsSoPN42PLB37ud",
+                  "Balance": "1000000450",
+                  "Flags": 0,
+                  "OwnerCount": 1,
+                  "Sequence": 6
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "638D03EB088FD660785B1EC9083DBD08DEBF2C40EE50BB805F22E620A99A7B8C",
+                "PreviousFields": {
+                  "Balance": "-2298000050"
+                },
+                "PreviousTxnID": "2A52150DF74CD4AA0EBACB2114ED2AA3DEFBF6AA551F6C492E3E0D8BCB3A1CC7",
+                "PreviousTxnLgrSeq": 350621
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rf8kg7r5Fc8cCszGdD2jeUZt2FrgQd76BS",
+                  "Balance": "28919651745",
+                  "Flags": 0,
+                  "OwnerCount": 6,
+                  "Sequence": 177
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AD03851218E2ABA52029946E24F17B825EBFD5B51A896FAA20F773DB2944E6EB",
+                "PreviousFields": {
+                  "Balance": "32217652255",
+                  "Sequence": 176
+                },
+                "PreviousTxnID": "6A26F6A82369C46AC830481B24F51A1D4FC2FF01CEEB83256DED312D996B9857",
+                "PreviousTxnLgrSeq": 354496
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "unavailable"
+        }
+      }
+    ]
+  },
+  "status": "success"
+}
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-354579.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-354579.json
@@ -1,0 +1,81 @@
+{
+  "ledger_hash": "024BA9BD6BF8C5289C19F742514168701523975B261198EDC6707B9032B051D1",
+  "ledger_index": 354579,
+  "validated": true,
+  "ledger": {
+    "account_hash": "441C914856853B60371A3FECFA85B6FF97455A4D50EAB21BF8B4755C2370FF9B",
+    "close_flags": 0,
+    "close_time": 416555860,
+    "close_time_human": "2013-Mar-14 05:57:40.000000000 UTC",
+    "close_time_resolution": 10,
+    "close_time_iso": "2013-03-14T05:57:40Z",
+    "ledger_hash": "024BA9BD6BF8C5289C19F742514168701523975B261198EDC6707B9032B051D1",
+    "parent_close_time": 416555850,
+    "parent_hash": "1C70CC7CFA52FAEEBC1E2043610A4180936F410CDB96FA6E639B99BB422E6F9F",
+    "total_coins": "99999999999684540",
+    "transaction_hash": "01A4A38A92CE64F1BA1FDA669C1F040FD08585241307BC41490619486FC9CB82",
+    "ledger_index": "354579",
+    "closed": true,
+    "transactions": [
+      {
+        "Account": "rf8kg7r5Fc8cCszGdD2jeUZt2FrgQd76BS",
+        "Amount": "1751100340",
+        "Destination": "rUaJuLc3UXFVjeCuTcy8hhHAjQGwX2E4cS",
+        "Fee": "10",
+        "Flags": 0,
+        "Sequence": 177,
+        "SigningPubKey": "0253634FDEC7DB331E6BB257D8064C627A5502356ECE1EDCD2EA49980BA519D89E",
+        "TransactionType": "Payment",
+        "TxnSignature": "3045022100CDA321E743BFABB86BB26814AEE6A251701EDD762B8ECC09B55C8C27B3C5429702200CC7FC77B52FCB3621A6461043255BCA8BD3B0AA201BD95E569673AE087B0F25",
+        "hash": "E3351344532351B0A578AEF474BCC9C4F8EC368877D2AD1420F3B3F4BD40EABF",
+        "DeliverMax": "1751100340",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUaJuLc3UXFVjeCuTcy8hhHAjQGwX2E4cS",
+                  "Balance": "1000000000",
+                  "Flags": 0,
+                  "OwnerCount": 2,
+                  "Sequence": 35
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "3D7D26A8C51CBC71A9B843CDDA5F893C7F7E38EADC329FBA13DC73E927A61353",
+                "PreviousFields": {
+                  "Balance": "-751100340"
+                },
+                "PreviousTxnID": "A0FA864A311D21136D006C7FC7C994E3AB4B2E0279A86D4C5EEE85BEB31A20CF",
+                "PreviousTxnLgrSeq": 346610
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rf8kg7r5Fc8cCszGdD2jeUZt2FrgQd76BS",
+                  "Balance": "27168551395",
+                  "Flags": 0,
+                  "OwnerCount": 6,
+                  "Sequence": 178
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AD03851218E2ABA52029946E24F17B825EBFD5B51A896FAA20F773DB2944E6EB",
+                "PreviousFields": {
+                  "Balance": "28919651745",
+                  "Sequence": 177
+                },
+                "PreviousTxnID": "54288E8EF04C365E0B54DF99D77D443A87949D194620182AD110781BD02C8A33",
+                "PreviousTxnLgrSeq": 354575
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "unavailable"
+        }
+      }
+    ]
+  },
+  "status": "success"
+}
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-87704323.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-87704323.json
@@ -1,0 +1,2870 @@
+{
+  "ledger_hash": "BAA4AF508E9A9CB7685D9E61B82486681E52E9B920904B0650499497F050D8FA",
+  "ledger_index": 87704323,
+  "validated": true,
+  "ledger": {
+    "account_hash": "7DAE592D1BEA699144927AAAC8ED093D6C77A87A577AE6BFCEBC6CF63149A181",
+    "close_flags": 0,
+    "close_time": 767945182,
+    "close_time_human": "2024-May-02 06:06:22.000000000 UTC",
+    "close_time_resolution": 10,
+    "close_time_iso": "2024-05-02T06:06:22Z",
+    "ledger_hash": "BAA4AF508E9A9CB7685D9E61B82486681E52E9B920904B0650499497F050D8FA",
+    "parent_close_time": 767945181,
+    "parent_hash": "57EE5B4098CC7B59A1EF983A9FFCA60DB95D6C953B866E5938DAD54297F57298",
+    "total_coins": "99987623645747962",
+    "transaction_hash": "85080CCE30323594FEAA76D397F7690573B6734C0BFFE7ECCD47414714DC4400",
+    "ledger_index": "87704323",
+    "closed": true,
+    "transactions": [
+      {
+        "Account": "rGXryA5DxQcoG746yr2NQ89yKXMyah7FTm",
+        "Amount": "1",
+        "Destination": "rxRpSNb1VktvzBz8JF2oJC6qaww6RZ7Lw",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 87704341,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7B226F70223A226D696E74222C22616D6F756E74223A22313030303030303030222C22677061223A2230227D"
+            }
+          }
+        ],
+        "Sequence": 85179688,
+        "SigningPubKey": "EDE28110466D80F835079E13325839F8E80A7B50F7977BB7102B80E08CFFC88BF3",
+        "TransactionType": "Payment",
+        "TxnSignature": "1D2AE472E8C8A370E2F5E0F8A40F5523D64D0677E756574FF6980241237EE12CCC75575957746DB564C705746442E3C9B1758E7689D50F7E65C4DC20FC2BB70F",
+        "hash": "066738E2C59D0E72D07B50EB61C628A835538090450FC772941E694AE900F0E0",
+        "DeliverMax": "1",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rxRpSNb1VktvzBz8JF2oJC6qaww6RZ7Lw",
+                  "Balance": "11634269590",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 84788621
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "91A852CE8B4D796D39743843FE1B1E8E597203E607EEAEF67CE78207C1EC892A",
+                "PreviousFields": {
+                  "Balance": "11634269589"
+                },
+                "PreviousTxnID": "E21A9F1B2D24C6A72F4A096A56DF545C821A6803751224AD511F5F27654ABCD9",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rGXryA5DxQcoG746yr2NQ89yKXMyah7FTm",
+                  "Balance": "10055800",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 85179689
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BD43DDD5DC11B248DCDF6DEC306EEDE2381F11F844826A58EC506F68966E4C29",
+                "PreviousFields": {
+                  "Balance": "10055811",
+                  "Sequence": 85179688
+                },
+                "PreviousTxnID": "22CF1B41785BBE3E91CC1B30A95C9853D9F61CF07E135F17AC60A883B3EB4EC9",
+                "PreviousTxnLgrSeq": 87704221
+              }
+            }
+          ],
+          "TransactionIndex": 21,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "1"
+        }
+      },
+      {
+        "Account": "rLuiHsHsdFn4HscaGf4kR429bWmsj2wfBw",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 87704336,
+        "OfferSequence": 86995101,
+        "Sequence": 0,
+        "SigningPubKey": "EDCC84393BB4993742B0DD43137EFDA09B62FF45FE0AA75A2780999AA64792F9DC",
+        "TakerGets": "10865762",
+        "TakerPays": {
+          "currency": "BCH",
+          "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+          "value": "0.0219057"
+        },
+        "TicketSequence": 86995083,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "DC01C6B36DC5736ACE22D29B148EAFA3093EA02FA73DCF55759C98A8A7FC3DE05D147025673CCD96007262CA9A5502B8140DAE61366C0AC4DF6FADE62A445B05",
+        "hash": "0A0362FC53C64E56EC9A27ADA54B6798F39C13A7C31A3FE9EABEDFFB6F352638",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "13e3",
+                  "IndexPrevious": "13e0",
+                  "Owner": "rLuiHsHsdFn4HscaGf4kR429bWmsj2wfBw",
+                  "RootIndex": "BBE1F078DB2815FC774207E7FF6BD45967F4B716620165109FE398A9A585642F"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "4B79E72C776326D60A37B59F7DB52A7D84951900095E0AED18B61F5050FA6B82"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rLuiHsHsdFn4HscaGf4kR429bWmsj2wfBw",
+                  "BookDirectory": "F494F072B110B6E7CF1684EE7A18202DFA2BE765DAC783994C07299184218F20",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "13e3",
+                  "PreviousTxnID": "2DFE2B0DE860E71BE3C45339F2A46BA1C671602B289C83500ADEF7D1EEC0D11D",
+                  "PreviousTxnLgrSeq": 87704319,
+                  "Sequence": 86995101,
+                  "TakerGets": "10865762",
+                  "TakerPays": {
+                    "currency": "BCH",
+                    "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+                    "value": "0.0219057"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "72EF86E59777A035D8ADE7A8D631D15E250A137187F148D19F4AF12824BC1C77"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "A896E7086132629ECEC3EFCE40F1E20EF772045FA6E7B93763F5EA8B0BAC3D22",
+                "NewFields": {
+                  "Account": "rLuiHsHsdFn4HscaGf4kR429bWmsj2wfBw",
+                  "BookDirectory": "F494F072B110B6E7CF1684EE7A18202DFA2BE765DAC783994C07299184218F20",
+                  "OwnerNode": "13e3",
+                  "Sequence": 86995083,
+                  "TakerGets": "10865762",
+                  "TakerPays": {
+                    "currency": "BCH",
+                    "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+                    "value": "0.0219057"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rLuiHsHsdFn4HscaGf4kR429bWmsj2wfBw",
+                  "Balance": "704648815",
+                  "Flags": 0,
+                  "OwnerCount": 59,
+                  "Sequence": 86995125,
+                  "TicketCount": 23
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C156E65B4B489F0025602247572FF26AF4D251F0B6F8E36A559AF7D8EBFAD058",
+                "PreviousFields": {
+                  "Balance": "704648827",
+                  "OwnerCount": 60,
+                  "TicketCount": 24
+                },
+                "PreviousTxnID": "2DFE2B0DE860E71BE3C45339F2A46BA1C671602B289C83500ADEF7D1EEC0D11D",
+                "PreviousTxnLgrSeq": 87704319
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rLuiHsHsdFn4HscaGf4kR429bWmsj2wfBw",
+                  "Flags": 0,
+                  "OwnerNode": "13e2",
+                  "PreviousTxnID": "E6D3CDD13612EC7E5549F2D3C541EE6E7ED8E2D73025ED15DEB02DF34E3674E9",
+                  "PreviousTxnLgrSeq": 87704177,
+                  "TicketSequence": 86995083
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "ED7B90CBD84C280F50332D8B413438EC2DBE07CF386E6218D9B7D98748265554"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "13e2",
+                  "Owner": "rLuiHsHsdFn4HscaGf4kR429bWmsj2wfBw",
+                  "RootIndex": "BBE1F078DB2815FC774207E7FF6BD45967F4B716620165109FE398A9A585642F"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F267691ED88BC529D77BDB6C735CBB04E8A2F816E6FFEEE07EE563D3FF35B68F"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4c07299184218f20",
+                  "Flags": 0,
+                  "RootIndex": "F494F072B110B6E7CF1684EE7A18202DFA2BE765DAC783994C07299184218F20",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000004243480000000000",
+                  "TakerPaysIssuer": "06CDAB9869053E0AC7764D9ACB35B182CB195414"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F494F072B110B6E7CF1684EE7A18202DFA2BE765DAC783994C07299184218F20"
+              }
+            }
+          ],
+          "TransactionIndex": 13,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 87704324,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "58CE24DCA19D871DFB54FDACFFED6A3184D0B109051FF5573FCED7516C6B78F040A2D25C857BDC68408223DBFF04577E3FF00068DB8BAC71"
+            }
+          }
+        ],
+        "Sequence": 1051569,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "534F4C4F00000000000000000000000000000000",
+          "issuer": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz",
+          "value": "0.0413889137045704"
+        },
+        "TakerPays": "10",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3142A742CD469D06D3368387CF1201B4F7158B92B6A26279CD6E16FEA60B55DF91F68CEC6221F3BCCE18C6333F2FFFC9B92DB4A46B299D89860B01114EAF5406",
+        "hash": "0D7A50E2A21FAD029901F6EED3252022C7CBFA8D00F92067EEC97DE9A5513CDA",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9aZRryD8AZzGqQjYrQQuBBzebjF555Xsa",
+                  "Balance": "23043414112",
+                  "Flags": 0,
+                  "OwnerCount": 15,
+                  "Sequence": 85980546
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "547BD7E3B75FDEE721B73AED1D39AD94D3250E520358CC6521F39F15C6ADE46D",
+                "PreviousFields": {
+                  "Balance": "23043424085"
+                },
+                "PreviousTxnID": "DAD2D087DDD04A9BB8ECA61B729DB8CA2030C8F6BDA1541C84C5155C247AD9A7",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-124703.6207428336"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "r9aZRryD8AZzGqQjYrQQuBBzebjF555Xsa",
+                    "value": "100000000"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz",
+                    "value": "0"
+                  },
+                  "LowNode": "3778"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "BF2F4026A88BF068A5DF2ADF7A22C67193DE3E57CAE95C520EE83D02EDDADE64",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-124703.5793539199"
+                  }
+                },
+                "PreviousTxnID": "DAD2D087DDD04A9BB8ECA61B729DB8CA2030C8F6BDA1541C84C5155C247AD9A7",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "0D7A50E2A21FAD029901F6EED3252022C7CBFA8D00F92067EEC97DE9A5513CDA",
+                  "Balance": "2308715152",
+                  "Flags": 0,
+                  "OwnerCount": 117,
+                  "Sequence": 1051570
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "43EF2B13198A3B43617B4A6BD0578CCFFA0F3C77A9BE9409D13AE1CE5328170C",
+                  "Balance": "2308705189",
+                  "Sequence": 1051569
+                },
+                "PreviousTxnID": "43EF2B13198A3B43617B4A6BD0578CCFFA0F3C77A9BE9409D13AE1CE5328170C",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-74.59653561435723"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "7",
+                  "LowLimit": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz",
+                    "value": "0"
+                  },
+                  "LowNode": "3845"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "E56AB275B511ECDF6E9C9D8BE9404F3FECBE5C841770584036FF8A832AF3F3B9",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-74.63792866695317"
+                  }
+                },
+                "PreviousTxnID": "43EF2B13198A3B43617B4A6BD0578CCFFA0F3C77A9BE9409D13AE1CE5328170C",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9aZRryD8AZzGqQjYrQQuBBzebjF555Xsa",
+                  "BookDirectory": "C73FAC6C294EBA5B9E22A8237AAE80725E85372510A6CA794F0EBEAEC6831F8F",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "Sequence": 85980503,
+                  "TakerGets": "580472447",
+                  "TakerPays": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz",
+                    "value": "2409.139316987112"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "ECE990B65D79F743A2D370DB71784CEF2CFA92FD44234CAEA744A2CE9BD0AB0A",
+                "PreviousFields": {
+                  "TakerGets": "580482420",
+                  "TakerPays": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz",
+                    "value": "2409.180705900817"
+                  }
+                },
+                "PreviousTxnID": "DAD2D087DDD04A9BB8ECA61B729DB8CA2030C8F6BDA1541C84C5155C247AD9A7",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            }
+          ],
+          "TransactionIndex": 11,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+        "Expiration": 767948783,
+        "Fee": "20",
+        "Flags": 2148073472,
+        "LastLedgerSequence": 87704324,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7768616C655F33"
+            }
+          }
+        ],
+        "OfferSequence": 50707527,
+        "Sequence": 50707531,
+        "SigningPubKey": "02E729FFD554E5254291CB033D0CC08B32D6A3795A747C5F4F7DFECA20B616B6BF",
+        "TakerGets": "2760955645",
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+          "value": "0.025567"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3044022046DEBE67A662470BA10D72E9E97D830334AC4B4887BD5A2587B7A253C401527002201EE4F8C9DFC8DF308371FD12851B08F5BD2AD89E130CA701B5E76559B0BC53DB",
+        "hash": "132967F342CDEA13876E83F91478D8A7A01928EF269DB324972DD5AEA1B6234A",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "49209317154a2a50",
+                  "Flags": 0,
+                  "RootIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E270150749209317154A2A50",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000004254430000000000",
+                  "TakerPaysIssuer": "06A148131B436B2561C85967685B098E050EED4E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E270150749209317154A2A50"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E27015074920E61A33F2843F",
+                "NewFields": {
+                  "ExchangeRate": "4920e61a33f2843f",
+                  "RootIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E27015074920E61A33F2843F",
+                  "TakerPaysCurrency": "0000000000000000000000004254430000000000",
+                  "TakerPaysIssuer": "06A148131B436B2561C85967685B098E050EED4E"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "BookDirectory": "036D7E923EF22B65E19D95A6365C3373E1E96586E270150749209317154A2A50",
+                  "BookNode": "0",
+                  "Expiration": 767948779,
+                  "Flags": 196608,
+                  "OwnerNode": "654",
+                  "PreviousTxnID": "1F63D4EC8240565048833E56FD5762BDBF869D14790EED05D77EE77E3566D7F9",
+                  "PreviousTxnLgrSeq": 87704322,
+                  "Sequence": 50707527,
+                  "TakerGets": "2760955681",
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.025315"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "0F2EB8AB72294D9A094B3F48BE35A28A7A6D8A4375622E5C852C2121C808D9A3"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "6B8D13047DE4B3DBD4B53493E8F3F22F607A1B27DC8D034F0C114890AB82BE82",
+                "NewFields": {
+                  "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "BookDirectory": "036D7E923EF22B65E19D95A6365C3373E1E96586E27015074920E61A33F2843F",
+                  "Expiration": 767948783,
+                  "Flags": 196608,
+                  "OwnerNode": "654",
+                  "Sequence": 50707531,
+                  "TakerGets": "2760955645",
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.025567"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "651",
+                  "Owner": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "RootIndex": "8D47835C2516C1F8F28A43C140356DA142DEB58CA29EF27212ECE6DCFC4472C7"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9A7EE90E967B2FE985037889A13CC4240A3EECB1D7DFCF76B0E0950AFF099AA4"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "Balance": "6335456911",
+                  "Flags": 0,
+                  "MessageKey": "02000000000000000000000000F3AE90A6141CEB9C639BA74FC024278306F6D42E",
+                  "OwnerCount": 33,
+                  "Sequence": 50707532
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E938FF495007E7C01911CDFDA087111CD0130C8A6FDACCCB34914636A31486C5",
+                "PreviousFields": {
+                  "Balance": "6335456931",
+                  "Sequence": 50707531
+                },
+                "PreviousTxnID": "4085CAF5E1B6C2ABD2E36B1D72E698B0671C88EB80959E189D3E8E0B1D12F163",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            }
+          ],
+          "TransactionIndex": 19,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rSCXRaUyg9CkzHMidE7oYETB4W2bM2se7",
+        "Amount": {
+          "currency": "CSC",
+          "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+          "value": "25799"
+        },
+        "Destination": "r3RaNVLvWjqqtFAawC6jbRhgKyFH7HvRS8",
+        "DestinationTag": 811921039,
+        "Fee": "12",
+        "Flags": 131072,
+        "LastLedgerSequence": 87704510,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "383131393231303339"
+            }
+          }
+        ],
+        "Sequence": 73870676,
+        "SigningPubKey": "EDEFA8F91DBE7BE5C9E6F0479788BD65A0399BFD60C8BBF4B59A123A74CCD83CCB",
+        "TransactionType": "Payment",
+        "TxnSignature": "D5903245F186BB1BB53848246F956B718544CF56BC36402A1AC841D637CDC39F57720C78799205DA06F4628B12FB335EF168B07934288ED11E81724D70FEA400",
+        "hash": "17FAF3B5CD34A48954E9E7DF1D1DD644FF6C09CF606DCBF6948F2599764965FD",
+        "DeliverMax": {
+          "currency": "CSC",
+          "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+          "value": "25799"
+        },
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rSCXRaUyg9CkzHMidE7oYETB4W2bM2se7",
+                  "Balance": "2182697960",
+                  "Flags": 0,
+                  "OwnerCount": 20,
+                  "Sequence": 73870677
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "0C43A8B86466FFDD7C207163ACDB88B57E99F936E64A03AA91C61D017A0A78E8",
+                "PreviousFields": {
+                  "Balance": "2182697972",
+                  "Sequence": 73870676
+                },
+                "PreviousTxnID": "2C71FEE80A8AC5AEAD6EDF2A9F2A292D60F1B4927EB0B6784A2AAEA279A14756",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-10088263624.10697"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "CSC",
+                    "issuer": "r3RaNVLvWjqqtFAawC6jbRhgKyFH7HvRS8",
+                    "value": "65000000000"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "CSC",
+                    "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                    "value": "0"
+                  },
+                  "LowNode": "196"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "79BF2E136951AB7E5A2C3DBC53C9FF81751150056961292876297B896440D208",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-10088237825.10697"
+                  }
+                },
+                "PreviousTxnID": "1D12BF246440A57F2B0C07092ECA49B7C87E97AD8CE82150AFEC12DB4D69C3E5",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "CSC",
+                    "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                    "value": "0"
+                  },
+                  "HighNode": "ab8",
+                  "LowLimit": {
+                    "currency": "CSC",
+                    "issuer": "rSCXRaUyg9CkzHMidE7oYETB4W2bM2se7",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "A90D63132A990A1BE11BCC24F013C7FB219F457FC77915248554D2A5B2406A2E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "25799"
+                  }
+                },
+                "PreviousTxnID": "2C71FEE80A8AC5AEAD6EDF2A9F2A292D60F1B4927EB0B6784A2AAEA279A14756",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            }
+          ],
+          "TransactionIndex": 7,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "CSC",
+            "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+            "value": "25799"
+          }
+        }
+      },
+      {
+        "Account": "rSCXRaUyg9CkzHMidE7oYETB4W2bM2se7",
+        "Fee": "12",
+        "Flags": 131072,
+        "LastLedgerSequence": 87704509,
+        "Sequence": 73870675,
+        "SigningPubKey": "EDEFA8F91DBE7BE5C9E6F0479788BD65A0399BFD60C8BBF4B59A123A74CCD83CCB",
+        "TakerGets": "10500000",
+        "TakerPays": {
+          "currency": "CSC",
+          "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+          "value": "25799"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "C67E0947EEF9BCDB85A41961B64C6ABADB7C738AB6280CE7DA7AAA6156D485572C4627E105941862DAF3FE02C7C9FEA449BC7998064E3462F20B140BA738D509",
+        "hash": "2C71FEE80A8AC5AEAD6EDF2A9F2A292D60F1B4927EB0B6784A2AAEA279A14756",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rSCXRaUyg9CkzHMidE7oYETB4W2bM2se7",
+                  "Balance": "2182697972",
+                  "Flags": 0,
+                  "OwnerCount": 20,
+                  "Sequence": 73870676
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "0C43A8B86466FFDD7C207163ACDB88B57E99F936E64A03AA91C61D017A0A78E8",
+                "PreviousFields": {
+                  "Balance": "2192613188",
+                  "Sequence": 73870675
+                },
+                "PreviousTxnID": "1D12BF246440A57F2B0C07092ECA49B7C87E97AD8CE82150AFEC12DB4D69C3E5",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-250783435.4456941"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "CSC",
+                    "issuer": "rf7g4JWCxu9oE1MKsWTihL9whY75AphCaV",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "CSC",
+                    "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                    "value": "0"
+                  },
+                  "LowNode": "c80"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "1A49A0D9DF9B20CB5478B3422DC1AE617EF83D79E35CB142B3C08AF29BE1685A",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-250809234.4456941"
+                  }
+                },
+                "PreviousTxnID": "FEEF40A18C264C05955D75665C42C43C05B656D6329A258A42F0D5894EF39442",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "25799"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "CSC",
+                    "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                    "value": "0"
+                  },
+                  "HighNode": "ab8",
+                  "LowLimit": {
+                    "currency": "CSC",
+                    "issuer": "rSCXRaUyg9CkzHMidE7oYETB4W2bM2se7",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "A90D63132A990A1BE11BCC24F013C7FB219F457FC77915248554D2A5B2406A2E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  }
+                },
+                "PreviousTxnID": "1D12BF246440A57F2B0C07092ECA49B7C87E97AD8CE82150AFEC12DB4D69C3E5",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "CA12DDFA2F0C76C874274CD1FBE1200FFFD5585CB7F329A5E3BA798555B2672F",
+                  "Account": "rf7g4JWCxu9oE1MKsWTihL9whY75AphCaV",
+                  "Balance": "95787967479",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 86795310
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B903F282E4025EDD63F076A50FB293B051B49D1055AAD7C6188EBDFAE270BF07",
+                "PreviousFields": {
+                  "Balance": "95778052275"
+                },
+                "PreviousTxnID": "FEEF40A18C264C05955D75665C42C43C05B656D6329A258A42F0D5894EF39442",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            }
+          ],
+          "TransactionIndex": 6,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+        "Expiration": 767948783,
+        "Fee": "20",
+        "Flags": 2148073472,
+        "LastLedgerSequence": 87704324,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7768616C655F32"
+            }
+          }
+        ],
+        "OfferSequence": 50707526,
+        "Sequence": 50707530,
+        "SigningPubKey": "02E729FFD554E5254291CB033D0CC08B32D6A3795A747C5F4F7DFECA20B616B6BF",
+        "TakerGets": "2760955645",
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+          "value": "0.025343"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3044022061F13369F672813456DA2C15C4973964B430DCAA66277214BE5719D0B3052B61022023F45D210F9E1EF662EFDC144A6DDDC189E628D29E497F64E54759E7CE2CF9D5",
+        "hash": "4085CAF5E1B6C2ABD2E36B1D72E698B0671C88EB80959E189D3E8E0B1D12F163",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "492049f5e2254d3e",
+                  "Flags": 0,
+                  "RootIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507492049F5E2254D3E",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000004254430000000000",
+                  "TakerPaysIssuer": "06A148131B436B2561C85967685B098E050EED4E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507492049F5E2254D3E"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E270150749209C5057EB4E27",
+                "NewFields": {
+                  "ExchangeRate": "49209c5057eb4e27",
+                  "RootIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E270150749209C5057EB4E27",
+                  "TakerPaysCurrency": "0000000000000000000000004254430000000000",
+                  "TakerPaysIssuer": "06A148131B436B2561C85967685B098E050EED4E"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "4DC39A02AE9B57DE1BFF299C0704FF505B3767187B199984DC27CA1776EBB886",
+                "NewFields": {
+                  "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "BookDirectory": "036D7E923EF22B65E19D95A6365C3373E1E96586E270150749209C5057EB4E27",
+                  "Expiration": 767948783,
+                  "Flags": 196608,
+                  "OwnerNode": "654",
+                  "Sequence": 50707530,
+                  "TakerGets": "2760955645",
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.025343"
+                  }
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "BookDirectory": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507492049F5E2254D3E",
+                  "BookNode": "0",
+                  "Expiration": 767948779,
+                  "Flags": 196608,
+                  "OwnerNode": "654",
+                  "PreviousTxnID": "855989DBBA6E58485260411DA78030DB18942196F23B01496F5644AC640FC143",
+                  "PreviousTxnLgrSeq": 87704322,
+                  "Sequence": 50707526,
+                  "TakerGets": "2760955681",
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.025093"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "5CBB9B114D9EFDED138219B58648BC84F41D1887E189E41A9C42C99D1AF2505A"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "651",
+                  "Owner": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "RootIndex": "8D47835C2516C1F8F28A43C140356DA142DEB58CA29EF27212ECE6DCFC4472C7"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9A7EE90E967B2FE985037889A13CC4240A3EECB1D7DFCF76B0E0950AFF099AA4"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "Balance": "6335456931",
+                  "Flags": 0,
+                  "MessageKey": "02000000000000000000000000F3AE90A6141CEB9C639BA74FC024278306F6D42E",
+                  "OwnerCount": 33,
+                  "Sequence": 50707531
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E938FF495007E7C01911CDFDA087111CD0130C8A6FDACCCB34914636A31486C5",
+                "PreviousFields": {
+                  "Balance": "6335456951",
+                  "Sequence": 50707530
+                },
+                "PreviousTxnID": "75DF91A16ADD96AE1F2CF04CC60D82405A91A268FEA87AC6B09CC0876D45BF04",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            }
+          ],
+          "TransactionIndex": 18,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 87704324,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "C15175CA9AACC87D4CFD6AC3F5F5827633219C8E000000003FB44F64CCB0877F3FE0B1AC0CD4F7953FA530ED7D8E629C3FF00068DB8BAC71"
+            }
+          }
+        ],
+        "Sequence": 1051568,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "SGB",
+          "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+          "value": "0.5216884852049924"
+        },
+        "TakerPays": {
+          "currency": "534F4C4F00000000000000000000000000000000",
+          "issuer": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz",
+          "value": "0.0000413889137045704"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "A1F882CB41B102F2802DCB3A4BBD6BB709A3EC24530FF8005B311E3C71A70710941C464761AAED5C3E28C5393961AC6B6C3AC2F8704502F2AD957FA1B87B6C04",
+        "hash": "43EF2B13198A3B43617B4A6BD0578CCFFA0F3C77A9BE9409D13AE1CE5328170C",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "79FA8E1193B834FEC422FC049B073D3276686C9A3C6E026A54BF2892EB990BA7",
+                  "Account": "rEaErQ5vEbHXThFedUrjz9YFotG5HHcxoW",
+                  "Balance": "9507266801",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 86807985
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "071F1CD013F73512BE3BF73DD49193AB8F187AE47E5BC20146D7A1EBFD324D31",
+                "PreviousFields": {
+                  "Balance": "9507276787"
+                },
+                "PreviousTxnID": "D76EBAC94363B98275523C0B54EABA77057940B6671BA93AD9ED7E4981FE58F8",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rs6xPU7XL3JU8FETm9Einfe7ZPPJjpoonE",
+                  "BookDirectory": "5C8970D155D65DB8FF49B291D7EFFA4A09F9E8A68D9974B25A088FFB2F2C0930",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "Sequence": 74391965,
+                  "TakerGets": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz",
+                    "value": "93.65559744158781"
+                  },
+                  "TakerPays": "22572018"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "1362CBF2FD7A850E38261A691C0164CD403AF922FB9E2D7E49695487B117AE24",
+                "PreviousFields": {
+                  "TakerGets": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz",
+                    "value": "93.69703125561594"
+                  },
+                  "TakerPays": "22582004"
+                },
+                "PreviousTxnID": "D76EBAC94363B98275523C0B54EABA77057940B6671BA93AD9ED7E4981FE58F8",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "SGB",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-491668.6680745492"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "SGB",
+                    "issuer": "rEaErQ5vEbHXThFedUrjz9YFotG5HHcxoW",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "SGB",
+                    "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+                    "value": "0"
+                  },
+                  "LowNode": "5e9"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "271A1B6B3A233F67D046B8C47524D44ECB4B3BF1921FAA40BE9C0A6D5B0C1EDC",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "SGB",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-491668.146386064"
+                  }
+                },
+                "PreviousTxnID": "D76EBAC94363B98275523C0B54EABA77057940B6671BA93AD9ED7E4981FE58F8",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rs6xPU7XL3JU8FETm9Einfe7ZPPJjpoonE",
+                  "Balance": "34427557",
+                  "Flags": 0,
+                  "OwnerCount": 4,
+                  "Sequence": 74391975
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "47F63648E20E7F55621172F21472128A4A63F5AE7164DE8BDC9EB88C413DC4AD",
+                "PreviousFields": {
+                  "Balance": "34417571"
+                },
+                "PreviousTxnID": "D76EBAC94363B98275523C0B54EABA77057940B6671BA93AD9ED7E4981FE58F8",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "SGB",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-38.68664930705858"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "SGB",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "7",
+                  "LowLimit": {
+                    "currency": "SGB",
+                    "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+                    "value": "0"
+                  },
+                  "LowNode": "5f4"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "8D426D0D58528156D32A4D77C4B176C9552DFD85B2E953F8B4FE971CE52CA294",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "SGB",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-39.20990285771919"
+                  }
+                },
+                "PreviousTxnID": "C4D4986FE857F144B8F21B8D603430931EE65F382E1FB8547EF23E9FB0664DA5",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "43EF2B13198A3B43617B4A6BD0578CCFFA0F3C77A9BE9409D13AE1CE5328170C",
+                  "Balance": "2308705189",
+                  "Flags": 0,
+                  "OwnerCount": 117,
+                  "Sequence": 1051569
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "C4D4986FE857F144B8F21B8D603430931EE65F382E1FB8547EF23E9FB0664DA5",
+                  "Balance": "2308705199",
+                  "Sequence": 1051568
+                },
+                "PreviousTxnID": "C4D4986FE857F144B8F21B8D603430931EE65F382E1FB8547EF23E9FB0664DA5",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-74.63792866695317"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "7",
+                  "LowLimit": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz",
+                    "value": "0"
+                  },
+                  "LowNode": "3845"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "E56AB275B511ECDF6E9C9D8BE9404F3FECBE5C841770584036FF8A832AF3F3B9",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-74.59649485292504"
+                  }
+                },
+                "PreviousTxnID": "DAD2D087DDD04A9BB8ECA61B729DB8CA2030C8F6BDA1541C84C5155C247AD9A7",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "374.6331794474586"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz",
+                    "value": "0"
+                  },
+                  "HighNode": "34fe",
+                  "LowLimit": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rs6xPU7XL3JU8FETm9Einfe7ZPPJjpoonE",
+                    "value": "399452785"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "EBCF0375E1AC70A5C6EFF16D353F97A24EBA336DF4356C1A5CE4EBA4B1F1CA43",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "374.6746174048681"
+                  }
+                },
+                "PreviousTxnID": "D76EBAC94363B98275523C0B54EABA77057940B6671BA93AD9ED7E4981FE58F8",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            }
+          ],
+          "TransactionIndex": 10,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBJQsMcEVj9mxSuq24M7tcakvSVrVyJ8yk",
+        "Amount": "1",
+        "Destination": "rxRpSNb1VktvzBz8JF2oJC6qaww6RZ7Lw",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 87704341,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7B226F70223A226D696E74222C22616D6F756E74223A22313030303030303030222C22677061223A2230227D"
+            }
+          }
+        ],
+        "Sequence": 84861448,
+        "SigningPubKey": "ED9EFDE38B8F241517A0034AFEA267CB3974380614F58FF2ECAF3C0B90F49E6BDE",
+        "TransactionType": "Payment",
+        "TxnSignature": "E32B4EBF01C8CA1C52B8450C49672804D029F0BE9BD4C2EC4C1EB9150A08BD8DA4807C91A7F9F0C1808D0ED89154FF4C61FF95FD4DC00CF397DC23296B25380B",
+        "hash": "554529475AD75BB7204F5FC27C8DFAF50B452DE77A3EC1ABFBD348EBDE5DD8C4",
+        "DeliverMax": "1",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBJQsMcEVj9mxSuq24M7tcakvSVrVyJ8yk",
+                  "Balance": "11691653",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 84861449
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "6B7844B8894D1E80A7479C1A7A50207BDE446F215DB35875801F31EF72688617",
+                "PreviousFields": {
+                  "Balance": "11691666",
+                  "Sequence": 84861448
+                },
+                "PreviousTxnID": "56B5C4C28C0B309B4DA40544466A23C80A3C8489F089362D4F83690F743492DC",
+                "PreviousTxnLgrSeq": 87704224
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rxRpSNb1VktvzBz8JF2oJC6qaww6RZ7Lw",
+                  "Balance": "11634269588",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 84788621
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "91A852CE8B4D796D39743843FE1B1E8E597203E607EEAEF67CE78207C1EC892A",
+                "PreviousFields": {
+                  "Balance": "11634269587"
+                },
+                "PreviousTxnID": "D639F7F7805AB21F549E1556D8FD59BAF166D0E4E1F44519254276BABDCAB1E9",
+                "PreviousTxnLgrSeq": 87704322
+              }
+            }
+          ],
+          "TransactionIndex": 5,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "1"
+        }
+      },
+      {
+        "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+        "Expiration": 767948783,
+        "Fee": "20",
+        "Flags": 2148073472,
+        "LastLedgerSequence": 87704324,
+        "OfferSequence": 50707524,
+        "Sequence": 50707528,
+        "SigningPubKey": "02E729FFD554E5254291CB033D0CC08B32D6A3795A747C5F4F7DFECA20B616B6BF",
+        "TakerGets": "2760955645",
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+          "value": "0.024895"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "30440220190F0E70A341C4F45A82BD2C5256FE18D2F8C5EDD5DA9B7041AFEBAE24D72970022027A76A8BFF1199BDEF8EB2A12C64B5E2337D157678DA627A14C7BAE958643FE5",
+        "hash": "5B6F654598CE96FE7B66479B6B396C5D382D671C82B60A13AE12039F96992EAC",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "491fb7b37bdb931c",
+                  "Flags": 0,
+                  "RootIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507491FB7B37BDB931C",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000004254430000000000",
+                  "TakerPaysIssuer": "06A148131B436B2561C85967685B098E050EED4E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507491FB7B37BDB931C"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507492008BC9FDCE1F5",
+                "NewFields": {
+                  "ExchangeRate": "492008bc9fdce1f5",
+                  "RootIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507492008BC9FDCE1F5",
+                  "TakerPaysCurrency": "0000000000000000000000004254430000000000",
+                  "TakerPaysIssuer": "06A148131B436B2561C85967685B098E050EED4E"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "651",
+                  "Owner": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "RootIndex": "8D47835C2516C1F8F28A43C140356DA142DEB58CA29EF27212ECE6DCFC4472C7"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9A7EE90E967B2FE985037889A13CC4240A3EECB1D7DFCF76B0E0950AFF099AA4"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "A67B87213C668050286CD96C40799F1EE337163ED07B6FD1B89882A7681CB229",
+                "NewFields": {
+                  "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "BookDirectory": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507492008BC9FDCE1F5",
+                  "Expiration": 767948783,
+                  "Flags": 196608,
+                  "OwnerNode": "654",
+                  "Sequence": 50707528,
+                  "TakerGets": "2760955645",
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.024895"
+                  }
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "BookDirectory": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507491FB7B37BDB931C",
+                  "BookNode": "0",
+                  "Expiration": 767948779,
+                  "Flags": 196608,
+                  "OwnerNode": "654",
+                  "PreviousTxnID": "1A2A21EF3ED9C4D8AB176512FBF1239A33F08C1E1B16A2CC716E2EA83B5CD418",
+                  "PreviousTxnLgrSeq": 87704322,
+                  "Sequence": 50707524,
+                  "TakerGets": "2760955681",
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.024649"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "C2BA2191C39ECBEFA215845C6BED72A621CE41538278139DD93FF263C6042D3C"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "Balance": "6335456971",
+                  "Flags": 0,
+                  "MessageKey": "02000000000000000000000000F3AE90A6141CEB9C639BA74FC024278306F6D42E",
+                  "OwnerCount": 33,
+                  "Sequence": 50707529
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E938FF495007E7C01911CDFDA087111CD0130C8A6FDACCCB34914636A31486C5",
+                "PreviousFields": {
+                  "Balance": "6335456991",
+                  "Sequence": 50707528
+                },
+                "PreviousTxnID": "1F63D4EC8240565048833E56FD5762BDBF869D14790EED05D77EE77E3566D7F9",
+                "PreviousTxnLgrSeq": 87704322
+              }
+            }
+          ],
+          "TransactionIndex": 16,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 87704326,
+        "OfferSequence": 135062229,
+        "Sequence": 135062238,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "101403.7576"
+        },
+        "TakerPays": "200000000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3044022030DF31E1E7F4F689056338A7FAB74C2965D18030368A5D3CD58A1AFC216FAA64022035116D98CABAF8ACCF32DB820851691F3C8F1DF7A202A6971EE8959C2E0CCFA1",
+        "hash": "6025BD2BAE22A679250688746D488FD982ADF948F7705E4B636CB2CFBA4A3D87",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5B0701CF8BFEE8F5",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "49E7D5304717BAE809A0EA546B1FE2CD50AC3FF6A29B1D68E7842E5B43072EC1",
+                  "PreviousTxnLgrSeq": 87704322,
+                  "Sequence": 135062229,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "101403.6416"
+                  },
+                  "TakerPays": "200000000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "127D1FFDC82BF6537AFA7825E76D4D582792995BB1358168FFBBB897AF372106"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "36158608575",
+                  "Flags": 0,
+                  "OwnerCount": 14,
+                  "Sequence": 135062239
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "36158608595",
+                  "Sequence": 135062238
+                },
+                "PreviousTxnID": "691EDFB4C3833667D3164780541832A852D2AF12D73F921D5CF3BEDA825E12A0",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "212A6E358085BC839DE4C820C798B6069AD0EF7A79CD67A4EA772C79A7312ED4",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5B0701CF0583CF17",
+                  "Sequence": 135062238,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "101403.7576"
+                  },
+                  "TakerPays": "200000000000"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5B0701CF0583CF17",
+                "NewFields": {
+                  "ExchangeRate": "5b0701cf0583cf17",
+                  "RootIndex": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5B0701CF0583CF17",
+                  "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+                  "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5b0701cf8bfee8f5",
+                  "Flags": 0,
+                  "RootIndex": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5B0701CF8BFEE8F5",
+                  "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+                  "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5B0701CF8BFEE8F5"
+              }
+            }
+          ],
+          "TransactionIndex": 4,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 87704325,
+        "OfferSequence": 135062225,
+        "Sequence": 135062234,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": {
+          "currency": "5553444300000000000000000000000000000000",
+          "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+          "value": "97318"
+        },
+        "TakerPays": "200000000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3044022008785EB76D30396403858E6A2A207E28F94C60E18747009272004FAA763495D302202C0D6BB2A0BABE24C16B2CA0960D1FA197682D22244002FCD93FA75B4E504026",
+        "hash": "66DEFACA3810E5D352F606B22D1D15C0F60186E6CD7E85D28AFD615FDD0CF820",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5b074c6d91f9a70c",
+                  "Flags": 0,
+                  "RootIndex": "1371BCEED87E4C5C53C442854276A5ABB5D41F635AB7C4475B074C6D91F9A70C",
+                  "TakerGetsCurrency": "5553444300000000000000000000000000000000",
+                  "TakerGetsIssuer": "06AA7798F7A8FA6914CC1E82C556E5B0A0CCB9E3",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1371BCEED87E4C5C53C442854276A5ABB5D41F635AB7C4475B074C6D91F9A70C"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1371BCEED87E4C5C53C442854276A5ABB5D41F635AB7C4475B074D1E8293CCED",
+                "NewFields": {
+                  "ExchangeRate": "5b074d1e8293cced",
+                  "RootIndex": "1371BCEED87E4C5C53C442854276A5ABB5D41F635AB7C4475B074D1E8293CCED",
+                  "TakerGetsCurrency": "5553444300000000000000000000000000000000",
+                  "TakerGetsIssuer": "06AA7798F7A8FA6914CC1E82C556E5B0A0CCB9E3"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "36158608655",
+                  "Flags": 0,
+                  "OwnerCount": 14,
+                  "Sequence": 135062235
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "36158608675",
+                  "Sequence": 135062234
+                },
+                "PreviousTxnID": "327DA33CCF82097653384E909DA21E2FE4E8973A778725701BCEBF0513BE5144",
+                "PreviousTxnLgrSeq": 87704322
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "88E94EF04339425A4646E10B05580DFE98691C294D44262D57E1CA759D73031B",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "1371BCEED87E4C5C53C442854276A5ABB5D41F635AB7C4475B074D1E8293CCED",
+                  "Sequence": 135062234,
+                  "TakerGets": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "97318"
+                  },
+                  "TakerPays": "200000000000"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "1371BCEED87E4C5C53C442854276A5ABB5D41F635AB7C4475B074C6D91F9A70C",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "00FEF21F10EB5B62916EE489D9A698B92EA3EADC3FA4B5F19D32BB73109CA12B",
+                  "PreviousTxnLgrSeq": 87704321,
+                  "Sequence": 135062225,
+                  "TakerGets": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "97354"
+                  },
+                  "TakerPays": "200000000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "A9A2817B9D287B86ED45A1903F4BCA9924D0B08DB508D645113E3AADCB68C34B"
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 87704325,
+        "OfferSequence": 135062228,
+        "Sequence": 135062237,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": "36058000000",
+        "TakerPays": {
+          "currency": "5553445400000000000000000000000000000000",
+          "issuer": "rcvxE9PS9YBwxtGg1qNeewV6ZB3wGubZq",
+          "value": "18705.744224354"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "30440220111E77E30C290CE564284445A8874FB9D218CA5107491C3CFA87352DA48AC00402203FAFD33B29FF049CE82E61B636D825998BE473EB469E967F6DEAFF837FB80CFE",
+        "hash": "691EDFB4C3833667D3164780541832A852D2AF12D73F921D5CF3BEDA825E12A0",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "36158608595",
+                  "Flags": 0,
+                  "OwnerCount": 14,
+                  "Sequence": 135062238
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "36158608615",
+                  "Sequence": 135062237
+                },
+                "PreviousTxnID": "ABA57101E6E6CB6A89998E8D1AB031522EEAA231D6889FE9CED5E8131CDC1F65",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "2410509CE58C2F04403737A3FD84B17D66C423554EEF919D4E126E2B5E90F880",
+                "NewFields": {
+                  "ExchangeRate": "4e126e2b5e90f880",
+                  "RootIndex": "2410509CE58C2F04403737A3FD84B17D66C423554EEF919D4E126E2B5E90F880",
+                  "TakerPaysCurrency": "5553445400000000000000000000000000000000",
+                  "TakerPaysIssuer": "06CB988E900D81BAE9217E6FE6B60CD2DDA12767"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4e126e3921336780",
+                  "Flags": 0,
+                  "RootIndex": "2410509CE58C2F04403737A3FD84B17D66C423554EEF919D4E126E3921336780",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "5553445400000000000000000000000000000000",
+                  "TakerPaysIssuer": "06CB988E900D81BAE9217E6FE6B60CD2DDA12767"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "2410509CE58C2F04403737A3FD84B17D66C423554EEF919D4E126E3921336780"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "A87DD144A447726E0632B985B14B92BE12D0FF4BC7E7782BA71865236764D03F",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "2410509CE58C2F04403737A3FD84B17D66C423554EEF919D4E126E2B5E90F880",
+                  "Sequence": 135062237,
+                  "TakerGets": "36058000000",
+                  "TakerPays": {
+                    "currency": "5553445400000000000000000000000000000000",
+                    "issuer": "rcvxE9PS9YBwxtGg1qNeewV6ZB3wGubZq",
+                    "value": "18705.744224354"
+                  }
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "2410509CE58C2F04403737A3FD84B17D66C423554EEF919D4E126E3921336780",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "AA79F83133ED878B066FC72F14B6B89EDC094518E7521DFEDBC37BD5645888E7",
+                  "PreviousTxnLgrSeq": 87704321,
+                  "Sequence": 135062228,
+                  "TakerGets": "36058000000",
+                  "TakerPays": {
+                    "currency": "5553445400000000000000000000000000000000",
+                    "issuer": "rcvxE9PS9YBwxtGg1qNeewV6ZB3wGubZq",
+                    "value": "18705.957327134"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "CB2CF8633922D913A3C3145230CAFD887085B0A75E0046DFEAC7742AD57335DC"
+              }
+            }
+          ],
+          "TransactionIndex": 3,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+
+      {
+        "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+        "Expiration": 767948783,
+        "Fee": "20",
+        "Flags": 2148073472,
+        "LastLedgerSequence": 87704324,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7768616C655F31"
+            }
+          }
+        ],
+        "OfferSequence": 50707525,
+        "Sequence": 50707529,
+        "SigningPubKey": "02E729FFD554E5254291CB033D0CC08B32D6A3795A747C5F4F7DFECA20B616B6BF",
+        "TakerGets": "2760955645",
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+          "value": "0.025119"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100E6D892548B6D84B704527FEF2938815FDF8F0963DEC39C084C61CA87807D618802203014D7FE692E335CC3F3AD8170FD76AC1D3EA36246C87E9D9BB57302561F886C",
+        "hash": "75DF91A16ADD96AE1F2CF04CC60D82405A91A268FEA87AC6B09CC0876D45BF04",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "492000d4af00702d",
+                  "Flags": 0,
+                  "RootIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507492000D4AF00702D",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000004254430000000000",
+                  "TakerPaysIssuer": "06A148131B436B2561C85967685B098E050EED4E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507492000D4AF00702D"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507492052867BE4180E",
+                "NewFields": {
+                  "ExchangeRate": "492052867be4180e",
+                  "RootIndex": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507492052867BE4180E",
+                  "TakerPaysCurrency": "0000000000000000000000004254430000000000",
+                  "TakerPaysIssuer": "06A148131B436B2561C85967685B098E050EED4E"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "2232FE477299A6463393D00029B4E1FDAD86E582CCE52375AEDDA54D40609A6F",
+                "NewFields": {
+                  "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "BookDirectory": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507492052867BE4180E",
+                  "Expiration": 767948783,
+                  "Flags": 196608,
+                  "OwnerNode": "654",
+                  "Sequence": 50707529,
+                  "TakerGets": "2760955645",
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.025119"
+                  }
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "BookDirectory": "036D7E923EF22B65E19D95A6365C3373E1E96586E2701507492000D4AF00702D",
+                  "BookNode": "0",
+                  "Expiration": 767948779,
+                  "Flags": 196608,
+                  "OwnerNode": "654",
+                  "PreviousTxnID": "A9AA5C5A52167E02E8395339A7537388DC3D5740EC217E4661821CE426A4771D",
+                  "PreviousTxnLgrSeq": 87704322,
+                  "Sequence": 50707525,
+                  "TakerGets": "2760955681",
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.024871"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "2D8F054C2879DC88CC96E87FCBC0849CFB39B709DCC405509F9283D2275D85DA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "651",
+                  "Owner": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "RootIndex": "8D47835C2516C1F8F28A43C140356DA142DEB58CA29EF27212ECE6DCFC4472C7"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9A7EE90E967B2FE985037889A13CC4240A3EECB1D7DFCF76B0E0950AFF099AA4"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rETx8GBiH6fxhTcfHM9fGeyShqxozyD3xe",
+                  "Balance": "6335456951",
+                  "Flags": 0,
+                  "MessageKey": "02000000000000000000000000F3AE90A6141CEB9C639BA74FC024278306F6D42E",
+                  "OwnerCount": 33,
+                  "Sequence": 50707530
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E938FF495007E7C01911CDFDA087111CD0130C8A6FDACCCB34914636A31486C5",
+                "PreviousFields": {
+                  "Balance": "6335456971",
+                  "Sequence": 50707529
+                },
+                "PreviousTxnID": "5B6F654598CE96FE7B66479B6B396C5D382D671C82B60A13AE12039F96992EAC",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            }
+          ],
+          "TransactionIndex": 17,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 87704325,
+        "OfferSequence": 135062227,
+        "Sequence": 135062236,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": {
+          "currency": "5553445400000000000000000000000000000000",
+          "issuer": "rcvxE9PS9YBwxtGg1qNeewV6ZB3wGubZq",
+          "value": "99787.9736"
+        },
+        "TakerPays": "200000000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304402206C85F1E3FC53E5C4875CED481F0DA658C14FB7130C631760260E9758FF6783480220736C5998FDFC668702CD646E7C9602D87C382677E4145CD75E7581040CADD8FF",
+        "hash": "ABA57101E6E6CB6A89998E8D1AB031522EEAA231D6889FE9CED5E8131CDC1F65",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "36158608615",
+                  "Flags": 0,
+                  "OwnerCount": 14,
+                  "Sequence": 135062237
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "36158608635",
+                  "Sequence": 135062236
+                },
+                "PreviousTxnID": "F439CD1413C2C5A88D8682D7C79E188629B879D23B9C518F9C798F52BCF396E5",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "799BECD7CA247A0647749B9C316898DD239A2C414C27A19C5B071ED97E8018C9",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "EFD57795AAC92596D271FB43A29E7DAFEB463FF0EE3C5A4A8966528442FB9C26",
+                  "PreviousTxnLgrSeq": 87704321,
+                  "Sequence": 135062227,
+                  "TakerGets": {
+                    "currency": "5553445400000000000000000000000000000000",
+                    "issuer": "rcvxE9PS9YBwxtGg1qNeewV6ZB3wGubZq",
+                    "value": "99788.23359999999"
+                  },
+                  "TakerPays": "200000000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "64640BCF44E2290901B131E99C511368DFC52E5239D072BFB2D87C7021D6B964"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "673FB4CB5BB8C372AB8119F08399222E59EA461FD0D93CFE07A6CD8F6969A4B0",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "799BECD7CA247A0647749B9C316898DD239A2C414C27A19C5B071EDAB5C32215",
+                  "Sequence": 135062236,
+                  "TakerGets": {
+                    "currency": "5553445400000000000000000000000000000000",
+                    "issuer": "rcvxE9PS9YBwxtGg1qNeewV6ZB3wGubZq",
+                    "value": "99787.9736"
+                  },
+                  "TakerPays": "200000000000"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5b071ed97e8018c9",
+                  "Flags": 0,
+                  "RootIndex": "799BECD7CA247A0647749B9C316898DD239A2C414C27A19C5B071ED97E8018C9",
+                  "TakerGetsCurrency": "5553445400000000000000000000000000000000",
+                  "TakerGetsIssuer": "06CB988E900D81BAE9217E6FE6B60CD2DDA12767",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "799BECD7CA247A0647749B9C316898DD239A2C414C27A19C5B071ED97E8018C9"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "799BECD7CA247A0647749B9C316898DD239A2C414C27A19C5B071EDAB5C32215",
+                "NewFields": {
+                  "ExchangeRate": "5b071edab5c32215",
+                  "RootIndex": "799BECD7CA247A0647749B9C316898DD239A2C414C27A19C5B071EDAB5C32215",
+                  "TakerGetsCurrency": "5553445400000000000000000000000000000000",
+                  "TakerGetsIssuer": "06CB988E900D81BAE9217E6FE6B60CD2DDA12767"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 2,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rGzoiLYuRvCArDSBFitLeMRyhxJcuuH9mN",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 87704336,
+        "OfferSequence": 86989449,
+        "Sequence": 0,
+        "SigningPubKey": "EDDF0B3446990F09073D338694CB86BB8940299B7DD18E30AD8DC15DAD6179BAD7",
+        "TakerGets": {
+          "currency": "DVT",
+          "issuer": "rQDuc1MyMjh4fCgVg8bNATYNWcpgz2BDQ2",
+          "value": "5088.0977799"
+        },
+        "TakerPays": "35321475",
+        "TicketSequence": 86989414,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "F047C0BE7877627FF93D7E9129C0D88B0D1A206516C5D3E00337E73CA1D634A1D1916C815535FAB85364C26044B8DA80A8358E5F8804F34A1C3DB8EAA9301C06",
+        "hash": "B8325F7ED5DE21BC98539016E9FD2D71CF73246C433547801FDDC9E00749DE81",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rGzoiLYuRvCArDSBFitLeMRyhxJcuuH9mN",
+                  "Balance": "1298311987",
+                  "Flags": 0,
+                  "OwnerCount": 95,
+                  "Sequence": 86989493,
+                  "TicketCount": 55
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1EE2B37B50CAF3D9B72D4EBB02C775C7E8DB8996E5CE6AF0280A93EDAA1A40E2",
+                "PreviousFields": {
+                  "Balance": "1298311999",
+                  "OwnerCount": 96,
+                  "TicketCount": 56
+                },
+                "PreviousTxnID": "DBCD15CBCB744800B71B421BE8D70AF87B0BDA62DF899728EFFD68651B0BA930",
+                "PreviousTxnLgrSeq": 87704319
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rGzoiLYuRvCArDSBFitLeMRyhxJcuuH9mN",
+                  "BookDirectory": "ECF0A351478DA7240CEC93A9921428666D95AA1A49BB4B955818A9B65407DFFF",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "1367",
+                  "PreviousTxnID": "DBCD15CBCB744800B71B421BE8D70AF87B0BDA62DF899728EFFD68651B0BA930",
+                  "PreviousTxnLgrSeq": 87704319,
+                  "Sequence": 86989449,
+                  "TakerGets": {
+                    "currency": "DVT",
+                    "issuer": "rQDuc1MyMjh4fCgVg8bNATYNWcpgz2BDQ2",
+                    "value": "5088.083405358687"
+                  },
+                  "TakerPays": "35321475"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "270B81409055C24926B3CB1B8ADBCC1C37B39126D443C47696BDEE954907E63C"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "1366",
+                  "Owner": "rGzoiLYuRvCArDSBFitLeMRyhxJcuuH9mN",
+                  "RootIndex": "6187485E15E2A7CBA0A9A6DB0CA282D4015101C3797C941126CBDCE9C388B043"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "30BC028D2C25A6B51929C1A493FDC00D79722DDEE189769825F1F44B4FE723C4"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rGzoiLYuRvCArDSBFitLeMRyhxJcuuH9mN",
+                  "Flags": 0,
+                  "OwnerNode": "1365",
+                  "PreviousTxnID": "B572C126C069FBDBFA4A6828E093094AF2D5549E250882B2C8999FA1A9838643",
+                  "PreviousTxnLgrSeq": 87704069,
+                  "TicketSequence": 86989414
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "8019539170E8EF4DAD1812EB817BAAEF08E6F132168D6BDEC299ABD534872396"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "92B082A93DA4E2E1A7F171E1CC473A2CC4B88448FFD63D03F2ED0935FC4B74A2",
+                "NewFields": {
+                  "Account": "rGzoiLYuRvCArDSBFitLeMRyhxJcuuH9mN",
+                  "BookDirectory": "ECF0A351478DA7240CEC93A9921428666D95AA1A49BB4B955818A9B65407DFFF",
+                  "OwnerNode": "1367",
+                  "Sequence": 86989414,
+                  "TakerGets": {
+                    "currency": "DVT",
+                    "issuer": "rQDuc1MyMjh4fCgVg8bNATYNWcpgz2BDQ2",
+                    "value": "5088.083405358687"
+                  },
+                  "TakerPays": "35321475"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "1366",
+                  "IndexPrevious": "1364",
+                  "Owner": "rGzoiLYuRvCArDSBFitLeMRyhxJcuuH9mN",
+                  "RootIndex": "6187485E15E2A7CBA0A9A6DB0CA282D4015101C3797C941126CBDCE9C388B043"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CCBFAAF33DCF3A6BAECF4BE64075A491AFE87DF933883CEEFE82020134DA5053"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5818a9b65407dfff",
+                  "Flags": 0,
+                  "RootIndex": "ECF0A351478DA7240CEC93A9921428666D95AA1A49BB4B955818A9B65407DFFF",
+                  "TakerGetsCurrency": "0000000000000000000000004456540000000000",
+                  "TakerGetsIssuer": "FEBBCEE704EFB979F2D055D3DB1F39F6F41B6B25",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "ECF0A351478DA7240CEC93A9921428666D95AA1A49BB4B955818A9B65407DFFF"
+              }
+            }
+          ],
+          "TransactionIndex": 20,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rsEXMkw11FPDQeAeHcWh6QNbA8EGjhj8FY",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 87704341,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7B226D6F64756C65223A2258574D2041737369737465642054726164696E67222C22616363657373223A2258574D204E4654204469616D6F6E64222C2276657273696F6E223A2276302E352E302062657461222C227374726174656779223A224261736963227D"
+            }
+          }
+        ],
+        "Sequence": 77761954,
+        "SigningPubKey": "ED1A76C4859E58F612B736724399958F324B39DF8F8D89A12E69845E3321108871",
+        "TakerGets": "10000000",
+        "TakerPays": {
+          "currency": "XAH",
+          "issuer": "rswh1fvyLqHizBS2awu1vs6QcmwTBd9qiv",
+          "value": "33.761439646"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "C798213E8C990659E557A74534A4358AC8A3A78A55BA8CFA3458B4596FCE9A3E54613F99426654DFF83F21A98037C96C41DCD81679D9BAD1CEAB5186ED172306",
+        "hash": "BEFDD8BB721FCB01582A9C608DFB47989569069D438F82124A5BFAA0DAC278A3",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rsEXMkw11FPDQeAeHcWh6QNbA8EGjhj8FY",
+                  "Balance": "233813132",
+                  "Flags": 0,
+                  "OwnerCount": 30,
+                  "Sequence": 77761955
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "167E94D00E8F736D43A6F81E98D7FA609FCFF3313EE48FC0FDA6F6ECB25D345B",
+                "PreviousFields": {
+                  "Balance": "233813147",
+                  "OwnerCount": 29,
+                  "Sequence": 77761954
+                },
+                "PreviousTxnID": "0E820BB421305708B325FB7CECCE50D3CA5E241319A30C991914FD4BF86AB4FA",
+                "PreviousTxnLgrSeq": 87704306
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "16A2300132CEFCA0B78A176BD584A81FF0B72387B7DA0A8D40873BB6E94148BA",
+                "NewFields": {
+                  "Account": "rsEXMkw11FPDQeAeHcWh6QNbA8EGjhj8FY",
+                  "BookDirectory": "F52A3ABAFA4C5856E662441BD92DD9C45B045889AD2BA46D4F0BFE95C5B876C0",
+                  "OwnerNode": "1",
+                  "Sequence": 77761954,
+                  "TakerGets": "10000000",
+                  "TakerPays": {
+                    "currency": "XAH",
+                    "issuer": "rswh1fvyLqHizBS2awu1vs6QcmwTBd9qiv",
+                    "value": "33.761439646"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rsEXMkw11FPDQeAeHcWh6QNbA8EGjhj8FY",
+                  "RootIndex": "60E939C40CA17276587618373DB172DD1E347AE2AA6BE7267005AE94936A2835"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "266FE682B3E3BD6E8AB7A41EB5B7AAD9ED83AFD06699ABB2D458BA893D07A5BE"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F52A3ABAFA4C5856E662441BD92DD9C45B045889AD2BA46D4F0BFE95C5B876C0",
+                "NewFields": {
+                  "ExchangeRate": "4f0bfe95c5b876c0",
+                  "RootIndex": "F52A3ABAFA4C5856E662441BD92DD9C45B045889AD2BA46D4F0BFE95C5B876C0",
+                  "TakerPaysCurrency": "0000000000000000000000005841480000000000",
+                  "TakerPaysIssuer": "17A73888B98222E485D927BCDFD63FC3895AD2AE"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 8,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 87704324,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "4209DCD25EF91F20D6C0FC12F175B6CD0AD6BAF604A22498404A3ED505E3E037401BE767D34DF04E4076E2CE7646AE053FF0000000000000"
+            }
+          }
+        ],
+        "Sequence": 1051567,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": "9939",
+        "TakerPays": {
+          "currency": "SGB",
+          "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+          "value": "0.0005216884852049924"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "7AE0BEC498F6224AB90EB6A6792A39C9EBB01F960BCC1C7963408ECB4CEB58134A0DF586E92A3AA02FFF0CE3BC0B24AF491300B728059D51B258DC43C6FCDC0F",
+        "hash": "C4D4986FE857F144B8F21B8D603430931EE65F382E1FB8547EF23E9FB0664DA5",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+                  "Balance": "252580537",
+                  "Flags": 0,
+                  "OwnerCount": 31,
+                  "Sequence": 77735066
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "0943A7CA0445F090EFA54DF215581407714AE7E396207B491C049F9EB75BB6A5",
+                "PreviousFields": {
+                  "Balance": "252570598"
+                },
+                "PreviousTxnID": "4809E032BE36F28C90A3824DF5F28250BFCCF3985C35E04235CD29411AE227C2",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+                  "BookDirectory": "CF4E10710F68879A15534813B9047ED60B2A0E90988B9F965906C4AC0727C256",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "1",
+                  "Sequence": 77735064,
+                  "TakerGets": {
+                    "currency": "SGB",
+                    "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+                    "value": "365.6536989495917"
+                  },
+                  "TakerPays": "6966043"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "141FC5FC5B32AD1CF25E80F2DF6B1D4B0E8EF0936967253160D412ACEA3EFC9C",
+                "PreviousFields": {
+                  "TakerGets": {
+                    "currency": "SGB",
+                    "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+                    "value": "366.175405765622"
+                  },
+                  "TakerPays": "6975982"
+                },
+                "PreviousTxnID": "4809E032BE36F28C90A3824DF5F28250BFCCF3985C35E04235CD29411AE227C2",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "SGB",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-39.20990285771919"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "SGB",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "7",
+                  "LowLimit": {
+                    "currency": "SGB",
+                    "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+                    "value": "0"
+                  },
+                  "LowNode": "5f4"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "8D426D0D58528156D32A4D77C4B176C9552DFD85B2E953F8B4FE971CE52CA294",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "SGB",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-38.68819604168891"
+                  }
+                },
+                "PreviousTxnID": "D76EBAC94363B98275523C0B54EABA77057940B6671BA93AD9ED7E4981FE58F8",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "SGB",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1336.091568733186"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "SGB",
+                    "issuer": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+                    "value": "23523463"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "SGB",
+                    "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+                    "value": "0"
+                  },
+                  "LowNode": "571"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "9A0EB00C56F3A466A7973F355AFF8937FE3F601A379254740E231B9286AE26B2",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "SGB",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1336.614840669664"
+                  }
+                },
+                "PreviousTxnID": "4809E032BE36F28C90A3824DF5F28250BFCCF3985C35E04235CD29411AE227C2",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "C4D4986FE857F144B8F21B8D603430931EE65F382E1FB8547EF23E9FB0664DA5",
+                  "Balance": "2308705199",
+                  "Flags": 0,
+                  "OwnerCount": 117,
+                  "Sequence": 1051568
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "DAD2D087DDD04A9BB8ECA61B729DB8CA2030C8F6BDA1541C84C5155C247AD9A7",
+                  "Balance": "2308715148",
+                  "Sequence": 1051567
+                },
+                "PreviousTxnID": "DAD2D087DDD04A9BB8ECA61B729DB8CA2030C8F6BDA1541C84C5155C247AD9A7",
+                "PreviousTxnLgrSeq": 87704321
+              }
+            }
+          ],
+          "TransactionIndex": 9,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 87704336,
+        "OfferSequence": 87081890,
+        "Sequence": 0,
+        "SigningPubKey": "EDDC0F61F5B2EDC288EF56C0F0B9DCC4C1D596165FC7A53D72022FDBEC3C1D2669",
+        "TakerGets": "10961956",
+        "TakerPays": {
+          "currency": "CTF",
+          "issuer": "r9Xzi4KsSF1Xtr8WHyBmUcvfP9FzTyG5wp",
+          "value": "13.8404395"
+        },
+        "TicketSequence": 87081863,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "2373A64A911CCBE49A0DE54B280179820331B86E2CF8E7ACAC6E35708E6C347AEA46F2F08705CCDAA0079755C5544FE3EEDDCCCDA9DD29BA32A57225C4669E0A",
+        "hash": "C77F38D8B210A702653F858D28F26B3C7ADA420E8B0A92637AEA8682656FD02F",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "BookDirectory": "F659CD75B06FE8D87B6835DE42D740B9716ACAE3EC7F6DAD4F047C53F91D8E5D",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "1d09",
+                  "PreviousTxnID": "8BDDC238A97C6D49A77466E23B4EBE78E62D198A49C351E10F211CB61FBF0CB2",
+                  "PreviousTxnLgrSeq": 87704319,
+                  "Sequence": 87081890,
+                  "TakerGets": "10961856",
+                  "TakerPays": {
+                    "currency": "CTF",
+                    "issuer": "r9Xzi4KsSF1Xtr8WHyBmUcvfP9FzTyG5wp",
+                    "value": "13.8404395"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "1B0BE0AE861B39672B82A5374A311B6A40A8C99847FA2A2A0C7FB9AC9B4097BC"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "21B6A82EF103AE354F606B7601CC562AB7B176ED1A1767B33C0DB10014EFF923",
+                "NewFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "BookDirectory": "F659CD75B06FE8D87B6835DE42D740B9716ACAE3EC7F6DAD4F047C53F91D8E5D",
+                  "OwnerNode": "1d09",
+                  "Sequence": 87081863,
+                  "TakerGets": "10961856",
+                  "TakerPays": {
+                    "currency": "CTF",
+                    "issuer": "r9Xzi4KsSF1Xtr8WHyBmUcvfP9FzTyG5wp",
+                    "value": "13.8404395"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "1d08",
+                  "Owner": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "RootIndex": "53ED31436B8E4B6ABA33E063401FCB848CD1039A6593485672C52B223D0AD814"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "A6A53E0C495FFAE8EF3DDA962E7A22377B781D28A35B229774287D0DA076AB80"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "Balance": "751727187",
+                  "Flags": 0,
+                  "OwnerCount": 70,
+                  "Sequence": 87081922,
+                  "TicketCount": 30
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C95B3E1594FED5D82C3BA09148095523ABB8C6FF39F02C29DE15B4F4E5B2E8E5",
+                "PreviousFields": {
+                  "Balance": "751727199",
+                  "OwnerCount": 71,
+                  "TicketCount": 31
+                },
+                "PreviousTxnID": "8BDDC238A97C6D49A77466E23B4EBE78E62D198A49C351E10F211CB61FBF0CB2",
+                "PreviousTxnLgrSeq": 87704319
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "1d09",
+                  "IndexPrevious": "1d01",
+                  "Owner": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "RootIndex": "53ED31436B8E4B6ABA33E063401FCB848CD1039A6593485672C52B223D0AD814"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "D2C0200466AEC3E48AE9C6D4A6BEFF163075940343A92E20B46E225C053D5526"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "Flags": 0,
+                  "OwnerNode": "1d08",
+                  "PreviousTxnID": "B69AF6ED1DC487C6263872755690D8C77EB733F05078EA7BE66AAA77113DB7EE",
+                  "PreviousTxnLgrSeq": 87703978,
+                  "TicketSequence": 87081863
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "F308D7265DC46430651E4F0521CC9927C8482EF81A3CAB30CDBC894656B124B9"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f047c53f91d8e5d",
+                  "Flags": 0,
+                  "RootIndex": "F659CD75B06FE8D87B6835DE42D740B9716ACAE3EC7F6DAD4F047C53F91D8E5D",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000004354460000000000",
+                  "TakerPaysIssuer": "5D9DC6DF26803CCB315D17C15B69A0A49DB1B7A5"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F659CD75B06FE8D87B6835DE42D740B9716ACAE3EC7F6DAD4F047C53F91D8E5D"
+              }
+            }
+          ],
+          "TransactionIndex": 14,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rUCzdq8HD6HQRbZctLBEjvkWEMsouMbDQQ",
+        "Amount": "1",
+        "Destination": "rxRpSNb1VktvzBz8JF2oJC6qaww6RZ7Lw",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 87704341,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7B226F70223A226D696E74222C22616D6F756E74223A22313030303030303030222C22677061223A2230227D"
+            }
+          }
+        ],
+        "Sequence": 84861417,
+        "SigningPubKey": "ED9BBC24D2B42DFC390C0EF599B0EF9F43BC34DC734982768DF3D27BECA8ACF486",
+        "TransactionType": "Payment",
+        "TxnSignature": "E4A8ADDDFB78F4EE12CA3874DC5145C2509D2886DF499646A12F434A7AF8BFE0B1C616DFAEA930BB7C0F85DD782A43FE21FC9FDEF3E05F1454BC17A6C8D2DC03",
+        "hash": "E21A9F1B2D24C6A72F4A096A56DF545C821A6803751224AD511F5F27654ABCD9",
+        "DeliverMax": "1",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUCzdq8HD6HQRbZctLBEjvkWEMsouMbDQQ",
+                  "Balance": "11559429",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 84861418
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "85CD6468AF12A8AF5D032F53EEC63F0F42CB78C599EA8B156BEA1EA3C13F3129",
+                "PreviousFields": {
+                  "Balance": "11559442",
+                  "Sequence": 84861417
+                },
+                "PreviousTxnID": "85469A8C50F3D0F1A3B83456B2ED229C3C1E3DBF9E1CC10C56A8BC72AD7E3E91",
+                "PreviousTxnLgrSeq": 87704224
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rxRpSNb1VktvzBz8JF2oJC6qaww6RZ7Lw",
+                  "Balance": "11634269589",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 84788621
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "91A852CE8B4D796D39743843FE1B1E8E597203E607EEAEF67CE78207C1EC892A",
+                "PreviousFields": {
+                  "Balance": "11634269588"
+                },
+                "PreviousTxnID": "554529475AD75BB7204F5FC27C8DFAF50B452DE77A3EC1ABFBD348EBDE5DD8C4",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            }
+          ],
+          "TransactionIndex": 15,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "1"
+        }
+      },
+      {
+        "Account": "rntopA1H9AJoFjpiCueBMFEpXQRBD3ueyG",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 87704336,
+        "OfferSequence": 86894617,
+        "Sequence": 0,
+        "SigningPubKey": "EDC680BD209E3E1CFE3494D3BEBADB43CC9A15787AA5930B6D6A08003B82BF2C11",
+        "TakerGets": "2147281",
+        "TakerPays": {
+          "currency": "4348494E47000000000000000000000000000000",
+          "issuer": "raeatrkxnL8rLu8a6mqmBzoGeGtFHoFLZg",
+          "value": "93359.2141107"
+        },
+        "TicketSequence": 86894590,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "609B0079AEF44E5E5BC33F2CA32F5EF9817E5F91F201347B7A7DB6186A41B4D2DAC9EDDC8C9A21D3C5906FEDEAEFB1587719CE7C955FAE19785611A60B16A001",
+        "hash": "E56EE623C152D9BA62AC2A726847115C35B06BC4E01AF134CE878E88C0F0342A",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rntopA1H9AJoFjpiCueBMFEpXQRBD3ueyG",
+                  "Balance": "771770450",
+                  "Flags": 0,
+                  "OwnerCount": 59,
+                  "Sequence": 86894625,
+                  "TicketCount": 27
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1D0BC1B01F163A7CDB618BDF3EB6F008B9DE79D6EA7CDEF3D42AA7F7B1979E8A",
+                "PreviousFields": {
+                  "Balance": "771770462",
+                  "OwnerCount": 60,
+                  "TicketCount": 28
+                },
+                "PreviousTxnID": "73CCA84115A1373C9E6DE866740893BD7039976F4C7C2D6E6E267FC89A544756",
+                "PreviousTxnLgrSeq": 87704319
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rntopA1H9AJoFjpiCueBMFEpXQRBD3ueyG",
+                  "BookDirectory": "7217FCB7ABA7C70ED332C8B9AF2D7E98B756CBEAE476BC3F530F727BA802991A",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "850",
+                  "PreviousTxnID": "73CCA84115A1373C9E6DE866740893BD7039976F4C7C2D6E6E267FC89A544756",
+                  "PreviousTxnLgrSeq": 87704319,
+                  "Sequence": 86894617,
+                  "TakerGets": "2147176",
+                  "TakerPays": {
+                    "currency": "4348494E47000000000000000000000000000000",
+                    "issuer": "raeatrkxnL8rLu8a6mqmBzoGeGtFHoFLZg",
+                    "value": "93359.2141107"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "2BB4B532D0D190B071482AF292D2EE83D9DF5C0FEF991AF9A48B10F730A1881A"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rntopA1H9AJoFjpiCueBMFEpXQRBD3ueyG",
+                  "Flags": 0,
+                  "OwnerNode": "84f",
+                  "PreviousTxnID": "C54C951E7CA800C57D404B38E4701FDBD6BDB60E11312BA0EB033A28D62A8531",
+                  "PreviousTxnLgrSeq": 87704157,
+                  "TicketSequence": 86894590
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "56CA2F659DE5CE9A8E7B64CAA4BD032B0A2F12A0F1938D01DC8606DE563E94C1"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "530f727ba802991a",
+                  "Flags": 0,
+                  "RootIndex": "7217FCB7ABA7C70ED332C8B9AF2D7E98B756CBEAE476BC3F530F727BA802991A",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "4348494E47000000000000000000000000000000",
+                  "TakerPaysIssuer": "3DDCED704343391D02EAA5BC76BFC7FC298180C4"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "7217FCB7ABA7C70ED332C8B9AF2D7E98B756CBEAE476BC3F530F727BA802991A"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "850",
+                  "IndexPrevious": "845",
+                  "Owner": "rntopA1H9AJoFjpiCueBMFEpXQRBD3ueyG",
+                  "RootIndex": "48DE6591182BD42995AB191B9C76C3589D784BFFD45F0171638319E44683F4C2"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "7C8C2D170AFC5D6ABFF54DED70BB1ED54CA56793EA7D4AFC513EC2F3615560C7"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "84f",
+                  "Owner": "rntopA1H9AJoFjpiCueBMFEpXQRBD3ueyG",
+                  "RootIndex": "48DE6591182BD42995AB191B9C76C3589D784BFFD45F0171638319E44683F4C2"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "D493BE01D2F246C07167AF8441BD8BA6CED6C90DC6A3294E2F2F0E164FC74154"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "D5C29F8724BC49199ECB32E9BBE04E4EC19E10FF9908C0375EFD6403FB9DAACA",
+                "NewFields": {
+                  "Account": "rntopA1H9AJoFjpiCueBMFEpXQRBD3ueyG",
+                  "BookDirectory": "7217FCB7ABA7C70ED332C8B9AF2D7E98B756CBEAE476BC3F530F727BA802991A",
+                  "OwnerNode": "850",
+                  "Sequence": 86894590,
+                  "TakerGets": "2147176",
+                  "TakerPays": {
+                    "currency": "4348494E47000000000000000000000000000000",
+                    "issuer": "raeatrkxnL8rLu8a6mqmBzoGeGtFHoFLZg",
+                    "value": "93359.2141107"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 12,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 87704325,
+        "OfferSequence": 135062226,
+        "Sequence": 135062235,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": "36058000000",
+        "TakerPays": {
+          "currency": "5553444300000000000000000000000000000000",
+          "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+          "value": "18497.45435802"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3044022034B30191369E9D6D8DCC3036624B6F9BD911FE3C4211FB76531FC8AE129139B502200CFBF2D7D8988E4942DB9F5FA1D3F9498E1B21DE835DD0C9439EDB59E79CACA7",
+        "hash": "F439CD1413C2C5A88D8682D7C79E188629B879D23B9C518F9C798F52BCF396E5",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "36158608635",
+                  "Flags": 0,
+                  "OwnerCount": 14,
+                  "Sequence": 135062236
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "36158608655",
+                  "Sequence": 135062235
+                },
+                "PreviousTxnID": "66DEFACA3810E5D352F606B22D1D15C0F60186E6CD7E85D28AFD615FDD0CF820",
+                "PreviousTxnLgrSeq": 87704323
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4e1239a0158e7500",
+                  "Flags": 0,
+                  "RootIndex": "33DFFDF31565C801C27B84E5A0202D944687663C0BDCD0144E1239A0158E7500",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "5553444300000000000000000000000000000000",
+                  "TakerPaysIssuer": "06AA7798F7A8FA6914CC1E82C556E5B0A0CCB9E3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "33DFFDF31565C801C27B84E5A0202D944687663C0BDCD0144E1239A0158E7500"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "33DFFDF31565C801C27B84E5A0202D944687663C0BDCD0144E1239A1DA8D4100",
+                "NewFields": {
+                  "ExchangeRate": "4e1239a1da8d4100",
+                  "RootIndex": "33DFFDF31565C801C27B84E5A0202D944687663C0BDCD0144E1239A1DA8D4100",
+                  "TakerPaysCurrency": "5553444300000000000000000000000000000000",
+                  "TakerPaysIssuer": "06AA7798F7A8FA6914CC1E82C556E5B0A0CCB9E3"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "33DFFDF31565C801C27B84E5A0202D944687663C0BDCD0144E1239A0158E7500",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "687D388480E4003C0113C36EC3B0AAF34ABCA3ED4F77D5926BA9895ADC7E97EF",
+                  "PreviousTxnLgrSeq": 87704321,
+                  "Sequence": 135062226,
+                  "TakerGets": "36058000000",
+                  "TakerPays": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "18497.42695394"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "D9BF25CA4F507533D36F9AA28373837345640553A46449F1EE5CC2DD3355912D"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "FB97C7DF5275A5AF7B4F3727E19969AABDF2D13C7607371988C8E8EC250157A0",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "33DFFDF31565C801C27B84E5A0202D944687663C0BDCD0144E1239A1DA8D4100",
+                  "Sequence": 135062235,
+                  "TakerGets": "36058000000",
+                  "TakerPays": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "18497.45435802"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 1,
+          "TransactionResult": "tesSUCCESS"
+        }
+      }
+    ]
+  },
+  "status": "success"
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-90150378.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-90150378.json
@@ -1,0 +1,10262 @@
+{
+  "ledger_hash": "9804C2A3DF946979C3E01756FA24F5993297B2DBB33596E12A0CF4934A67BA31",
+  "ledger_index": 90150378,
+  "validated": true,
+  "ledger": {
+    "account_hash": "4502698BF444ADF38DCD7CBC7B3EFA8879198AF58347037CFF5BDCB1A6BB5439",
+    "close_flags": 0,
+    "close_time": 777338502,
+    "close_time_human": "2024-Aug-18 23:21:42.000000000 UTC",
+    "close_time_resolution": 10,
+    "close_time_iso": "2024-08-18T23:21:42Z",
+    "ledger_hash": "9804C2A3DF946979C3E01756FA24F5993297B2DBB33596E12A0CF4934A67BA31",
+    "parent_close_time": 777338501,
+    "parent_hash": "6B6F4F23670F5241D49AF7FE0C769981CF640E5A8C9D871D184BC1F4607B57CC",
+    "total_coins": "99987294513513060",
+    "transaction_hash": "9D5BC8AA7A45B1B3C077E94D3D577BD4B12A88B17C8C023DA24E7F0C88FAC92A",
+    "ledger_index": "90150378",
+    "closed": true,
+    "transactions": [
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 7381799,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "RPR",
+          "issuer": "r3qWgpz2ry3BhcRJ8JE6rxM8esrfhuKp4R",
+          "value": "0.0001353713821586175"
+        },
+        "TakerPays": {
+          "currency": "MAG",
+          "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+          "value": "6309226183723641e-28"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "1E38A8AD89B091F3B11B0E4FEF46C34646013BC07B33B44548E496820B15AFEF2EFE05D74941D73C8BBE5C61B1C2545634D45199B477991A80438DE8C44F5508",
+        "hash": "0348B0D3BC9B797816F5E00C5C6C869A6DBCD221D392F6C2CAE253F742771373",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0006861383917448995"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "MAG",
+                    "issuer": "rU6eZDWCAr4bnRUCMb1kA12BaiQgGQFu3J",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "MAG",
+                    "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+                    "value": "0"
+                  },
+                  "LowNode": "1e4"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "5BD7FD3BEB358265FD0F4053ED70722D9E9F577509C10851431ECCED243B795B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0006861390225110533"
+                  }
+                },
+                "PreviousTxnID": "A060334B0990A0E8574E1C5176A046BEA083264B978363EDD02E1F8C146B8D2B",
+                "PreviousTxnLgrSeq": 90150336
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.00202298966994428"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "MAG",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "HighNode": "8",
+                  "LowLimit": {
+                    "currency": "MAG",
+                    "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+                    "value": "0"
+                  },
+                  "LowNode": "214"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "6AEDB0D2B26C22AC4401CBDCEB4181C26081FE867AC3A8C233488A6D66724DE8",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.002022989039178126"
+                  }
+                },
+                "PreviousTxnID": "61FBF21D3D668C910637EF07E324BE0FE0F2268069EA91B0B9882D7422556B39",
+                "PreviousTxnLgrSeq": 90150357
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "RPR",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-147.2185176136946"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "RPR",
+                    "issuer": "rU6eZDWCAr4bnRUCMb1kA12BaiQgGQFu3J",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "RPR",
+                    "issuer": "r3qWgpz2ry3BhcRJ8JE6rxM8esrfhuKp4R",
+                    "value": "0"
+                  },
+                  "LowNode": "f07"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "769E25E47BE0C44F257B6AAA4CFF93960253A278B5277588F9509F6186031024",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "RPR",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-147.2183822423124"
+                  }
+                },
+                "PreviousTxnID": "A060334B0990A0E8574E1C5176A046BEA083264B978363EDD02E1F8C146B8D2B",
+                "PreviousTxnLgrSeq": 90150336
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "RPR",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5.085633592429894"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "RPR",
+                    "issuer": "r3qWgpz2ry3BhcRJ8JE6rxM8esrfhuKp4R",
+                    "value": "0"
+                  },
+                  "HighNode": "f0d",
+                  "LowLimit": {
+                    "currency": "RPR",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "9"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B2465B6C95B1C9C8345D1F14985CB5DEA6AFBBD4E9CB2B9FF3697C5E8B4D7CE4",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "RPR",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5.085768963812053"
+                  }
+                },
+                "PreviousTxnID": "7E8C767965BE73B6E2CA683C2E7569AAA3001A97E435C77E112D44B951DF4EAD",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "0348B0D3BC9B797816F5E00C5C6C869A6DBCD221D392F6C2CAE253F742771373",
+                  "Balance": "420568278",
+                  "Flags": 0,
+                  "OwnerCount": 142,
+                  "Sequence": 7381800
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "7E8C767965BE73B6E2CA683C2E7569AAA3001A97E435C77E112D44B951DF4EAD",
+                  "Balance": "420568288",
+                  "Sequence": 7381799
+                },
+                "PreviousTxnID": "7E8C767965BE73B6E2CA683C2E7569AAA3001A97E435C77E112D44B951DF4EAD",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 45,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rJSwZhfNmufdYk6b3CJ7zFe1UCAyzyjgYr",
+        "Amount": "87",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 5000157,
+        "Fee": "10",
+        "Sequence": 89637295,
+        "SigningPubKey": "ED22AD5EE2902B7B0627E44B77EDA1CADC849E214E05B2D69407AE2B4DC2FB661F",
+        "TransactionType": "Payment",
+        "TxnSignature": "B68F605A47C81473A220865ACA8172E5201EE2749A949DE1B36A8A1CA544F27D3BB41984FD7A8E8558A34BE3CB6959AAFCC51C60D6B61450E080823E56F62E0B",
+        "hash": "0EF308B718E6238E68E37CF85A5E37F7985ABD8CF657F25EE78750F10091C3B6",
+        "DeliverMax": "87",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rJSwZhfNmufdYk6b3CJ7zFe1UCAyzyjgYr",
+                  "Balance": "52759348",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89637296
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "0BEE2DAB74F772F5DDE0D15A8E6E58A206A6AEB9A1AD38724922725C5F4621CA",
+                "PreviousFields": {
+                  "Balance": "52759445",
+                  "Sequence": 89637295
+                },
+                "PreviousTxnID": "7C3684F3D31948BFE59C45346FDD9D25D70F4E8228BC1D98A52DEC74045E68EE",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180902427",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180902340"
+                },
+                "PreviousTxnID": "7C3684F3D31948BFE59C45346FDD9D25D70F4E8228BC1D98A52DEC74045E68EE",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 85,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "87"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 12933007,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "XDX",
+          "issuer": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+          "value": "0.00000002650556741724856"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "1982696995377698e-30"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "FADDB845DCD1EE557800BCE4EA3AFDE8F36BAFF02BC1DF137D6C8E666FCF5F5DB405A7DC88402AC0AB7AC46A6699893BBE1D1010E44B7A4EC62B5BD3283BD302",
+        "hash": "11DE80F7F3C0305E0CA8286CA64089B96C50FBEC8F0631C2F793D455870A4177",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1048576,
+                  "HighLimit": {
+                    "currency": "XDX",
+                    "issuer": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+                    "value": "0"
+                  },
+                  "HighNode": "f02",
+                  "LowLimit": {
+                    "currency": "XDX",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c",
+                  "PreviousTxnID": "A9A209E309DD7FBD258B15E179FEE46AD96DBC9D118DCEC31AC7D97D226CAD16",
+                  "PreviousTxnLgrSeq": 90150378
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "096644062FE21891EB63D15CD0C6929DA64024D17927CE252D73BD741A87846F",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000000008867365563372514"
+                  },
+                  "Flags": 1114112
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "756727A846E5AD37BEF80E11730FD2161803B0771D168769F9B4E2E26DEEB8D8",
+                "PreviousTxnID": "A9A209E309DD7FBD258B15E179FEE46AD96DBC9D118DCEC31AC7D97D226CAD16",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.00000009596906466705974"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "0"
+                  },
+                  "LowNode": "2387"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "9A6C3769BB8CF0725767B6A272158F3D8FF28954928CEFC249B2FC2C1E34E3FA",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.00000009596840152566073"
+                  }
+                },
+                "PreviousTxnID": "70B96464104A9C71110126333469ED4BEF145C2795A7FADC32E09E27A0293AF4",
+                "PreviousTxnLgrSeq": 90150357
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "11DE80F7F3C0305E0CA8286CA64089B96C50FBEC8F0631C2F793D455870A4177",
+                  "Balance": "1187998058",
+                  "Flags": 0,
+                  "OwnerCount": 51,
+                  "Sequence": 12933008
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "A9A209E309DD7FBD258B15E179FEE46AD96DBC9D118DCEC31AC7D97D226CAD16",
+                  "Balance": "1187998068",
+                  "OwnerCount": 52,
+                  "Sequence": 12933007
+                },
+                "PreviousTxnID": "A9A209E309DD7FBD258B15E179FEE46AD96DBC9D118DCEC31AC7D97D226CAD16",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-23.7507774630176"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rH7nHWM5xHB374VrLiHga87D7SUcX5PdzF",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "0"
+                  },
+                  "LowNode": "232c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "CF3A039DAC0563315D559DAFA7CF0D8E0694E1B91B3AB8902011C398417FDE62",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-23.75077746301826"
+                  }
+                },
+                "PreviousTxnID": "FA0389C5AE26D1F9897C60E0EE48459BA015E4E6C6F92FCC56E2947608D33330",
+                "PreviousTxnLgrSeq": 90150300
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "f01",
+                  "Owner": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+                  "RootIndex": "08FE718A3C070C1E1DA13EF37C7EA90148F28A8E01879E94258DB573AA304957"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F1DC51C2DD326A767B6E4ABA79A4B67D9F773353E1E4DB2DE91FFA5D08A7EBA6"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "317507.0700329159"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "XDX",
+                    "issuer": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+                    "value": "0"
+                  },
+                  "HighNode": "efd",
+                  "LowLimit": {
+                    "currency": "XDX",
+                    "issuer": "rH7nHWM5xHB374VrLiHga87D7SUcX5PdzF",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F889F0529903BD96FF52498EF0768E945727DF93B762E288EC73AFFF86E3447B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "317507.070032907"
+                  }
+                },
+                "PreviousTxnID": "FA0389C5AE26D1F9897C60E0EE48459BA015E4E6C6F92FCC56E2947608D33330",
+                "PreviousTxnLgrSeq": 90150300
+              }
+            }
+          ],
+          "TransactionIndex": 68,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rs3RZsga1KbhSZetRsL22pkTyWyFU86Kkf",
+        "Amount": "88",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1159,
+        "Fee": "10",
+        "Sequence": 89522278,
+        "SigningPubKey": "EDF1D64EADDC52F5AA380ADF16C94443096C87E2F8854533F3ED79FD424168A12E",
+        "TransactionType": "Payment",
+        "TxnSignature": "75BD90D708003AB91C2C4D00C7FA36607265BB50549BD07156E3F29466D2BFBB0405DDD2F2E36CAFC54240C1B47D7BF67A052F512F6429500B06FEAFF8E90B0A",
+        "hash": "16B87C1F181D85FE57BB37B11EE852D5098683B013A8D12A045A6D5E08B3E484",
+        "DeliverMax": "88",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rs3RZsga1KbhSZetRsL22pkTyWyFU86Kkf",
+                  "Balance": "55109086",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89522279
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "054427CEEE4A008A9E92FC26DEEDB5FEAE6F915D5FD7836B047335C6A20AE7FA",
+                "PreviousFields": {
+                  "Balance": "55109184",
+                  "Sequence": 89522278
+                },
+                "PreviousTxnID": "19EAA5989C249ED755A736B59B03DEE014CFF95F4E948A8C19AB33130DC51CED",
+                "PreviousTxnLgrSeq": 90150367
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180901723",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180901635"
+                },
+                "PreviousTxnID": "8A9571807677CB204C065F37CE348BF364F0527CC7264D87A182AA539C50959A",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 41,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "88"
+        }
+      },
+      {
+        "Account": "rajaw3L7R7hgz8F1VVAobVVPnC3Vujvvhb",
+        "Amount": "87",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1000179,
+        "Fee": "10",
+        "Sequence": 89532862,
+        "SigningPubKey": "ED08F7601644B20FD386BEC0DCE287D64222FB3FE9EECB1485E552123DC55B91C4",
+        "TransactionType": "Payment",
+        "TxnSignature": "5A767AF934F2485EABE16AB9B36D4E108458A70C6FEBAFEA9D43C44CBB5FABE9AAC08256C3E6AE7B86E786D6E69D4EC4194F38AD0E8235513455A3C8C60A7C06",
+        "hash": "1BD0448B078C75260DF3B04C5BCE1AF1FEA58561FD137726834295EED7FCF211",
+        "DeliverMax": "87",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180901899",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180901812"
+                },
+                "PreviousTxnID": "B23385B6542FF5422C41A89E29973ACC3ABA7A5442D20F2403EFA97DCACA38DB",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rajaw3L7R7hgz8F1VVAobVVPnC3Vujvvhb",
+                  "Balance": "55229359",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89532863
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "67D6D3B3F0BF0F6BF400C6B827BF1CEF41E0F22E11761E85387D2583EE0B7501",
+                "PreviousFields": {
+                  "Balance": "55229456",
+                  "Sequence": 89532862
+                },
+                "PreviousTxnID": "18F790771B3FE7674245186A694D29188262E22CD8E6965A4DE75DD5BD3E3923",
+                "PreviousTxnLgrSeq": 90150376
+              }
+            }
+          ],
+          "TransactionIndex": 51,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "87"
+        }
+      },
+      {
+        "Account": "raNR1sExa5tk8QjXe8VEj5gq1a3mooCRy1",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 90150396,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7B226D6F64756C65223A2258574D2041737369737465642054726164696E67222C22616363657373223A2258574D204E4654204469616D6F6E64222C2276657273696F6E223A2276302E352E302062657461222C227374726174656779223A224261736963227D"
+            }
+          }
+        ],
+        "OfferSequence": 78230806,
+        "Sequence": 78230809,
+        "SigningPubKey": "EDFBACDE76DEA63F488370F8C28195DBC845E322A18439B823B85F4111B5799CA2",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "2071E95A11E3ED2FB26C5743AAF32A5544B674145F0C851A347E2D85526A404D08520D4BD244A8D376CD9E81B37A29FCF6C30C1DA3FDC6851337CD713FC7D108",
+        "hash": "1F6289AC558D0D41BCD0A5C34D712AA4840D7BA5D19402EACAEBBFB01D2D0810",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "raNR1sExa5tk8QjXe8VEj5gq1a3mooCRy1",
+                  "BookDirectory": "D0D96BED674C43D3BC63BEF5E4AF279C4779252C712A4887560FFC2EE2A39109",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "1",
+                  "PreviousTxnID": "630C89AE9C44716608745109AC2A00B08A227E0795BCFF27AB4A88DFD7D94FC8",
+                  "PreviousTxnLgrSeq": 90150317,
+                  "Sequence": 78230806,
+                  "TakerGets": {
+                    "currency": "584D454D45000000000000000000000000000000",
+                    "issuer": "r4UPddYeGeZgDhSGPkooURsQtmGda4oYQW",
+                    "value": "222251.71"
+                  },
+                  "TakerPays": "10000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "0CB5EA95ECCB8481D0A7A97ADC46226167FC3E741D967EF6B7A8961B25CC6971"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "raNR1sExa5tk8QjXe8VEj5gq1a3mooCRy1",
+                  "RootIndex": "C6CE007190DE92E642741BD6870BE51AD7D58C678DC184477CA3B82C4BEDA531"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "48BF20571CD1FC2727E8D979CCE05C11558811BF0693649C7738D855B2F1B9F1"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "raNR1sExa5tk8QjXe8VEj5gq1a3mooCRy1",
+                  "Balance": "74822984",
+                  "Flags": 0,
+                  "OwnerCount": 16,
+                  "Sequence": 78230810
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "7CFFE50487104CE975AD1C872CA11A4D00370F1E175583E154D0F23AF4F64998",
+                "PreviousFields": {
+                  "Balance": "74822996",
+                  "OwnerCount": 17,
+                  "Sequence": 78230809
+                },
+                "PreviousTxnID": "F48E4518082FA29BB5DACAA50E3BCABA3B23535726AC7A02C52180CDC2390E6E",
+                "PreviousTxnLgrSeq": 90150358
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "560ffc2ee2a39109",
+                  "Flags": 0,
+                  "RootIndex": "D0D96BED674C43D3BC63BEF5E4AF279C4779252C712A4887560FFC2EE2A39109",
+                  "TakerGetsCurrency": "584D454D45000000000000000000000000000000",
+                  "TakerGetsIssuer": "E8821BE16B79CC5EC488DDE02DED645205C38D1C",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "D0D96BED674C43D3BC63BEF5E4AF279C4779252C712A4887560FFC2EE2A39109"
+              }
+            }
+          ],
+          "TransactionIndex": 52,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150381,
+        "Sequence": 104034214,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+          "value": "0.8244862791883925"
+        },
+        "TakerPays": {
+          "currency": "EUR",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "46695.91669070026"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100F4A535F63C0F6B19511D3D81F88422BCB54680B1B1F5740314183F0C18B7AE2C022079A5637F0F8C371802D3C1A6E6F054544AE6083BAEF8DBBD39276C34423361C0",
+        "hash": "205C8FA2160FBCA935145A72418B9B15CB4BF841EEBF27ADE9FFA77D6B56875E",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "44C3BD278C802227716777088E9D525632D95F663543B7FB8F9FFAB622CF638C",
+                "NewFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "DB071D30B72F44A1ABFF0937C2C53B4D9B6A4EE2F4BC490E59141F0C701F3877",
+                  "OwnerNode": "c982",
+                  "Sequence": 104034214,
+                  "TakerGets": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.8244862791883925"
+                  },
+                  "TakerPays": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "46695.91669070026"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "c981",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9E1545C92DE33FB8C9673211120C31C1F8E9465566DF642829D6131747757F3E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678521",
+                  "Flags": 0,
+                  "OwnerCount": 86,
+                  "Sequence": 104034215
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678531",
+                  "OwnerCount": 85,
+                  "Sequence": 104034214
+                },
+                "PreviousTxnID": "9A491C30D9BF74F6C2329A652982C287FF515CC63C68359BD4986057BF21642A",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DB071D30B72F44A1ABFF0937C2C53B4D9B6A4EE2F4BC490E59141F0C701F3877",
+                "NewFields": {
+                  "ExchangeRate": "59141f0c701f3877",
+                  "RootIndex": "DB071D30B72F44A1ABFF0937C2C53B4D9B6A4EE2F4BC490E59141F0C701F3877",
+                  "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                  "TakerGetsIssuer": "06A148131B436B2561C85967685B098E050EED4E",
+                  "TakerPaysCurrency": "0000000000000000000000004555520000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 20,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rMAGnTv4eMWktZnhKa5cHcDiY84ZiKUaQm",
+        "Amount": "2288",
+        "Destination": "rwtk8uetu7BWwhXqbpqxmCyAFhsDiYbFS6",
+        "Fee": "15",
+        "Flags": 2147483648,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "546970207265776172642066726F6D204D61676E65746963"
+            }
+          }
+        ],
+        "Sequence": 80950461,
+        "SigningPubKey": "03ECD7DE6564273713EE4EA28A1F4522B3B480F66DC903EB4E5309D32F633A6DAC",
+        "TransactionType": "Payment",
+        "TxnSignature": "304402206FE10AAF4495347C4F98C80A454AC01DD945D58CC3D6DFE5C37E960F8A6767840220614C042240E16ADD3C37461F762A73237EEB7B47D273789E32D63404182036D9",
+        "hash": "20C14B01C29057ADB2A46408C25C79A30F518AB596E9EDD6FE652083DDAAF7DF",
+        "DeliverMax": "2288",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMAGnTv4eMWktZnhKa5cHcDiY84ZiKUaQm",
+                  "Balance": "4996567",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 80950462
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "CED60F22A245F8DE393F2351C5097A81836153584DC3C24B803FA1B9906A506A",
+                "PreviousFields": {
+                  "Balance": "4996582",
+                  "Sequence": 80950461
+                },
+                "PreviousTxnID": "0D6A56E32C57437A1CDE64AC4150AEC312BB38AA111290003F544409A03DF844",
+                "PreviousTxnLgrSeq": 90150347
+              }
+            }
+          ],
+          "TransactionIndex": 89,
+          "TransactionResult": "tecUNFUNDED_PAYMENT"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150381,
+        "Sequence": 104034216,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TakerGets": {
+          "currency": "BCH",
+          "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+          "value": "5.241728978310229"
+        },
+        "TakerPays": "3167403436",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100CB331C1798B57BEC7B89AF9225F57F27D8FF12DF2516B34F0BC20327850F02A802204AA87041BAE1545419676551AD20AB39DA2D905F8C125D259035BFD12F62E9D0",
+        "hash": "24C91D28E9EF0DB230803D0CB43B238F5D68FABFD392D27A4A003C04A113D107",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "33C81D720DBA84863A1510FD5C6C3E9224F0F5778261CF175D1577C69063B4D8",
+                "NewFields": {
+                  "ExchangeRate": "5d1577c69063b4d8",
+                  "RootIndex": "33C81D720DBA84863A1510FD5C6C3E9224F0F5778261CF175D1577C69063B4D8",
+                  "TakerGetsCurrency": "0000000000000000000000004243480000000000",
+                  "TakerGetsIssuer": "06CDAB9869053E0AC7764D9ACB35B182CB195414"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "c981",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9E1545C92DE33FB8C9673211120C31C1F8E9465566DF642829D6131747757F3E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678501",
+                  "Flags": 0,
+                  "OwnerCount": 88,
+                  "Sequence": 104034217
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678511",
+                  "OwnerCount": 87,
+                  "Sequence": 104034216
+                },
+                "PreviousTxnID": "9B0EE5E8034C12B6669D709553581696F024BACFD7FCF1C23B574F1C770DE9F7",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "BF32054042C686AEAF45CDEB2ECB9FCED248574BB0F4203001481EC221F29693",
+                "NewFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "33C81D720DBA84863A1510FD5C6C3E9224F0F5778261CF175D1577C69063B4D8",
+                  "OwnerNode": "c982",
+                  "Sequence": 104034216,
+                  "TakerGets": {
+                    "currency": "BCH",
+                    "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+                    "value": "5.241728978310229"
+                  },
+                  "TakerPays": "3167403436"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 22,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104033994,
+        "Sequence": 104034211,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "304402201079F81C8A80DB9C8680454C561D4ED412B49EEBD202B5D566C24F45A7D380E7022005735EDA0A435F7C57A603D268E9A3A851A60F0B09E2D71CCB605A08EDAB7EA9",
+        "hash": "257D389A36B07C2D93AE9B2A6CC0F8F526BC7B6FF740ABFB1154DA78C1CACE06",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "c981",
+                  "IndexPrevious": "c97f",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "459AAE1593169E8594669891FE733971DEC9344F8CFEE6551EEFB3B0DC656F4C"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678551",
+                  "Flags": 0,
+                  "OwnerCount": 85,
+                  "Sequence": 104034212
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678561",
+                  "OwnerCount": 86,
+                  "Sequence": 104034211
+                },
+                "PreviousTxnID": "911B5143CD2CC6ED7116D60831AC2DF2CB95C0012FEE1D887CCB84DDF7FA3561",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "DCBE2F8E6D6301D83DA0FB697299BFEECD45EF73EFD3EC726003C6487D6356F2",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c980",
+                  "PreviousTxnID": "3E55CDF0369C9323AAC45BEF0C1194462605DEC4ABA3AB2D68899F9FEAE5BA15",
+                  "PreviousTxnLgrSeq": 90150299,
+                  "Sequence": 104033994,
+                  "TakerGets": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.8417466729354772"
+                  },
+                  "TakerPays": "89430497639"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "CA8A66DE7C8F931FA51BF061C6AF87E9205BD94C95AB32EF79BF893406B6E36C"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "6003c6487d6356f2",
+                  "Flags": 0,
+                  "RootIndex": "DCBE2F8E6D6301D83DA0FB697299BFEECD45EF73EFD3EC726003C6487D6356F2",
+                  "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                  "TakerGetsIssuer": "06A148131B436B2561C85967685B098E050EED4E",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DCBE2F8E6D6301D83DA0FB697299BFEECD45EF73EFD3EC726003C6487D6356F2"
+              }
+            }
+          ],
+          "TransactionIndex": 17,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rweJHjm5WDjKcfyGSW72xeAkWztE5d2qkP",
+        "Amount": "87",
+        "Destination": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+        "DestinationTag": 1111131,
+        "Fee": "10",
+        "Sequence": 89523254,
+        "SigningPubKey": "ED884D872930844EF8285AF8DCCD78697D04A1BF1DCFF16A00F1BE344AC290DB13",
+        "TransactionType": "Payment",
+        "TxnSignature": "B301FBE504C719E2B6475D3E443B4D3913BF9E799B7E03D06612F59C3900DDE10D96E0AF31FFDD8AB8E4C9FBC87C694F755190A060CE191A4B8147743AC98202",
+        "hash": "317AFA368A630579C0E84661FACF40D09A53527C990692BFE9E07834CBF79112",
+        "DeliverMax": "87",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rweJHjm5WDjKcfyGSW72xeAkWztE5d2qkP",
+                  "Balance": "55125417",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89523255
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2195E6CEEA3CABA6C3EE430DB01F543D20A6869E3D86656942617F8DF347FBF9",
+                "PreviousFields": {
+                  "Balance": "55125514",
+                  "Sequence": 89523254
+                },
+                "PreviousTxnID": "C2320930D579F0B0DCFEF4258864FC22FFCF700ABBBA407EDB76F4C3DB60859D",
+                "PreviousTxnLgrSeq": 90150357
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+                  "Balance": "37855829",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89531841
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2A9DF02FF78FCCE946B77372B25D9C6F875895CEE6AAC1D37A7158BAA3E9BBDC",
+                "PreviousFields": {
+                  "Balance": "37855742"
+                },
+                "PreviousTxnID": "533DFCD5ECEB38DEB39F96D80B452F0F8C803AAC4F44DEB4D0A75FBE7EE35A75",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 37,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "87"
+        }
+      },
+      {
+        "Account": "raNR1sExa5tk8QjXe8VEj5gq1a3mooCRy1",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 90150396,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7B226D6F64756C65223A2258574D2041737369737465642054726164696E67222C22616363657373223A2258574D204E4654204469616D6F6E64222C2276657273696F6E223A2276302E352E302062657461222C227374726174656779223A224261736963227D"
+            }
+          }
+        ],
+        "Sequence": 78230810,
+        "SigningPubKey": "EDFBACDE76DEA63F488370F8C28195DBC845E322A18439B823B85F4111B5799CA2",
+        "TakerGets": {
+          "currency": "584D454D45000000000000000000000000000000",
+          "issuer": "r4UPddYeGeZgDhSGPkooURsQtmGda4oYQW",
+          "value": "222296.17"
+        },
+        "TakerPays": "10000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "06034BEF6731C138825E09D5A273E9F617B995C0E8722DE25047F9985E2FF01860C1595EDDBAB0784FC18908AE33125C23D61AE529B285D3AE4B9D575DEDAF06",
+        "hash": "35A4400A38E91E1098AC0FF98A6CFB4F7ADB33E1FF0C59B8568B9D54AA7D6A5C",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "0C77EE73D4FDCC237066CFD10D6BCAA7BB60AF2C282AFD95D07C81D6577609B8",
+                "NewFields": {
+                  "Account": "raNR1sExa5tk8QjXe8VEj5gq1a3mooCRy1",
+                  "BookDirectory": "D0D96BED674C43D3BC63BEF5E4AF279C4779252C712A4887560FFB5D5CA6E166",
+                  "OwnerNode": "1",
+                  "Sequence": 78230810,
+                  "TakerGets": {
+                    "currency": "584D454D45000000000000000000000000000000",
+                    "issuer": "r4UPddYeGeZgDhSGPkooURsQtmGda4oYQW",
+                    "value": "222296.17"
+                  },
+                  "TakerPays": "10000000"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "raNR1sExa5tk8QjXe8VEj5gq1a3mooCRy1",
+                  "RootIndex": "C6CE007190DE92E642741BD6870BE51AD7D58C678DC184477CA3B82C4BEDA531"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "48BF20571CD1FC2727E8D979CCE05C11558811BF0693649C7738D855B2F1B9F1"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "raNR1sExa5tk8QjXe8VEj5gq1a3mooCRy1",
+                  "Balance": "74822969",
+                  "Flags": 0,
+                  "OwnerCount": 17,
+                  "Sequence": 78230811
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "7CFFE50487104CE975AD1C872CA11A4D00370F1E175583E154D0F23AF4F64998",
+                "PreviousFields": {
+                  "Balance": "74822984",
+                  "OwnerCount": 16,
+                  "Sequence": 78230810
+                },
+                "PreviousTxnID": "1F6289AC558D0D41BCD0A5C34D712AA4840D7BA5D19402EACAEBBFB01D2D0810",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "D0D96BED674C43D3BC63BEF5E4AF279C4779252C712A4887560FFB5D5CA6E166",
+                "NewFields": {
+                  "ExchangeRate": "560ffb5d5ca6e166",
+                  "RootIndex": "D0D96BED674C43D3BC63BEF5E4AF279C4779252C712A4887560FFB5D5CA6E166",
+                  "TakerGetsCurrency": "584D454D45000000000000000000000000000000",
+                  "TakerGetsIssuer": "E8821BE16B79CC5EC488DDE02DED645205C38D1C"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 53,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rpS5T1YgEaxPLSmN4Po6Ufhwa46ZcuLWMj",
+        "Amount": "87",
+        "Destination": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+        "DestinationTag": 75786,
+        "Fee": "10",
+        "Sequence": 89645910,
+        "SigningPubKey": "EDDA62B07E16F4D5F4FF791331A127EAF0F2801B0F188705E1084E2E484FF164A2",
+        "TransactionType": "Payment",
+        "TxnSignature": "23F4F4BDE11AE6C5532C0744D02BE812F8592B7F8807DA72C3885D2B0B1D909401E7C18BD4D43331524BAF6E6E5992544BC3C4708FD70B1D7EED6FC316770700",
+        "hash": "3AE1061BF61BEF17E75D9D1D58B603BD25F9410F628E96BB1C544D7F92DA98C4",
+        "DeliverMax": "87",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+                  "Balance": "37855916",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89531841
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2A9DF02FF78FCCE946B77372B25D9C6F875895CEE6AAC1D37A7158BAA3E9BBDC",
+                "PreviousFields": {
+                  "Balance": "37855829"
+                },
+                "PreviousTxnID": "317AFA368A630579C0E84661FACF40D09A53527C990692BFE9E07834CBF79112",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpS5T1YgEaxPLSmN4Po6Ufhwa46ZcuLWMj",
+                  "Balance": "52719273",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89645911
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A635C954A25D04700BDE078F690258A967EBCF0498FBDAC646DDDAEFA1AF6FD8",
+                "PreviousFields": {
+                  "Balance": "52719370",
+                  "Sequence": 89645910
+                },
+                "PreviousTxnID": "28FDF74763F287024418B113752DFBC8F88B61B25C6C1C64C451F967427446D7",
+                "PreviousTxnLgrSeq": 90150372
+              }
+            }
+          ],
+          "TransactionIndex": 43,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "87"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104034163,
+        "Sequence": 104034204,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "304502210086335A725297F39786FE7BC4D48B6C22ABDC3E0E71A10CF4DE10BBC5A596DCB402205040BB15FA4AE995E219409BF4CA781464B504870B2B43169F61709DD03A2ACC",
+        "hash": "3B3F302CBE0327AB11AC447D64BE04D8A795F07EEC27E0BF42C8A8A58A0A5F10",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5c13e2a0019b4e32",
+                  "Flags": 0,
+                  "RootIndex": "38D06F9EAB40629B223D38A77C895FB39D07FCFCB8D6AE935C13E2A0019B4E32",
+                  "TakerGetsCurrency": "0000000000000000000000004453480000000000",
+                  "TakerGetsIssuer": "06B80F0F1D98AEDA846ED981F741C398FB2C4FD1",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "38D06F9EAB40629B223D38A77C895FB39D07FCFCB8D6AE935C13E2A0019B4E32"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "c981",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9E1545C92DE33FB8C9673211120C31C1F8E9465566DF642829D6131747757F3E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678621",
+                  "Flags": 0,
+                  "OwnerCount": 88,
+                  "Sequence": 104034205
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678631",
+                  "OwnerCount": 89,
+                  "Sequence": 104034204
+                },
+                "PreviousTxnID": "C69C19D4D65986DB586C03DE5576C8B3A957AB7BA57F208F073B816213872EAD",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "38D06F9EAB40629B223D38A77C895FB39D07FCFCB8D6AE935C13E2A0019B4E32",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c982",
+                  "PreviousTxnID": "AFF75DCF5FB42211CD91EB5E4E7BA6E8E67BC0D5080C969DDF6CD02388076177",
+                  "PreviousTxnLgrSeq": 90150372,
+                  "Sequence": 104034163,
+                  "TakerGets": {
+                    "currency": "DSH",
+                    "issuer": "rcXY84C4g14iFp6taFXjjQGVeHqSCh9RX",
+                    "value": "80.29849901947048"
+                  },
+                  "TakerPays": "4494468717"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "C101BBC6595651A738BE5003AD4E08AA2AA68726D7369AF1F257A5A256FA9A0A"
+              }
+            }
+          ],
+          "TransactionIndex": 10,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rJJ2NpGuGmQFuv6ory1yzx9EodZL5pCN5G",
+        "Amount": "89",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1097,
+        "Fee": "10",
+        "Sequence": 89527407,
+        "SigningPubKey": "EDE36E28AFFD5BFED3278F15F45233B87DE4AA4CA92E48A9D45EA993FADA6BE92D",
+        "TransactionType": "Payment",
+        "TxnSignature": "4547C007EDFA55387A10255A78A499C43548DBBA67DB21AA35F7A2E95EF02D504DC0FE9D46C18DF68A3D2BD397E87DF4485F0C157AF3B11736B19444557B2606",
+        "hash": "3E2FC5397C4A2CD9FAD96C8F3128E5B18CBBF4FA53E4EA2B3E7E95064253BEA3",
+        "DeliverMax": "89",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rJJ2NpGuGmQFuv6ory1yzx9EodZL5pCN5G",
+                  "Balance": "55286662",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89527408
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2D265267E6ACA7BBE52868A6EB83A18404E985C0EB9A45F31D72D35D0133BB75",
+                "PreviousFields": {
+                  "Balance": "55286761",
+                  "Sequence": 89527407
+                },
+                "PreviousTxnID": "DD3506E55B48888B55771F4B3BCF425AB86E03BDEB1D8A35B28CE952B17FF003",
+                "PreviousTxnLgrSeq": 90150375
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180902516",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180902427"
+                },
+                "PreviousTxnID": "0EF308B718E6238E68E37CF85A5E37F7985ABD8CF657F25EE78750F10091C3B6",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 86,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "89"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104034065,
+        "Sequence": 104034199,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "304502210091C7FD681B679BBC22A096E4412B992BF1EF91A9442DDBCF653BA2E825F622EA0220197B01755130045CDA9727190E5701E05BF7F453D60658CB9FAEC970B0FCE6A9",
+        "hash": "426FFD2D6EFB1F65CFDDF98EA657520E699C26B075A13C9F94F43552117292BD",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "DB071D30B72F44A1ABFF0937C2C53B4D9B6A4EE2F4BC490E591425CA8A0C2F41",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c981",
+                  "PreviousTxnID": "42F783FC313DA2446DF7AA9251F41218848BF449B4C81D78E6EB8ECEB2456393",
+                  "PreviousTxnLgrSeq": 90150325,
+                  "Sequence": 104034065,
+                  "TakerGets": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "1.687413471115077"
+                  },
+                  "TakerPays": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "95694.08466811763"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "0D3034712F998E40184F4EC7A92C574949B4368FFE43DEF6C63B53F7E6C85586"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678671",
+                  "Flags": 0,
+                  "OwnerCount": 91,
+                  "Sequence": 104034200
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678681",
+                  "OwnerCount": 92,
+                  "Sequence": 104034199
+                },
+                "PreviousTxnID": "BFDE938DC09A87DBA0CA5625F0FD73BFBB97CA4D4FB02415C27F0EC3AF6AC464",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "c982",
+                  "IndexPrevious": "c980",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "D2F5F8819C62765B668C36155555525E6FE527C513A8084409BE785FCDBCAB1F"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "591425ca8a0c2f41",
+                  "Flags": 0,
+                  "RootIndex": "DB071D30B72F44A1ABFF0937C2C53B4D9B6A4EE2F4BC490E591425CA8A0C2F41",
+                  "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                  "TakerGetsIssuer": "06A148131B436B2561C85967685B098E050EED4E",
+                  "TakerPaysCurrency": "0000000000000000000000004555520000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DB071D30B72F44A1ABFF0937C2C53B4D9B6A4EE2F4BC490E591425CA8A0C2F41"
+              }
+            }
+          ],
+          "TransactionIndex": 5,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104033918,
+        "Sequence": 104034207,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "3045022100D744E28F046FA2AD22B4EF7277D96F5C2672AE47173921D2E14ABCAE7838557D022035EB2F6CACDF2BFE0AA2722CE69A14280AE52529DB1A050489BC9456831D362B",
+        "hash": "4302B40269BC8E8A6B341865F0F269FF7A3C768D1CE417687BAD66E340840BE7",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5d1577c69055c0ea",
+                  "Flags": 0,
+                  "RootIndex": "33C81D720DBA84863A1510FD5C6C3E9224F0F5778261CF175D1577C69055C0EA",
+                  "TakerGetsCurrency": "0000000000000000000000004243480000000000",
+                  "TakerGetsIssuer": "06CDAB9869053E0AC7764D9ACB35B182CB195414",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "33C81D720DBA84863A1510FD5C6C3E9224F0F5778261CF175D1577C69055C0EA"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "33C81D720DBA84863A1510FD5C6C3E9224F0F5778261CF175D1577C69055C0EA",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c97f",
+                  "PreviousTxnID": "25A9B81AEAFBDC90F180FACCA4EEAA87E9FADE209A736869C906421DB60097D6",
+                  "PreviousTxnLgrSeq": 90150265,
+                  "Sequence": 104033918,
+                  "TakerGets": {
+                    "currency": "BCH",
+                    "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+                    "value": "5.249076952058057"
+                  },
+                  "TakerPays": "3171843573"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "966CABD84BBFBC6A7002B8812913C9F9FF7E090EE74631A2655C5C930A8AB9C9"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678591",
+                  "Flags": 0,
+                  "OwnerCount": 89,
+                  "Sequence": 104034208
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678601",
+                  "OwnerCount": 90,
+                  "Sequence": 104034207
+                },
+                "PreviousTxnID": "9903496281A9038250B0D0B3F16F390A9A7766AE822C0EF1ACBBEF615C7FD3F7",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "c980",
+                  "IndexPrevious": "c97e",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "D90A03842491ED75750A2A8F8E7198F4FEF9952DB98AF67E834200F562529474"
+              }
+            }
+          ],
+          "TransactionIndex": 13,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150381,
+        "Sequence": 104034217,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TakerGets": {
+          "currency": "BCH",
+          "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+          "value": "10.37756444190712"
+        },
+        "TakerPays": "6270818924",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304402207A8FDC6F8C56996D866726C5FD7B23CCF4D9D17CB4E41F2B37E452C5B1BF320302204ACE6ADAC6E195D951A14603AB0CD0AAA0754B502E6EE409FD0E0E05EF2988DF",
+        "hash": "44CD928FA9178301FA4693B72FBADC41E37F4A80C084AE21B78A5A4E07DEB65B",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "33C81D720DBA84863A1510FD5C6C3E9224F0F5778261CF175D1577C69066AD45",
+                "NewFields": {
+                  "ExchangeRate": "5d1577c69066ad45",
+                  "RootIndex": "33C81D720DBA84863A1510FD5C6C3E9224F0F5778261CF175D1577C69066AD45",
+                  "TakerGetsCurrency": "0000000000000000000000004243480000000000",
+                  "TakerGetsIssuer": "06CDAB9869053E0AC7764D9ACB35B182CB195414"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "6C8E5056B012D375482B6306C17E54ADAD53325112BE2D73BC24E544D06D9EA1",
+                "NewFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "33C81D720DBA84863A1510FD5C6C3E9224F0F5778261CF175D1577C69066AD45",
+                  "OwnerNode": "c982",
+                  "Sequence": 104034217,
+                  "TakerGets": {
+                    "currency": "BCH",
+                    "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+                    "value": "10.37756444190712"
+                  },
+                  "TakerPays": "6270818924"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "c981",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9E1545C92DE33FB8C9673211120C31C1F8E9465566DF642829D6131747757F3E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678491",
+                  "Flags": 0,
+                  "OwnerCount": 89,
+                  "Sequence": 104034218
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678501",
+                  "OwnerCount": 88,
+                  "Sequence": 104034217
+                },
+                "PreviousTxnID": "24C91D28E9EF0DB230803D0CB43B238F5D68FABFD392D27A4A003C04A113D107",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 23,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rLR5BTsGcnMp5SwUzX1V9VCTbN1hayH61R",
+        "Amount": "45",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 40000137,
+        "Fee": "10",
+        "Sequence": 89590400,
+        "SigningPubKey": "EDCAA98FB575F2F37ABFC638D58487961578B936DD52A9E9036C32C42BE84DF471",
+        "TransactionType": "Payment",
+        "TxnSignature": "73A52FDDEEB274045E792463705B4A57387F869077A34975F9E8DDCF69EEE3281760FAB885316C66F1C56E06A0F91D75C5CC942180AAB747148AE2CF7A083103",
+        "hash": "4561ED0814EDC216CEB2C33B4314A33181A000AA10018C79D70CAAD5FB02461F",
+        "DeliverMax": "45",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180902076",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180902031"
+                },
+                "PreviousTxnID": "5CDA5A50C68C52B0AEAE91F45736C61D4C4FF16EF081A6669B113916799B66DD",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rLR5BTsGcnMp5SwUzX1V9VCTbN1hayH61R",
+                  "Balance": "54996274",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89590401
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "9DF478229430E5969F94F60C9A33AE51A62CB96DD1B36BAF153751E5944C55D9",
+                "PreviousFields": {
+                  "Balance": "54996329",
+                  "Sequence": 89590400
+                },
+                "PreviousTxnID": "5CDA5A50C68C52B0AEAE91F45736C61D4C4FF16EF081A6669B113916799B66DD",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 74,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "45"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 7381802,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "262",
+          "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+          "value": "0.000001337543916954988"
+        },
+        "TakerPays": {
+          "currency": "434F524500000000000000000000000000000000",
+          "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+          "value": "0.00000002111098083070419"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "2124F0BAE757E6C406E170AD03FEA8BFF413CFD11F7CF6C33015F94365C64A0CB109BE801EA374409FEB7C0D8FE05ED5B494345B87E256BF85EF7ADED0F3990E",
+        "hash": "46491A71799B0F167CCBBAEEC92F0C73A71E406EC46D57A0962F6ADA6FD56C13",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "9.363079551474463"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "52DB81328A8EFF7305F672D5E8D9C6129B933D4CBC78C440D6EC6862C1B01883",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "9.36308088901838"
+                  }
+                },
+                "PreviousTxnID": "5E4BA18476053A38116B6CCB9C893E61CE537B02C9D03F08BB0103509F080A89",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-197.3126818978532"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "HighNode": "8",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "e9a"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B5AE9624630077C320F4F84D35562B165941C6E7D64BA7722A9CCDF0595F2F7E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-197.3126607921078"
+                  }
+                },
+                "PreviousTxnID": "83069E3255F94E278A77B8D7253B3DA6965E55FBA71D7DC05B9E3425AC6CA738",
+                "PreviousTxnLgrSeq": 90150357
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-85.81231058694953"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rNgEMUDzYaSFGCyBVEbdjWHe4aqRdBJFsN",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "e99"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B96747D67A5D752D833FFBC9A44A4686BF72A4F6FDF2B3DE42009C31A9E532ED",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-85.81233169269498"
+                  }
+                },
+                "PreviousTxnID": "99D252B646D3300ED79DC418AF9C73828641CDE03AE9B012A85ED5228B690FE8",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "46491A71799B0F167CCBBAEEC92F0C73A71E406EC46D57A0962F6ADA6FD56C13",
+                  "Balance": "420568248",
+                  "Flags": 0,
+                  "OwnerCount": 142,
+                  "Sequence": 7381803
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "5E4BA18476053A38116B6CCB9C893E61CE537B02C9D03F08BB0103509F080A89",
+                  "Balance": "420568258",
+                  "Sequence": 7381802
+                },
+                "PreviousTxnID": "5E4BA18476053A38116B6CCB9C893E61CE537B02C9D03F08BB0103509F080A89",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5.436865686510887"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rNgEMUDzYaSFGCyBVEbdjWHe4aqRdBJFsN",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F6B3EA89AA7CA0CFA93C462078472417FE72D18D460E006FFC28933EE4BC7145",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5.43686434896697"
+                  }
+                },
+                "PreviousTxnID": "99D252B646D3300ED79DC418AF9C73828641CDE03AE9B012A85ED5228B690FE8",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            }
+          ],
+          "TransactionIndex": 48,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104033996,
+        "Sequence": 104034209,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "3045022100ED55A5CAA2FA10E4BD7748A61BAA6461E31DD419BA3AFAB3F21D33D705DE2DC2022013B84C7C5176D16B6881A0B6408EE32016504E35C21B6F1CD02F60AD75326717",
+        "hash": "4676284472551BA2429ED8E6B9A342C4CF7E7C9842661BD0B383CECFA21CD889",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "c981",
+                  "IndexPrevious": "c97f",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "459AAE1593169E8594669891FE733971DEC9344F8CFEE6551EEFB3B0DC656F4C"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "6004b47c33a29c2f",
+                  "Flags": 0,
+                  "RootIndex": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C6004B47C33A29C2F",
+                  "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                  "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C6004B47C33A29C2F"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678571",
+                  "Flags": 0,
+                  "OwnerCount": 87,
+                  "Sequence": 104034210
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678581",
+                  "OwnerCount": 88,
+                  "Sequence": 104034209
+                },
+                "PreviousTxnID": "7A1AC7B43BABD48A680B780EDDF8C786DB3F50E5B5B937148A0A05B5534B5B94",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C6004B47C33A29C2F",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c980",
+                  "PreviousTxnID": "0DC272D998D2D2B3C156AF64CB26AE2CF0A5B614A28E354C3DD73F77C609EF45",
+                  "PreviousTxnLgrSeq": 90150300,
+                  "Sequence": 104033996,
+                  "TakerGets": {
+                    "currency": "BTC",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0.04121841316128962"
+                  },
+                  "TakerPays": "5458741760"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "F8F566C6B56912DD84EF880933E2A4EB77309DC7E0C91ABDCC68D5FA77981409"
+              }
+            }
+          ],
+          "TransactionIndex": 15,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 12933004,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "262",
+          "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+          "value": "1209108945623697e-27"
+        },
+        "TakerPays": {
+          "currency": "434F524500000000000000000000000000000000",
+          "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+          "value": "1908369280339045e-29"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "7AD1EC0709B7B27B1FF1BD1A0240CCC843F150D42B6D8BCD3B307211C2F6950871D10091A4F0288465BBA2DC48A76953120AF2CCECE97B886F13398638AE1400",
+        "hash": "47F35FC9B5D65C51A4474811AA177BD907FCF2FA1ACFD6C893F2C589DFA6C0F8",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1E1ADBD847116F2C0DF91CCB7165719E2285397499705C85414A745A3AC80F43",
+                "PreviousTxnID": "FC6AE5D9092F00CFF8F79B3215281D9556FD3CE2D87AA197347DCFE052C74789",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2E3957320EEE887014DF3E881746846EB526FC454748916C461BAADC6DE81B2C",
+                "PreviousTxnID": "FCCE9775345CD7E093A062444636EC54095D6533B212E3D5F16EF1590D92427C",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                  "RootIndex": "372150E433D95E6EDBBA7BFF24ADDE0E649E23282D9BE56862C4C0BE242350B5"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "604501E686FB1F4A23F3F60BF4949100D5F80883730A043BE5D537288092A4BE"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1048576,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c",
+                  "PreviousTxnID": "FCCE9775345CD7E093A062444636EC54095D6533B212E3D5F16EF1590D92427C",
+                  "PreviousTxnLgrSeq": 90150378
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "968094565752D3F13D0F072C005830CC4C81B87EBF471026B2B583BE4F008F9E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "6995000000000000e-28"
+                  },
+                  "Flags": 1114112
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "ea0",
+                  "Owner": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                  "RootIndex": "5DD87298A566F5805C113F1E887578A4AF0123F117D08E74F3A0698F1AD100ED"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B2FBE6A2AD61B0BBC3C6EECCAD32590841ADA8E5AE4811728B29F85AA95A747F"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-85.81231058693849"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rNgEMUDzYaSFGCyBVEbdjWHe4aqRdBJFsN",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "e99"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B96747D67A5D752D833FFBC9A44A4686BF72A4F6FDF2B3DE42009C31A9E532ED",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-85.81231058694953"
+                  }
+                },
+                "PreviousTxnID": "46491A71799B0F167CCBBAEEC92F0C73A71E406EC46D57A0962F6ADA6FD56C13",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "47F35FC9B5D65C51A4474811AA177BD907FCF2FA1ACFD6C893F2C589DFA6C0F8",
+                  "Balance": "1187998088",
+                  "Flags": 0,
+                  "OwnerCount": 52,
+                  "Sequence": 12933005
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "FCCE9775345CD7E093A062444636EC54095D6533B212E3D5F16EF1590D92427C",
+                  "Balance": "1187998098",
+                  "Sequence": 12933004
+                },
+                "PreviousTxnID": "FCCE9775345CD7E093A062444636EC54095D6533B212E3D5F16EF1590D92427C",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5.436865686511586"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rNgEMUDzYaSFGCyBVEbdjWHe4aqRdBJFsN",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F6B3EA89AA7CA0CFA93C462078472417FE72D18D460E006FFC28933EE4BC7145",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5.436865686510887"
+                  }
+                },
+                "PreviousTxnID": "46491A71799B0F167CCBBAEEC92F0C73A71E406EC46D57A0962F6ADA6FD56C13",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F7649E56EB86403211BE414801DA87DD2B143701E72EE2553D87DD748E698848",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1103773976379842e-26"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "ea1"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 65,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 90150391,
+        "OfferSequence": 88338587,
+        "Sequence": 0,
+        "SigningPubKey": "EDDC0F61F5B2EDC288EF56C0F0B9DCC4C1D596165FC7A53D72022FDBEC3C1D2669",
+        "TakerGets": {
+          "currency": "XPM",
+          "issuer": "rXPMof2PnL56qkzP1BjJFWmFCBitYNjV7",
+          "value": "47268.812373"
+        },
+        "TakerPays": "13657751",
+        "TicketSequence": 88338581,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "CC740D993C289547AFF6C55A8F8A1297A6EF294AE75B89FE8921740EC71D8BCCD0E6EBE3FDC470A03B465D563AE4E63793CB3BA6E3104A14D40B46E68025AF0C",
+        "hash": "4E9300CD40CD7DFA915B6552C8FF98CF2B9BEAD832E98A51B1183C403EE8EFF8",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "8e96",
+                  "Owner": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "RootIndex": "53ED31436B8E4B6ABA33E063401FCB848CD1039A6593485672C52B223D0AD814"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "171181272277F945FDB1DDC4CE50CC964B9F8CFFB97B4DF285A8F49E75FBD0C7"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "Flags": 0,
+                  "OwnerNode": "8e96",
+                  "PreviousTxnID": "5FCE50EDCA488E71AC89CA81683644A711D2BAA66E494159A6B94266E034BA5D",
+                  "PreviousTxnLgrSeq": 90150374,
+                  "TicketSequence": 88338581
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "4CAD38C43A9C7922FD92F71347B63196924DA025037DBF8878148BA1E543586E"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "5184CABFDC74B2F8F2ACCADB5F6C07B51BF0848839B4EA3AA40EC32016921433",
+                "NewFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "BookDirectory": "BC44CA32BC71CAE4B73FE7CA24F63C75E419A90F79C39648570A43E4DC9D3000",
+                  "OwnerNode": "8e97",
+                  "Sequence": 88338581,
+                  "TakerGets": {
+                    "currency": "XPM",
+                    "issuer": "rXPMof2PnL56qkzP1BjJFWmFCBitYNjV7",
+                    "value": "47268.46750190351"
+                  },
+                  "TakerPays": "13657751"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "BookDirectory": "BC44CA32BC71CAE4B73FE7CA24F63C75E419A90F79C39648570A43E4DC9D3000",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "8e97",
+                  "PreviousTxnID": "6B1768ACF4C8071BC8CA8DE7C8C01FDB2DFF499C26D5853A81C5B85B487B15ED",
+                  "PreviousTxnLgrSeq": 90150376,
+                  "Sequence": 88338587,
+                  "TakerGets": {
+                    "currency": "XPM",
+                    "issuer": "rXPMof2PnL56qkzP1BjJFWmFCBitYNjV7",
+                    "value": "47268.46750190351"
+                  },
+                  "TakerPays": "13657751"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "56787BACFF0E32458A81186B0CD46190059B0BB2113E95C236FA212270A78AE3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "570a43e4dc9d3000",
+                  "Flags": 0,
+                  "RootIndex": "BC44CA32BC71CAE4B73FE7CA24F63C75E419A90F79C39648570A43E4DC9D3000",
+                  "TakerGetsCurrency": "00000000000000000000000058504D0000000000",
+                  "TakerGetsIssuer": "05BF248FCC66F460FA409F08318975FE8AB2FD1E",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "BC44CA32BC71CAE4B73FE7CA24F63C75E419A90F79C39648570A43E4DC9D3000"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "Balance": "1767846377",
+                  "Flags": 0,
+                  "OwnerCount": 94,
+                  "Sequence": 88338620,
+                  "TicketCount": 46
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C95B3E1594FED5D82C3BA09148095523ABB8C6FF39F02C29DE15B4F4E5B2E8E5",
+                "PreviousFields": {
+                  "Balance": "1767846389",
+                  "OwnerCount": 95,
+                  "TicketCount": 47
+                },
+                "PreviousTxnID": "561155A7A882D4336F33A8B4DD238C3B603E2AC57B05077C799D4786470AD674",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "8e97",
+                  "IndexPrevious": "8e8b",
+                  "Owner": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "RootIndex": "53ED31436B8E4B6ABA33E063401FCB848CD1039A6593485672C52B223D0AD814"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "E4D56D7DFBAABD40EE948A9DC3A8F6F0C1764293EAA2D29DCF6F2366262E102C"
+              }
+            }
+          ],
+          "TransactionIndex": 82,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 90150396,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7B226D6F64756C65223A2258574D2041737369737465642054726164696E67222C22616363657373223A2258574D204E4654204469616D6F6E64222C2276657273696F6E223A2276302E352E302062657461222C227374726174656779223A224261736963227D"
+            }
+          }
+        ],
+        "OfferSequence": 77858006,
+        "Sequence": 77858009,
+        "SigningPubKey": "ED3DCAF22FDDABE246DA4599A938559C95DA2BD90A2799354C9176B69E4F16BCAF",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "83549F7C311086CF92B5CDEA65D74A559F36C768600B605500276AA550227CE5CE8C9F24425B06FA69837AE68D58B97187747025100F445746905754FC566002",
+        "hash": "4EA0C25DA4CEC179C6DAB5DA9E0E8E230DC31846A29216380A7C27D4EC2F1E9F",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+                  "Balance": "237723964",
+                  "Flags": 0,
+                  "OwnerCount": 16,
+                  "Sequence": 77858010
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "0943A7CA0445F090EFA54DF215581407714AE7E396207B491C049F9EB75BB6A5",
+                "PreviousFields": {
+                  "Balance": "237723976",
+                  "OwnerCount": 17,
+                  "Sequence": 77858009
+                },
+                "PreviousTxnID": "F698BECA564EA406838200FC9EF3A2BBAB252E0E25DD0C928B2EDD5B872E2F96",
+                "PreviousTxnLgrSeq": 90150367
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+                  "BookDirectory": "A6BFCA061E062526916956017862BD0B9630A86F6C5F0455501F2F3980C1DBA0",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "1",
+                  "PreviousTxnID": "85DF86F8ADEF19F191365A0A013D820002D0CF219AAC384E67F7F85B98361654",
+                  "PreviousTxnLgrSeq": 90150356,
+                  "Sequence": 77858006,
+                  "TakerGets": "10000000",
+                  "TakerPays": {
+                    "currency": "SGB",
+                    "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+                    "value": "877.764829786"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "32202415B1AC67C04ECAA7A62F5F910B1A76AFB050F1CAB58AD0E57E19E0AB04"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+                  "RootIndex": "FB7FD5BD320C1FD457BA3FA9416E901182140B8712DE967A67ADB9A7DBB2AAFD"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "81831B6ECB29F00B5C9F237E6AA794AF27C90F7A5D7F9F05A92E712767302A03"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "501f2f3980c1dba0",
+                  "Flags": 0,
+                  "RootIndex": "A6BFCA061E062526916956017862BD0B9630A86F6C5F0455501F2F3980C1DBA0",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000005347420000000000",
+                  "TakerPaysIssuer": "06C9E89FEF0D5C8CE1E752F3A279627D51A0E7B4"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "A6BFCA061E062526916956017862BD0B9630A86F6C5F0455501F2F3980C1DBA0"
+              }
+            }
+          ],
+          "TransactionIndex": 25,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rfrHPNAUweBQCRJ9VZfefbM7WdCH48CKWH",
+        "Amount": "87",
+        "Destination": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+        "DestinationTag": 1111170,
+        "Fee": "10",
+        "Sequence": 89532986,
+        "SigningPubKey": "ED97FEDE0B369CFD8CED6734CC890F1B51A343862989BAEAB2288B5AC339B889C6",
+        "TransactionType": "Payment",
+        "TxnSignature": "3E2B82665AD24300E45DA83348E10F5378AB66E53E4058FE468E56812B17F416EE071D1FDA0B938D8EE419BD255E8A6F34667D3FBD6EF93C1FD818CF94CEC002",
+        "hash": "533DFCD5ECEB38DEB39F96D80B452F0F8C803AAC4F44DEB4D0A75FBE7EE35A75",
+        "DeliverMax": "87",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+                  "Balance": "37855742",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89531841
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2A9DF02FF78FCCE946B77372B25D9C6F875895CEE6AAC1D37A7158BAA3E9BBDC",
+                "PreviousFields": {
+                  "Balance": "37855655"
+                },
+                "PreviousTxnID": "F89307CD760EBBCCD6C64DA8A417EF7D693E6413B743248CB1846043DC33A723",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rfrHPNAUweBQCRJ9VZfefbM7WdCH48CKWH",
+                  "Balance": "55344594",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89532987
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C8ED992936DEBA0D9CB767D19E16A3F4E7244E87A1954630450B02D59B008C5E",
+                "PreviousFields": {
+                  "Balance": "55344691",
+                  "Sequence": 89532986
+                },
+                "PreviousTxnID": "9158FD91CCF26C29F9C1B87EF4BCA400EF0BC17F0ECBBA8389113ADA800191D3",
+                "PreviousTxnLgrSeq": 90150373
+              }
+            }
+          ],
+          "TransactionIndex": 28,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "87"
+        }
+      },
+      {
+        "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 90150391,
+        "OfferSequence": 88338592,
+        "Sequence": 0,
+        "SigningPubKey": "EDDC0F61F5B2EDC288EF56C0F0B9DCC4C1D596165FC7A53D72022FDBEC3C1D2669",
+        "TakerGets": {
+          "currency": "504958454C000000000000000000000000000000",
+          "issuer": "rK7stnonvoYMdoUrskiiWv6aZDvJ2ZgKAB",
+          "value": "475.0023368"
+        },
+        "TakerPays": "6887429",
+        "TicketSequence": 88338573,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "6CA95B08C836FC359D37CF2772E7B6A1E1D91A73C87AE791D46721BFCE9C05EA553E271D99728519FF8A579C069CC36A8203B4DE80252CCDF9D1586B084D1500",
+        "hash": "561155A7A882D4336F33A8B4DD238C3B603E2AC57B05077C799D4786470AD674",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "8e96",
+                  "Owner": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "RootIndex": "53ED31436B8E4B6ABA33E063401FCB848CD1039A6593485672C52B223D0AD814"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "171181272277F945FDB1DDC4CE50CC964B9F8CFFB97B4DF285A8F49E75FBD0C7"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "590526c46eeca000",
+                  "Flags": 0,
+                  "RootIndex": "2D05C0A07A644ACF28E30E7682A1A01856BA2958729AF9CB590526C46EECA000",
+                  "TakerGetsCurrency": "504958454C000000000000000000000000000000",
+                  "TakerGetsIssuer": "CA8FE658DA594C043BD17FB2AD43D055ABAE0AD3",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "2D05C0A07A644ACF28E30E7682A1A01856BA2958729AF9CB590526C46EECA000"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "Flags": 0,
+                  "OwnerNode": "8e96",
+                  "PreviousTxnID": "5FCE50EDCA488E71AC89CA81683644A711D2BAA66E494159A6B94266E034BA5D",
+                  "PreviousTxnLgrSeq": 90150374,
+                  "TicketSequence": 88338573
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "48AB5BD70133FBFFD427E148CC429AB8183F836FB6170EDFE72303EAD8DB67F9"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "7B3397819B33073A64BFD1E64655339C8627B3D0FD96287DCFD838B911159710",
+                "NewFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "BookDirectory": "2D05C0A07A644ACF28E30E7682A1A01856BA2958729AF9CB590526C46EECA000",
+                  "OwnerNode": "8e97",
+                  "Sequence": 88338573,
+                  "TakerGets": {
+                    "currency": "504958454C000000000000000000000000000000",
+                    "issuer": "rK7stnonvoYMdoUrskiiWv6aZDvJ2ZgKAB",
+                    "value": "474.9951034482759"
+                  },
+                  "TakerPays": "6887429"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "Balance": "1767846389",
+                  "Flags": 0,
+                  "OwnerCount": 95,
+                  "Sequence": 88338620,
+                  "TicketCount": 47
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C95B3E1594FED5D82C3BA09148095523ABB8C6FF39F02C29DE15B4F4E5B2E8E5",
+                "PreviousFields": {
+                  "Balance": "1767846401",
+                  "OwnerCount": 96,
+                  "TicketCount": 48
+                },
+                "PreviousTxnID": "1A6F3EE68FFCBC3BC71EDEABBB396F3E6FD7571B0D8C4036735EB75A9FAD2553",
+                "PreviousTxnLgrSeq": 90150376
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "BookDirectory": "2D05C0A07A644ACF28E30E7682A1A01856BA2958729AF9CB590526C46EECA000",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "8e97",
+                  "PreviousTxnID": "1A6F3EE68FFCBC3BC71EDEABBB396F3E6FD7571B0D8C4036735EB75A9FAD2553",
+                  "PreviousTxnLgrSeq": 90150376,
+                  "Sequence": 88338592,
+                  "TakerGets": {
+                    "currency": "504958454C000000000000000000000000000000",
+                    "issuer": "rK7stnonvoYMdoUrskiiWv6aZDvJ2ZgKAB",
+                    "value": "474.9951034482759"
+                  },
+                  "TakerPays": "6887429"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "CFE06DC9B80CC9CCAA889E8C9DDD5402E905D595EC2EABA2EAC0A961055A6A7E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "8e97",
+                  "IndexPrevious": "8e8b",
+                  "Owner": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "RootIndex": "53ED31436B8E4B6ABA33E063401FCB848CD1039A6593485672C52B223D0AD814"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "E4D56D7DFBAABD40EE948A9DC3A8F6F0C1764293EAA2D29DCF6F2366262E102C"
+              }
+            }
+          ],
+          "TransactionIndex": 81,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 90150391,
+        "OfferSequence": 88338549,
+        "Sequence": 0,
+        "SigningPubKey": "EDDC0F61F5B2EDC288EF56C0F0B9DCC4C1D596165FC7A53D72022FDBEC3C1D2669",
+        "TakerGets": "10961956",
+        "TakerPays": {
+          "currency": "CTF",
+          "issuer": "r9Xzi4KsSF1Xtr8WHyBmUcvfP9FzTyG5wp",
+          "value": "20.6214441"
+        },
+        "TicketSequence": 88338590,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "0F385B23CD9D584023C518ED858B3379DD3DB427D64BCEBC29AFC58CCD4B3ECD1F638A2B231361AD122DB489E44B4B5AD4D45EC514E7D5B09F67C6EFE7494006",
+        "hash": "5935A108CF6CC03BA2EFA158F9961A92B4937E326F02BA3EFB433BC90D4FEFA3",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "8e96",
+                  "Owner": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "RootIndex": "53ED31436B8E4B6ABA33E063401FCB848CD1039A6593485672C52B223D0AD814"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "171181272277F945FDB1DDC4CE50CC964B9F8CFFB97B4DF285A8F49E75FBD0C7"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "Flags": 0,
+                  "OwnerNode": "8e96",
+                  "PreviousTxnID": "5FCE50EDCA488E71AC89CA81683644A711D2BAA66E494159A6B94266E034BA5D",
+                  "PreviousTxnLgrSeq": 90150374,
+                  "TicketSequence": 88338590
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "328179EB06A1FCD9507B9494C4A5DA93078F409A90A942A59FEE298A09C17F27"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "41DC3907E0544D14F6C1963E881BC7CFF5A3FC9E17E815ED1843E5FED26D2335",
+                "NewFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "BookDirectory": "F659CD75B06FE8D87B6835DE42D740B9716ACAE3EC7F6DAD4F06AEF104F98BE1",
+                  "OwnerNode": "8e97",
+                  "Sequence": 88338590,
+                  "TakerGets": "10961856",
+                  "TakerPays": {
+                    "currency": "CTF",
+                    "issuer": "r9Xzi4KsSF1Xtr8WHyBmUcvfP9FzTyG5wp",
+                    "value": "20.6214441"
+                  }
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "BookDirectory": "F659CD75B06FE8D87B6835DE42D740B9716ACAE3EC7F6DAD4F06AEF104F98BE1",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "8e97",
+                  "PreviousTxnID": "3241ED838162FE745C52AEA4AA2D959FC6A2AC532B8FDFAAB1F3C1E3DA7C3B61",
+                  "PreviousTxnLgrSeq": 90150374,
+                  "Sequence": 88338549,
+                  "TakerGets": "10961856",
+                  "TakerPays": {
+                    "currency": "CTF",
+                    "issuer": "r9Xzi4KsSF1Xtr8WHyBmUcvfP9FzTyG5wp",
+                    "value": "20.6214441"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "52598014DBA07BF940E5AAFB542FD103979061E0E372E0D796B4E31B8F82F483"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "Balance": "1767846365",
+                  "Flags": 0,
+                  "OwnerCount": 93,
+                  "Sequence": 88338620,
+                  "TicketCount": 45
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C95B3E1594FED5D82C3BA09148095523ABB8C6FF39F02C29DE15B4F4E5B2E8E5",
+                "PreviousFields": {
+                  "Balance": "1767846377",
+                  "OwnerCount": 94,
+                  "TicketCount": 46
+                },
+                "PreviousTxnID": "4E9300CD40CD7DFA915B6552C8FF98CF2B9BEAD832E98A51B1183C403EE8EFF8",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "8e97",
+                  "IndexPrevious": "8e8b",
+                  "Owner": "rUytn6C2SCPtLEUMS7CiroRt6ZRr8MPUnN",
+                  "RootIndex": "53ED31436B8E4B6ABA33E063401FCB848CD1039A6593485672C52B223D0AD814"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "E4D56D7DFBAABD40EE948A9DC3A8F6F0C1764293EAA2D29DCF6F2366262E102C"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f06aef104f98be1",
+                  "Flags": 0,
+                  "RootIndex": "F659CD75B06FE8D87B6835DE42D740B9716ACAE3EC7F6DAD4F06AEF104F98BE1",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000004354460000000000",
+                  "TakerPaysIssuer": "5D9DC6DF26803CCB315D17C15B69A0A49DB1B7A5"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F659CD75B06FE8D87B6835DE42D740B9716ACAE3EC7F6DAD4F06AEF104F98BE1"
+              }
+            }
+          ],
+          "TransactionIndex": 83,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rLR5BTsGcnMp5SwUzX1V9VCTbN1hayH61R",
+        "Amount": "87",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 40000169,
+        "Fee": "10",
+        "Sequence": 89590399,
+        "SigningPubKey": "EDCAA98FB575F2F37ABFC638D58487961578B936DD52A9E9036C32C42BE84DF471",
+        "TransactionType": "Payment",
+        "TxnSignature": "FD92A04F123D6E96B18400289A5BE97CC2A4B8A8FA0CB98199D02595B5D7EF4F742A041A4D8CA53897FC1B7B67B5C7B6FEEC8F89A4F02460406284363CE45A03",
+        "hash": "5CDA5A50C68C52B0AEAE91F45736C61D4C4FF16EF081A6669B113916799B66DD",
+        "DeliverMax": "87",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180902031",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180901944"
+                },
+                "PreviousTxnID": "89F683F674A09729A9061BEFA5993E37456A95ADD1ED65AB382F8D4B18DBCD28",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rLR5BTsGcnMp5SwUzX1V9VCTbN1hayH61R",
+                  "Balance": "54996329",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89590400
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "9DF478229430E5969F94F60C9A33AE51A62CB96DD1B36BAF153751E5944C55D9",
+                "PreviousFields": {
+                  "Balance": "54996426",
+                  "Sequence": 89590399
+                },
+                "PreviousTxnID": "CAF0B9D95A678694ABA8A4AABB0B1566449DA57D65C2EAB3405DED41ECE3DC28",
+                "PreviousTxnLgrSeq": 90150361
+              }
+            }
+          ],
+          "TransactionIndex": 73,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "87"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 7381801,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "NET",
+          "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+          "value": "0.000002009491977936183"
+        },
+        "TakerPays": {
+          "currency": "262",
+          "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+          "value": "0.000000001337543916954988"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "4B6F14B0CB24086C7DA97A8492DDC183BAE809B7E91C53305A65FB40C53095142051AADF939DF17E7FCFFD44DD49058303D5F6CE6307A27565A7D6D0EF487A0E",
+        "hash": "5E4BA18476053A38116B6CCB9C893E61CE537B02C9D03F08BB0103509F080A89",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "9.36308088901838"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "52DB81328A8EFF7305F672D5E8D9C6129B933D4CBC78C440D6EC6862C1B01883",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "9.363079551474054"
+                  }
+                },
+                "PreviousTxnID": "A786B8DB8FFE0BF4EDD13FAF77896C7C217629B83A67D207F90B4F9C0E296656",
+                "PreviousTxnLgrSeq": 90150357
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000000035831252437583"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "7E7F2D4E27869445BE12682DFCB1420364E2EB5355BD8B4EA40A6B6DC236D2B1",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000002045323230373766"
+                  }
+                },
+                "PreviousTxnID": "9D90B824387DC4EF5B57513EDED9D267833D476D6E4A39205F8D221F713022DB",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1.226438319438625"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rGN8wfCoi7pJ2Eei9uA8ZcChHRJfLuzanu",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "944A055528510CEB85DDFD5B6D67EDF8DAF23B368766F37C698802502C7BBDA6",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1.226436309946647"
+                  }
+                },
+                "PreviousTxnID": "56AF3F97E43677CA3F5FD816E7C049B558CA95C70E9394703195F377757BA271",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.8163321606184202"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rGN8wfCoi7pJ2Eei9uA8ZcChHRJfLuzanu",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "9473E7A7DF990F7AD640AB094F152F31D3DF0C82F144214BC7394543B178DE73",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.8163334981627467"
+                  }
+                },
+                "PreviousTxnID": "56AF3F97E43677CA3F5FD816E7C049B558CA95C70E9394703195F377757BA271",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "5E4BA18476053A38116B6CCB9C893E61CE537B02C9D03F08BB0103509F080A89",
+                  "Balance": "420568258",
+                  "Flags": 0,
+                  "OwnerCount": 142,
+                  "Sequence": 7381802
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "9D90B824387DC4EF5B57513EDED9D267833D476D6E4A39205F8D221F713022DB",
+                  "Balance": "420568268",
+                  "Sequence": 7381801
+                },
+                "PreviousTxnID": "9D90B824387DC4EF5B57513EDED9D267833D476D6E4A39205F8D221F713022DB",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 47,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104033821,
+        "Sequence": 104034197,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "3044022078248DE8E7BA4C58F86A30A674F7EC4DE5BAF78D9E91E285056316777CD48E6C02202776E21F6DC020C61B7F36A6F419A9357E5F5B2481234B35061132AF2E4BBDC2",
+        "hash": "63B35726DDF88FF9BFD3F4A5C1BB3EA2A18C6F0EF5F956145E13260D0C966B61",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "c97e",
+                  "IndexPrevious": "c97c",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "4F8AE257E6A66DF63C832E1A3968EF02438A46D65A113DE0C0E39FE38DC84353"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5006ae466ee8154d",
+                  "Flags": 0,
+                  "RootIndex": "8C7111E0E30AA0E3D31C2A0973C2C7B57CCBF55988136BF05006AE466EE8154D",
+                  "TakerGetsCurrency": "0000000000000000000000004555520000000000",
+                  "TakerGetsIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230",
+                  "TakerPaysCurrency": "0000000000000000000000004254430000000000",
+                  "TakerPaysIssuer": "06A148131B436B2561C85967685B098E050EED4E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "8C7111E0E30AA0E3D31C2A0973C2C7B57CCBF55988136BF05006AE466EE8154D"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678691",
+                  "Flags": 0,
+                  "OwnerCount": 93,
+                  "Sequence": 104034198
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678701",
+                  "OwnerCount": 94,
+                  "Sequence": 104034197
+                },
+                "PreviousTxnID": "7B9AE961F7A1B6527C0E0D106CCCA38FA53C009A0182E36CD60021466FF6DBD1",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "8C7111E0E30AA0E3D31C2A0973C2C7B57CCBF55988136BF05006AE466EE8154D",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c97d",
+                  "PreviousTxnID": "4DC7C16E9B1B3A76E8FB875186B394C6EA1B274CB608C1A6A84041AD396D69AB",
+                  "PreviousTxnLgrSeq": 90150241,
+                  "Sequence": 104033821,
+                  "TakerGets": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "19584.19007280612"
+                  },
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.3682743082890382"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "FA9889CCA1C96CE86EF9ACC7AA5B29205ABAE944B899D9AF0457BD53A122E02C"
+              }
+            }
+          ],
+          "TransactionIndex": 3,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rwjyDXa3YsdZUJcJSDkyRRvt1qwPfxVNKY",
+        "Amount": "1",
+        "Destination": "rBopDD8B5v54exL7UvJ6TTzz9dG1FTqiQ2",
+        "DestinationTag": 2017,
+        "Fee": "25",
+        "Flags": 2147483648,
+        "LastLedgerSequence": 90150391,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "5768656E20796F75207365652074686973206D6573736167652C207765206861766520616C7265616479206265656E206172726573746564206F72207475726E6564206F757273656C76657320696E2E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "546F20616C6C20476174654875622075736572732C"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "476174654875622069732061207368616D656C6573732063686561742E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "496E20323031372C2047617465487562206C6F7374207E354D2055534420637573746F6D6572206173736574732062656361757365207468657920646964206E6F7420756E6465727374616E64205061727469616C205061796D656E742066656174757265"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "496E20323032322C2077652073656E74207E31334D205553442061737365747320746F204761746548756220776974682074686569722070726F6D697365733A"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "312E206E6F206C6F6E6765722074616B65206C6567616C20616374696F6E20616761696E7374207573"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "322E206E6F206675727468657220636C61696D7320666F7220636F6D70656E736174696F6E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "332E206B65657020354D2055534420616E64206169722064726F7020746865206C6566742061737365747320746F20616C6C2047617465487562207573657273"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "342E20646F206E6F74207368617265206F757220696E666F726D6174696F6E20776974682074686972642070617274696573"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "352E206D616B6520616E20616E6E6F756E63656D656E7420726567617264696E67207468652061626F76652061677265656D656E7473"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "77652073656E742074686520636F696E732C20627574204761746548756220646964206E6F74206B6565702074686569722070726F6D69736573"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "6E6F20616E6E6F756E63656D656E742C206E6F206169722064726F702C20636F6E74696E756520746F20746872656174656E2075732077697468206C6567616C20616374696F6E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "476174654875622061736B20666F72206D6F726520616E64206D6F726520636F696E732E20416E20696E7361746961626C6520626C61636B6D61696C657221"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "57652068617665206E6F206D6F726520636F696E732C2074686520747275746820697320746865206F6E6C79207468696E672077652063616E207368617265"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "54686520747275746820697320746865206F6E6C79207468696E672077652063616E2073686172652E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "54686520747275746820697320746865206F6E6C79207468696E672077652063616E2073686172652E"
+            }
+          }
+        ],
+        "Sequence": 90840630,
+        "SigningPubKey": "03924D5111DD356B7B68E7E68A16848968B8492D812728627A3582572B14C798BF",
+        "TransactionType": "Payment",
+        "TxnSignature": "3045022100DBEE9A78E7C02F79E65727BAD567BE7A8EF9FAA967DFA2D17A9FC665898F83DF022054CF74F08673D3816F480221765E88A3BDC3BB278C2D1025FC2AEA795FC69105",
+        "hash": "67F541C1DF43C4EBCDEA28A3F193FFC20F33EC4E0B321C3521F8CAE031F5F4D6",
+        "DeliverMax": "1",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBopDD8B5v54exL7UvJ6TTzz9dG1FTqiQ2",
+                  "Balance": "17732705099",
+                  "Flags": 0,
+                  "OwnerCount": 124,
+                  "Sequence": 67548541
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "03D091E4F0F519AB1256FBDF98C3B16E7060E658B5A7F8547A7EF92C0AE6788F",
+                "PreviousFields": {
+                  "Balance": "17732705098"
+                },
+                "PreviousTxnID": "CFE84E781C10E4C2C40646332DE6A7E32B74A21643055DD499BBDA44D2F50EE1",
+                "PreviousTxnLgrSeq": 90117681
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rwjyDXa3YsdZUJcJSDkyRRvt1qwPfxVNKY",
+                  "Balance": "4918370077",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 90840631
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1E70E44C3D201A11890678AC660EAD84642373F8D9B261ADEFA324306792F2B",
+                "PreviousFields": {
+                  "Balance": "4918370103",
+                  "Sequence": 90840630
+                },
+                "PreviousTxnID": "155ECB93E6128690A149D1D9037B43B94C3DF8DA892F90C9DE3FCC4ED0273B7F",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            }
+          ],
+          "TransactionIndex": 36,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "1"
+        }
+      },
+      {
+        "Account": "rBA7oBScBPccjDcmGhkmCY82v2ZeLa2K2f",
+        "Amount": "174265552",
+        "Destination": "rs2dgzYeqYqsk8bvkQR5YPyqsXYcA24MP2",
+        "DestinationTag": 388748,
+        "Fee": "1000000",
+        "Flags": 0,
+        "LastLedgerSequence": 90150396,
+        "Sequence": 73986195,
+        "SigningPubKey": "0311E5577768E37697156D9D9B19452F5AC3A71695B05D8D452CAC1B6B02D4227F",
+        "TransactionType": "Payment",
+        "TxnSignature": "304402206C7132CCCA24EBD1AA23CD47282E04DD6EFF7304268E2FCB630FEC5F7BA3BA3E0220065AD5358D53EFA2BABEBE3E200D62C5663CF0FBBA51B3161E0E48F7A2768410",
+        "hash": "6B5C03CA07C5E0AF382249396C3B2BAABDA78E0BC13B00989BC24B7A4CA436B4",
+        "DeliverMax": "174265552",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rs2dgzYeqYqsk8bvkQR5YPyqsXYcA24MP2",
+                  "Balance": "2976705552639",
+                  "Flags": 131072,
+                  "OwnerCount": 9,
+                  "Sequence": 945704
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "64B6FFE42CFD12696CE8BB04843DAC143820CF5BC4EFB10F51C293CB9B77C14F",
+                "PreviousFields": {
+                  "Balance": "2976531287087"
+                },
+                "PreviousTxnID": "CB1DF7EFEDD1AB0DBD1513F31647246BAF5A8DFCD8FCE94D3FAEAAEBC8F54FF5",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBA7oBScBPccjDcmGhkmCY82v2ZeLa2K2f",
+                  "Balance": "1813067694322",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 73986196
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E46AD04FC6268AFC5E4B22519F0242F93A2C62D0349C6FE51ECA0E76527FAE2D",
+                "PreviousFields": {
+                  "Balance": "1813242959874",
+                  "Sequence": 73986195
+                },
+                "PreviousTxnID": "65D539EABD6F6DCE779EB470288977556330912C22B76D6EB6A1F9A13F78C10B",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            }
+          ],
+          "TransactionIndex": 30,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "174265552"
+        }
+      },
+      {
+        "Account": "rfmRWBnsURok77crAHEdtnA5ExbPYAy4Sy",
+        "Amount": "87",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1149,
+        "Fee": "10",
+        "Sequence": 89637077,
+        "SigningPubKey": "ED31AA3CF5C54656363A271D5B872A12B8239901CAF3AAC662B73A7892ACD02EA5",
+        "TransactionType": "Payment",
+        "TxnSignature": "DD3862353E9183703373B583018526E13F547A6FAA7F97B2BD4F2CA12A25CF8A2DF6A20A8C3E4CCAD2803AB31DD84DF2BDCF88D8BF22ED67713CC6F2DE0EE402",
+        "hash": "6C7EE4F2E7BA797FC8BDDC8BE7AA1226A7ED1C02055F45F44ACB09439235374A",
+        "DeliverMax": "87",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180901413",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180901326"
+                },
+                "PreviousTxnID": "E9CEC850BBDDDF5600CD8C514A717824A83CD44F4382EEFFC6D4BBC11853FD88",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rfmRWBnsURok77crAHEdtnA5ExbPYAy4Sy",
+                  "Balance": "52759973",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89637078
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E6CF777504641E703E6EED807F5576EDAB6A133D9CE5FEE510A5A55F762FD279",
+                "PreviousFields": {
+                  "Balance": "52760070",
+                  "Sequence": 89637077
+                },
+                "PreviousTxnID": "38A3831C5D1663684283B03ED5DF5A9D113CE4B9A315A05F652823A5EA50D0CC",
+                "PreviousTxnLgrSeq": 90150371
+              }
+            }
+          ],
+          "TransactionIndex": 24,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "87"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "Sequence": 104034205,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TakerGets": {
+          "currency": "BCH",
+          "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+          "value": "5.238767300180419"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "1841.021613637472"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3044022017645FC96943EDF377417F589433297BEBB8F42A0C5E3B68FEF73FDC0C3F37F5022004DF4545C75CD12300F053F1B01674CE7BAE0AD378319D43D861285D53019AE4",
+        "hash": "6F294B39AFE6E09C3337FC92C5974FAF861D64E9DE4C33550481BE80B6E80B11",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "c981",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9E1545C92DE33FB8C9673211120C31C1F8E9465566DF642829D6131747757F3E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678611",
+                  "Flags": 0,
+                  "OwnerCount": 89,
+                  "Sequence": 104034206
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678621",
+                  "OwnerCount": 88,
+                  "Sequence": 104034205
+                },
+                "PreviousTxnID": "3B3F302CBE0327AB11AC447D64BE04D8A795F07EEC27E0BF42C8A8A58A0A5F10",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "EEF2CACB0DCA54B77773A166FE4DC0CF717C805F2574F49F3C1A8F97C2E783DC",
+                "NewFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "FC4B99C28DF8622E6040A053A39DA16EB7A8EA2A61D569D3570C7C2BAC8F4F9A",
+                  "OwnerNode": "c982",
+                  "Sequence": 104034205,
+                  "TakerGets": {
+                    "currency": "BCH",
+                    "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+                    "value": "5.238767300180419"
+                  },
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "1841.021613637472"
+                  }
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "FC4B99C28DF8622E6040A053A39DA16EB7A8EA2A61D569D3570C7C2BAC8F4F9A",
+                "NewFields": {
+                  "ExchangeRate": "570c7c2bac8f4f9a",
+                  "RootIndex": "FC4B99C28DF8622E6040A053A39DA16EB7A8EA2A61D569D3570C7C2BAC8F4F9A",
+                  "TakerGetsCurrency": "0000000000000000000000004243480000000000",
+                  "TakerGetsIssuer": "06CDAB9869053E0AC7764D9ACB35B182CB195414",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 11,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 12932993,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": "1444",
+        "TakerPays": {
+          "currency": "5553444300000000000000000000000000000000",
+          "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+          "value": "0.0000008402766638866123"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "A890325724977962637359F964D4DBBE56E73CE9E180DAFD89A5D4460D83D2F604971BE22747E0945292E7916A329CF3E9CF2222D322C1282141AA50C447F503",
+        "hash": "73552ED92ADB71A7563296A4643EB97230D6496FBD64CDDB1403545ACE2FFCCF",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "6EEFBC49B3F475E7DF6C906307DE385FB08661D21E0109E8A51FFBB700B904F6",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0008403498"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "0"
+                  },
+                  "LowNode": "169"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A14493C8BFD5BFDEAA3A0CF3CA9BF9D0E776C0FF04A3707844E8EC6CA87C399F",
+                "PreviousTxnID": "86B677B694E67F4DA1A2C345CCBDCAE5D7994921772A1322DA4FB7293C2369B1",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "168",
+                  "Owner": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                  "RootIndex": "11E2D9655996752410DFEB6D347CFAC68CB8CCC4B32DEAE013D46FEE55365BED"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "A40401935620DD6727398991FAB466E4225D4BCDA4F86EE6603B63475E2D2AB3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "383669860F36CDD7BF543C0711DD523E35F60ACA22C8AAD8FDDBB2632C4C5821",
+                  "Account": "rGHt6LT5v9DVaEAmFzj5ciuxuj41ZjLofs",
+                  "Balance": "327498064709",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 86795379
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AEAC617A4934A4E1029581A159AF8EB3356E4DE3C52324D9D5A73C00B8828BCF",
+                "PreviousFields": {
+                  "Balance": "327498063265"
+                },
+                "PreviousTxnID": "AC73C04E841F98BE390A545027CB546EB4FB4A236EECFB7243E3C9FA5796E9B5",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "73552ED92ADB71A7563296A4643EB97230D6496FBD64CDDB1403545ACE2FFCCF",
+                  "Balance": "1187996756",
+                  "Flags": 0,
+                  "OwnerCount": 52,
+                  "Sequence": 12932994
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "51097F12ACDBE43CC2F14359FD860948AFE9A84AA235AACC9CC9277870751607",
+                  "Balance": "1187998210",
+                  "OwnerCount": 51,
+                  "Sequence": 12932993
+                },
+                "PreviousTxnID": "155ECB93E6128690A149D1D9037B43B94C3DF8DA892F90C9DE3FCC4ED0273B7F",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-191361.8543446554"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rGHt6LT5v9DVaEAmFzj5ciuxuj41ZjLofs",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "0"
+                  },
+                  "LowNode": "10a"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "CDE55A8290DF221A643F51798BE6294A69384066D1ECFB7C2B9BEE2004B38D63",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-191361.8551850052"
+                  }
+                },
+                "PreviousTxnID": "AC73C04E841F98BE390A545027CB546EB4FB4A236EECFB7243E3C9FA5796E9B5",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            }
+          ],
+          "TransactionIndex": 54,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 7381804,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "0.0000001663293579709686"
+        },
+        "TakerPays": {
+          "currency": "XDX",
+          "issuer": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+          "value": "0.00001696837316857461"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "C5965D83766AD5A4CA5E21E4839A4FB59BFB10FC99F0A4DC0EFF3CE8AF91CC7FC0515953E89E2E16D3B43D4339499DCBBFBBDA29DDA461B80F2683FCBA56980E",
+        "hash": "73E7AA1E714FC3B0FAFBEBC296FEAF346CFD97FBF95677BC4816A0C98CE4572B",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "8725.716827816116"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "XDX",
+                    "issuer": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+                    "value": "0"
+                  },
+                  "HighNode": "efe",
+                  "LowLimit": {
+                    "currency": "XDX",
+                    "issuer": "rNMzDSPiQQa1Ti7ypKgVCyw6BB4Bj7xSVk",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "0E9C1DF70B0BCEFD17433570A380F4411D44CBD965BFD013B53867F42F914F8D",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "8725.733791981284"
+                  }
+                },
+                "PreviousTxnID": "D8BD8AFEA89A8770263B59CA7A4E9F908C0FB4B8A41BFD2086419EB65724159B",
+                "PreviousTxnLgrSeq": 90150376
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.08553154574941122"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rNMzDSPiQQa1Ti7ypKgVCyw6BB4Bj7xSVk",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "LowNode": "e0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "1864F80DEE9924CCC5DD96C5AFFA63722AC82F0F56614E78B97396B979225877",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.08553137942005325"
+                  }
+                },
+                "PreviousTxnID": "D8BD8AFEA89A8770263B59CA7A4E9F908C0FB4B8A41BFD2086419EB65724159B",
+                "PreviousTxnLgrSeq": 90150376
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "88459.85307488527"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "XDX",
+                    "issuer": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+                    "value": "0"
+                  },
+                  "HighNode": "f01",
+                  "LowLimit": {
+                    "currency": "XDX",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "2470726C876E2E6D7F354DED8B118BE7FF469278EA6E7606D06B0C7711A7CBA9",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "88459.8361107201"
+                  }
+                },
+                "PreviousTxnID": "7E8C767965BE73B6E2CA683C2E7569AAA3001A97E435C77E112D44B951DF4EAD",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.376476578595945"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "9"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "68062CBD2811E4D5FB502D7C86E4BB04DA46A2AAE9BE2B400045A57E3B5DBA8B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.376476744925303"
+                  }
+                },
+                "PreviousTxnID": "C611B0FD5BC0A1A1F75CB0DE3798FB45827E02DB1689EA0A99DB56C36CDEFB20",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "73E7AA1E714FC3B0FAFBEBC296FEAF346CFD97FBF95677BC4816A0C98CE4572B",
+                  "Balance": "420568228",
+                  "Flags": 0,
+                  "OwnerCount": 142,
+                  "Sequence": 7381805
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "C611B0FD5BC0A1A1F75CB0DE3798FB45827E02DB1689EA0A99DB56C36CDEFB20",
+                  "Balance": "420568238",
+                  "Sequence": 7381804
+                },
+                "PreviousTxnID": "C611B0FD5BC0A1A1F75CB0DE3798FB45827E02DB1689EA0A99DB56C36CDEFB20",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 50,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104033919,
+        "Sequence": 104034208,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "3045022100F22E8FE277848AA30A49B94A79BE3A22D9CF4809B0FC149B39521BBAFCEECAF502206E9DEE0522659F3013E9BE9F49977D4DBA61415FDEC3AC7717814029BC7437B2",
+        "hash": "7A1AC7B43BABD48A680B780EDDF8C786DB3F50E5B5B937148A0A05B5534B5B94",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5d1577c690638bf5",
+                  "Flags": 0,
+                  "RootIndex": "33C81D720DBA84863A1510FD5C6C3E9224F0F5778261CF175D1577C690638BF5",
+                  "TakerGetsCurrency": "0000000000000000000000004243480000000000",
+                  "TakerGetsIssuer": "06CDAB9869053E0AC7764D9ACB35B182CB195414",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "33C81D720DBA84863A1510FD5C6C3E9224F0F5778261CF175D1577C690638BF5"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "33C81D720DBA84863A1510FD5C6C3E9224F0F5778261CF175D1577C690638BF5",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c97f",
+                  "PreviousTxnID": "50F9B0EA5C0FD7ABD131F20DF2E94FBDB0689624635D7177AE004AB40338A753",
+                  "PreviousTxnLgrSeq": 90150265,
+                  "Sequence": 104033919,
+                  "TakerGets": {
+                    "currency": "BCH",
+                    "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+                    "value": "10.39211194548868"
+                  },
+                  "TakerPays": "6279609499"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "5DCC8319510BF77814FDAC86406DB3E06B6212246510A081A30BAE113240147C"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678581",
+                  "Flags": 0,
+                  "OwnerCount": 88,
+                  "Sequence": 104034209
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678591",
+                  "OwnerCount": 89,
+                  "Sequence": 104034208
+                },
+                "PreviousTxnID": "4302B40269BC8E8A6B341865F0F269FF7A3C768D1CE417687BAD66E340840BE7",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "c980",
+                  "IndexPrevious": "c97e",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "D90A03842491ED75750A2A8F8E7198F4FEF9952DB98AF67E834200F562529474"
+              }
+            }
+          ],
+          "TransactionIndex": 14,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104033814,
+        "Sequence": 104034196,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "3045022100D289E00783E6BA74BDA084D48EE26BF3F1EEB5B63021E3A0F225F9C9972CF9C202207EB0CBDFD133AE89C9F7EE04586146CC995BBB9B8287F43FFF6B09ADAC616B7B",
+        "hash": "7B9AE961F7A1B6527C0E0D106CCCA38FA53C009A0182E36CD60021466FF6DBD1",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "8C7111E0E30AA0E3D31C2A0973C2C7B57CCBF55988136BF05006AE466EE8154E",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c97d",
+                  "PreviousTxnID": "242FF830D49B1A77BF72CEB74539E9F9A7A42D6ADC4D395238C46896F161A599",
+                  "PreviousTxnLgrSeq": 90150241,
+                  "Sequence": 104033814,
+                  "TakerGets": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "9851.147941702473"
+                  },
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.1852476247726508"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "1A1FEE91442772470478DF8A18ADB6776FE235B9C471095EB59C70FF1A7420D1"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "c97e",
+                  "IndexPrevious": "c97c",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "4F8AE257E6A66DF63C832E1A3968EF02438A46D65A113DE0C0E39FE38DC84353"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5006ae466ee8154e",
+                  "Flags": 0,
+                  "RootIndex": "8C7111E0E30AA0E3D31C2A0973C2C7B57CCBF55988136BF05006AE466EE8154E",
+                  "TakerGetsCurrency": "0000000000000000000000004555520000000000",
+                  "TakerGetsIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230",
+                  "TakerPaysCurrency": "0000000000000000000000004254430000000000",
+                  "TakerPaysIssuer": "06A148131B436B2561C85967685B098E050EED4E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "8C7111E0E30AA0E3D31C2A0973C2C7B57CCBF55988136BF05006AE466EE8154E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678701",
+                  "Flags": 0,
+                  "OwnerCount": 94,
+                  "Sequence": 104034197
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678711",
+                  "OwnerCount": 95,
+                  "Sequence": 104034196
+                },
+                "PreviousTxnID": "102CD8B97D445344846845588A7FBB0E5AF32384B97A0FCCF9A243EAC41691B2",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            }
+          ],
+          "TransactionIndex": 2,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rJSwZhfNmufdYk6b3CJ7zFe1UCAyzyjgYr",
+        "Amount": "44",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1000005,
+        "Fee": "10",
+        "Sequence": 89637294,
+        "SigningPubKey": "ED22AD5EE2902B7B0627E44B77EDA1CADC849E214E05B2D69407AE2B4DC2FB661F",
+        "TransactionType": "Payment",
+        "TxnSignature": "5A81068EF4EFA64FF35154AD7ACC2A60A277661E9A8BA695CB6B89275A962C4A0615D06C179BECC31EB4FE6206816EAB7A96D9AAEE73A12FF8D778A7E1D59B05",
+        "hash": "7C3684F3D31948BFE59C45346FDD9D25D70F4E8228BC1D98A52DEC74045E68EE",
+        "DeliverMax": "44",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rJSwZhfNmufdYk6b3CJ7zFe1UCAyzyjgYr",
+                  "Balance": "52759445",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89637295
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "0BEE2DAB74F772F5DDE0D15A8E6E58A206A6AEB9A1AD38724922725C5F4621CA",
+                "PreviousFields": {
+                  "Balance": "52759499",
+                  "Sequence": 89637294
+                },
+                "PreviousTxnID": "FEF6AA2E57B9696FF62202E331874E7BB3A25066A10D4F2C1BBDD54E42247C09",
+                "PreviousTxnLgrSeq": 90150373
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180902340",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180902296"
+                },
+                "PreviousTxnID": "93A0F90E79E1AAB9364CF189EE4370A05ED3A6289A1F99D29D1A151D62358B6A",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 84,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "44"
+        }
+      },
+      {
+        "Account": "rLuiHsHsdFn4HscaGf4kR429bWmsj2wfBw",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 90150391,
+        "OfferSequence": 87753514,
+        "Sequence": 0,
+        "SigningPubKey": "EDCC84393BB4993742B0DD43137EFDA09B62FF45FE0AA75A2780999AA64792F9DC",
+        "TakerGets": "10096198",
+        "TakerPays": {
+          "currency": "XWM",
+          "issuer": "rJzBh2Sktnps8CoLVJeDjj3Y2aDzXhrAFL",
+          "value": "10097298.30313"
+        },
+        "TicketSequence": 87753506,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "590FA9C5722673E1C23EF99B226018341791245F0E0510D949075010E92151668D1BF9914464724258CDCACB47D8C36B476487778B86A6F34754643C63FCEB09",
+        "hash": "7C8A9342B983D03798F99641900D40786FD7A40971DA210DB809794FF2ECA6D4",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "55038d983fa5d2f2",
+                  "Flags": 0,
+                  "RootIndex": "16F345FAD063C76C947484142E6FB95CCAB1DFBE8ADDA94E55038D983FA5D2F2",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "00000000000000000000000058574D0000000000",
+                  "TakerPaysIssuer": "C54A3F48A019790E40786237A11BE6062D2ECD87"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "16F345FAD063C76C947484142E6FB95CCAB1DFBE8ADDA94E55038D983FA5D2F2"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "1EE630A28258F2C820EA56475E0000B974EBAC5726395CE0F3EC65790F1F8DB7",
+                "NewFields": {
+                  "Account": "rLuiHsHsdFn4HscaGf4kR429bWmsj2wfBw",
+                  "BookDirectory": "16F345FAD063C76C947484142E6FB95CCAB1DFBE8ADDA94E55038D983FA5D2F2",
+                  "OwnerNode": "5f93",
+                  "Sequence": 87753506,
+                  "TakerGets": "10096188",
+                  "TakerPays": {
+                    "currency": "XWM",
+                    "issuer": "rJzBh2Sktnps8CoLVJeDjj3Y2aDzXhrAFL",
+                    "value": "10097298.30313"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "5f92",
+                  "Owner": "rLuiHsHsdFn4HscaGf4kR429bWmsj2wfBw",
+                  "RootIndex": "BBE1F078DB2815FC774207E7FF6BD45967F4B716620165109FE398A9A585642F"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "72613AAACC773189A9EDCFF92576B1C24028DF5A5D1325FE40C239BDFB54A940"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rLuiHsHsdFn4HscaGf4kR429bWmsj2wfBw",
+                  "BookDirectory": "16F345FAD063C76C947484142E6FB95CCAB1DFBE8ADDA94E55038D983FA5D2F2",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "5f93",
+                  "PreviousTxnID": "85162CEB656AB9C2581CFCA66566F7CD0BBA1910B624718396C48F16B62D5230",
+                  "PreviousTxnLgrSeq": 90150374,
+                  "Sequence": 87753514,
+                  "TakerGets": "10096188",
+                  "TakerPays": {
+                    "currency": "XWM",
+                    "issuer": "rJzBh2Sktnps8CoLVJeDjj3Y2aDzXhrAFL",
+                    "value": "10097298.30313"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "8F2F3C29AB2228C4EFE159200B091C6CEA86D6F5CA3ABC0D67C081DBA41A66CB"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rLuiHsHsdFn4HscaGf4kR429bWmsj2wfBw",
+                  "Balance": "1820321709",
+                  "Flags": 0,
+                  "OwnerCount": 47,
+                  "Sequence": 87753515,
+                  "TicketCount": 2
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C156E65B4B489F0025602247572FF26AF4D251F0B6F8E36A559AF7D8EBFAD058",
+                "PreviousFields": {
+                  "Balance": "1820321721",
+                  "OwnerCount": 48,
+                  "TicketCount": 3
+                },
+                "PreviousTxnID": "85162CEB656AB9C2581CFCA66566F7CD0BBA1910B624718396C48F16B62D5230",
+                "PreviousTxnLgrSeq": 90150374
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rLuiHsHsdFn4HscaGf4kR429bWmsj2wfBw",
+                  "Flags": 0,
+                  "OwnerNode": "5f93",
+                  "PreviousTxnID": "4D131AEE5105CCDA707AA6747BE7AE5C26611AF720E01F05B2062BAF2D7B065D",
+                  "PreviousTxnLgrSeq": 90150191,
+                  "TicketSequence": 87753506
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "DDAE206BA7B2E578E487F86533EC51DBE99FE672D0CCA263AA6536DE80FA0CDC"
+              }
+            }
+          ],
+          "TransactionIndex": 71,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 7381798,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "XDX",
+          "issuer": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+          "value": "0.01696811405048895"
+        },
+        "TakerPays": {
+          "currency": "RPR",
+          "issuer": "r3qWgpz2ry3BhcRJ8JE6rxM8esrfhuKp4R",
+          "value": "0.0000001353713821586175"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "68DD54AE12007D99F1814FEBB2437B01C0F84438A7A5EB5EB4934A363F0DFDA1EFE7C44F8754D9A90E329F3B00652A7FF62C0340A788C40C830ED7F5BD37CE0A",
+        "hash": "7E8C767965BE73B6E2CA683C2E7569AAA3001A97E435C77E112D44B951DF4EAD",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "88459.8361107201"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "XDX",
+                    "issuer": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+                    "value": "0"
+                  },
+                  "HighNode": "f01",
+                  "LowLimit": {
+                    "currency": "XDX",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "2470726C876E2E6D7F354DED8B118BE7FF469278EA6E7606D06B0C7711A7CBA9",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "88459.85307883415"
+                  }
+                },
+                "PreviousTxnID": "A6EF480E49B4A7B7BF3D861CC7B52C9620EDF0FEACB8714CFFE807BE94569A01",
+                "PreviousTxnLgrSeq": 90150376
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "RPR",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-991.6562850538709"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "RPR",
+                    "issuer": "rUQKZKryi6TFLHbMp8tMJkQAX1ohTsVSty",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "RPR",
+                    "issuer": "r3qWgpz2ry3BhcRJ8JE6rxM8esrfhuKp4R",
+                    "value": "0"
+                  },
+                  "LowNode": "ef9"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "42A941E0373511530A5441F7E9479F595A0318747A0487CFAAB2FA0687EFEB4D",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "RPR",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-991.6564203916986"
+                  }
+                },
+                "PreviousTxnID": "C70E68BF6320AD78B824050E7DF1F7223D353FE9818E5AA8758D4CD772901B07",
+                "PreviousTxnLgrSeq": 90150229
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "RPR",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5.085768963812053"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "RPR",
+                    "issuer": "r3qWgpz2ry3BhcRJ8JE6rxM8esrfhuKp4R",
+                    "value": "0"
+                  },
+                  "HighNode": "f0d",
+                  "LowLimit": {
+                    "currency": "RPR",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "9"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B2465B6C95B1C9C8345D1F14985CB5DEA6AFBBD4E9CB2B9FF3697C5E8B4D7CE4",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "RPR",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5.085633625984313"
+                  }
+                },
+                "PreviousTxnID": "A060334B0990A0E8574E1C5176A046BEA083264B978363EDD02E1F8C146B8D2B",
+                "PreviousTxnLgrSeq": 90150336
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "7E8C767965BE73B6E2CA683C2E7569AAA3001A97E435C77E112D44B951DF4EAD",
+                  "Balance": "420568288",
+                  "Flags": 0,
+                  "OwnerCount": 142,
+                  "Sequence": 7381799
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "6FEDEFED009BD987F75C64D6CFE7513D8EB54B2DCB4325CC1F4696A3B1E830C3",
+                  "Balance": "420568298",
+                  "Sequence": 7381798
+                },
+                "PreviousTxnID": "6FEDEFED009BD987F75C64D6CFE7513D8EB54B2DCB4325CC1F4696A3B1E830C3",
+                "PreviousTxnLgrSeq": 90150376
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "124236.7131807742"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "XDX",
+                    "issuer": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+                    "value": "0"
+                  },
+                  "HighNode": "ef8",
+                  "LowLimit": {
+                    "currency": "XDX",
+                    "issuer": "rUQKZKryi6TFLHbMp8tMJkQAX1ohTsVSty",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "EBD0BE0F69A1B52B245DCFAE91B06FEB03F1E5E895A20A28086848FF7C1BA606",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "124236.6962126601"
+                  }
+                },
+                "PreviousTxnID": "C70E68BF6320AD78B824050E7DF1F7223D353FE9818E5AA8758D4CD772901B07",
+                "PreviousTxnLgrSeq": 90150229
+              }
+            }
+          ],
+          "TransactionIndex": 44,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rN9uNdZ26QfLPkZ6wTG6QMQBB1FLLHLCpV",
+        "Amount": "87",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1000186,
+        "Fee": "10",
+        "Sequence": 89119902,
+        "SigningPubKey": "ED381928FFA1A2B7789BFD2C262D2E6ADF0AD89227066A0B2DA1014F0A9865D785",
+        "TransactionType": "Payment",
+        "TxnSignature": "749A0962FC5B61B4F0E6AA091A14094EBBD154BB417070434B4761B3DA182C688EF94975E54E6BB327BA0C3F9E976693C85CC5015C270399B5C84DB79536BE04",
+        "hash": "7EEB99DC3FA9CEF7FF61485D248AC10346BDF23186649D06B7358B3ED50D8E6B",
+        "DeliverMax": "87",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180902252",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180902165"
+                },
+                "PreviousTxnID": "DFAC74D36AF4815ACD658439673C0AC0E26F66E00C9D6B57EF202581DD74A047",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rN9uNdZ26QfLPkZ6wTG6QMQBB1FLLHLCpV",
+                  "Balance": "52388771",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89119903
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "CC95100CF055E734F18242B34339986661F25B38F2151EC4FB2A1D85D2DBDBB4",
+                "PreviousFields": {
+                  "Balance": "52388868",
+                  "Sequence": 89119902
+                },
+                "PreviousTxnID": "57E04056EF89236FD158B03A1660B912D95C0E7BCC22A78294AD8A18F3F3CC00",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            }
+          ],
+          "TransactionIndex": 78,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "87"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 12932997,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "0.00001611362327698276"
+        },
+        "TakerPays": {
+          "currency": "5A52505900000000000000000000000000000000",
+          "issuer": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+          "value": "0.00003103122081260234"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "8934AAA8F1E6793DDD76DAD211A73F3BF8A12BC42331914C1A37E12267F6C6E0E01F5FFD53FC6C55845DEDA8A8D0532649BF2C803002EBD1ABEACAA8EB6AF30C",
+        "hash": "811E7ABE83FC0F35B9D543D33F1A0A1FD9F2EFFFA0BE7A8702EA197F96CF0404",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "e0",
+                  "Owner": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                  "RootIndex": "37B9EF2F6DAA50068F42E9BC0E00318605224E840A0171B2F7D9901D05432E38"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "07300B9A4762019DA71C90C04CC143818086350BCAC12733C50BA586F5B4DE60"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.328826582789501"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rLtURbYhZP4b984Vue45v79DCThWQxLmD3",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "LowNode": "df"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "1E42AF87018C6F9E76306573AAF7B5A085E3DC11725DDC8901AD4071A4094781",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.328813189845221"
+                  }
+                },
+                "PreviousTxnID": "F6ACB5B9AE153175A4A0EC344FE06BC3B0FEA771913D4283684D4CB4E80FEF5C",
+                "PreviousTxnLgrSeq": 90150372
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-633.2267880349945"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rLtURbYhZP4b984Vue45v79DCThWQxLmD3",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+                    "value": "0"
+                  },
+                  "LowNode": "89"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "2A16BBBAD0056C8A9180C46E05DFE6301D67DCBD2B1B67BFE7039B7DF63145C2",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-633.2525744456028"
+                  }
+                },
+                "PreviousTxnID": "F6ACB5B9AE153175A4A0EC344FE06BC3B0FEA771913D4283684D4CB4E80FEF5C",
+                "PreviousTxnLgrSeq": 90150372
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "90848E9A1185CCEF2B55329945A8D6075A88A10A854FF6DB890994AAD4CED060",
+                "PreviousTxnID": "14A222F5BEB0BC8FB105CDCC1BE7B06EBF375C63876AA8E44FAAB083F48B81B7",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "811E7ABE83FC0F35B9D543D33F1A0A1FD9F2EFFFA0BE7A8702EA197F96CF0404",
+                  "Balance": "1187997978",
+                  "Flags": 0,
+                  "OwnerCount": 52,
+                  "Sequence": 12932998
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "8ABC6F10F21F182A7A8EAB2BCB912F6169883D644B6112B4861FED51754170A9",
+                  "Balance": "1187997988",
+                  "Sequence": 12932997
+                },
+                "PreviousTxnID": "8ABC6F10F21F182A7A8EAB2BCB912F6169883D644B6112B4861FED51754170A9",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "8f",
+                  "Owner": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+                  "RootIndex": "4492BEF2FF8CE6639BB5E6AA330E8163DC45BED13660B310A2C5503C03534CA6"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "C3F0C59D3E02E306BD82ABA89093BEB615F70ADA0ECDE4E08A9470FB277D2744"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1048576,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c",
+                  "PreviousTxnID": "8ABC6F10F21F182A7A8EAB2BCB912F6169883D644B6112B4861FED51754170A9",
+                  "PreviousTxnLgrSeq": 90150378
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D63A73BFE673289DA86434524C38EBA61561FC4C7614601A6173E85C92A0AC07",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.00001339294428"
+                  },
+                  "Flags": 1114112
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "D9F260E4F8EDF98001192FAE5B99A794F53E2873DE6FEE9C6056C01BBA8E5E75",
+                "PreviousTxnID": "8ABC6F10F21F182A7A8EAB2BCB912F6169883D644B6112B4861FED51754170A9",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "E5D9EA1D087FA02C08D319E9DBD3167D791173D848A08EC9EB6F4F77F4CFA48C",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.02578641060829358"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+                    "value": "0"
+                  },
+                  "LowNode": "90"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 58,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rUrAwoYrZeHxrgmZWEAUTBJqWitsLfizvE",
+        "Amount": "44",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1000027,
+        "Fee": "10",
+        "Sequence": 89121337,
+        "SigningPubKey": "ED161E1637DFFEA90239D1758965FC982B7C3E95CE9327C0DA0F53AD2FDDA0FF37",
+        "TransactionType": "Payment",
+        "TxnSignature": "5719C122BE931BD0AD2E8375F0630380C33C5CFD3E0B6248FD491479D04123462C55F1D02F02198148FA6AAB6815D6DEE70271C41AF31CEBD11E80948B71C108",
+        "hash": "84CC428EE193F33A9B0325F3FCC3AEC7D4E3A133BEA472B1BE193E3891FF937F",
+        "DeliverMax": "44",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180901546",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180901502"
+                },
+                "PreviousTxnID": "EE535246B0C713909707A3F938057D6157EB40D868344E091A4EE6A08C8FEF28",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUrAwoYrZeHxrgmZWEAUTBJqWitsLfizvE",
+                  "Balance": "52374656",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89121338
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "9BCCA490C6664167C7C2B7DB374EC5F673251E3FD341A7D100B635C152516C2E",
+                "PreviousFields": {
+                  "Balance": "52374710",
+                  "Sequence": 89121337
+                },
+                "PreviousTxnID": "B500243B3DD630D3A67D9E2B994005DF308BFC740DA5F82B4164A92B75A53D89",
+                "PreviousTxnLgrSeq": 90150375
+              }
+            }
+          ],
+          "TransactionIndex": 29,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "44"
+        }
+      },
+      {
+        "Account": "rLdHRUSBf6GSVYU1yMnVo3DQaWQJ9bL1jn",
+        "Amount": "45",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1000134,
+        "Fee": "10",
+        "Sequence": 89121504,
+        "SigningPubKey": "EDBF2C48A2D96E12699AE6D9FE676BB2A926E29DD613C1561266A569F8E2EB1E3D",
+        "TransactionType": "Payment",
+        "TxnSignature": "D7F8E2BA902E46F2B6E0F81450A337631760FBE4C08256155CA4691B0A8E4C4D081188B017810CD79E0D2447828527BD920C8DB8A670B4E36EEF1465D21D0B08",
+        "hash": "89F683F674A09729A9061BEFA5993E37456A95ADD1ED65AB382F8D4B18DBCD28",
+        "DeliverMax": "45",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180901944",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180901899"
+                },
+                "PreviousTxnID": "1BD0448B078C75260DF3B04C5BCE1AF1FEA58561FD137726834295EED7FCF211",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rLdHRUSBf6GSVYU1yMnVo3DQaWQJ9bL1jn",
+                  "Balance": "52478316",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89121505
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "862043CB3AFBBAB7BBB1534C62B1C94C6AE50622F93420D87B85B0AFA1DBEE54",
+                "PreviousFields": {
+                  "Balance": "52478371",
+                  "Sequence": 89121504
+                },
+                "PreviousTxnID": "B28ACE08126DD2FDEC8F69E7DD64AE615128C0E5BFA7AEACDF52CD9F64D571FB",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            }
+          ],
+          "TransactionIndex": 72,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "45"
+        }
+      },
+      {
+        "Account": "rshq6HZcd5HjUF672DGroAJk66MymWk2kE",
+        "Amount": "89",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1095,
+        "Fee": "10",
+        "Sequence": 89120672,
+        "SigningPubKey": "ED901F5A5AD9F552FA21D3BC7D77590475F65CB650D0EF8F6510AFEB2549C2A3F7",
+        "TransactionType": "Payment",
+        "TxnSignature": "746EC3BC33CB4BFBDFFB2F1FB2A9BFC95E83812061F66474B6FDC27E89B483E07C0B064E93576F3B6AF5603F9EE26CA4EAD578BC321C901968784699ECA56D07",
+        "hash": "8A9571807677CB204C065F37CE348BF364F0527CC7264D87A182AA539C50959A",
+        "DeliverMax": "89",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rshq6HZcd5HjUF672DGroAJk66MymWk2kE",
+                  "Balance": "52407142",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89120673
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "041C2487ED068A58916E9178642B4A81CC73544D214F56A276A01C9DAC619725",
+                "PreviousFields": {
+                  "Balance": "52407241",
+                  "Sequence": 89120672
+                },
+                "PreviousTxnID": "B2CA50F931AE51FD7D21112935B9C508FFCB1138DA724C2C85105DE3464152B6",
+                "PreviousTxnLgrSeq": 90150376
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180901635",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180901546"
+                },
+                "PreviousTxnID": "84CC428EE193F33A9B0325F3FCC3AEC7D4E3A133BEA472B1BE193E3891FF937F",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 40,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "89"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 12932996,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": "181",
+        "TakerPays": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "0.00000001342801939748563"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "6D620C291C381780AC61A6F57E2F5BF9E5E2AC0A2C701ECB25ED37794F42A7A2B6A8ECFFC134428DFFB3436B49CB4E98F4850C21E02FB0B8112D661EC0783B08",
+        "hash": "8ABC6F10F21F182A7A8EAB2BCB912F6169883D644B6112B4861FED51754170A9",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "e0",
+                  "Owner": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                  "RootIndex": "37B9EF2F6DAA50068F42E9BC0E00318605224E840A0171B2F7D9901D05432E38"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "07300B9A4762019DA71C90C04CC143818086350BCAC12733C50BA586F5B4DE60"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "14.01690043414959"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "dc",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rnv4kx1H76k43HYKZa3wrKhVnWNvA4kQpm",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "318E00F1D5FCAAD58867D5AA41CF32A319597C463F8DB9CBB4D0851A3258AD50",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "14.01691382709387"
+                  }
+                },
+                "PreviousTxnID": "B966988492954BC2A6BC23C3E25A297CD156087C78DDEA6A6F9626F22EACA3C5",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "B416780D1A45F7BA8665AA6967CD1F346087B495EAC1B0D4FD8AC421444D04A5",
+                  "Account": "rnv4kx1H76k43HYKZa3wrKhVnWNvA4kQpm",
+                  "Balance": "189411848",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 86806716
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A64DC21AF513694977C5F654D42828F1D178E9DBBA85B270DCB95378669834F7",
+                "PreviousFields": {
+                  "Balance": "189411667"
+                },
+                "PreviousTxnID": "B966988492954BC2A6BC23C3E25A297CD156087C78DDEA6A6F9626F22EACA3C5",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "8ABC6F10F21F182A7A8EAB2BCB912F6169883D644B6112B4861FED51754170A9",
+                  "Balance": "1187997988",
+                  "Flags": 0,
+                  "OwnerCount": 52,
+                  "Sequence": 12932997
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "BDB443F83282FA5BBAD7550330F7BED45A74ACA2A0BE2E434274FEAC8B3766F6",
+                  "Balance": "1187998179",
+                  "OwnerCount": 51,
+                  "Sequence": 12932996
+                },
+                "PreviousTxnID": "BDB443F83282FA5BBAD7550330F7BED45A74ACA2A0BE2E434274FEAC8B3766F6",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D63A73BFE673289DA86434524C38EBA61561FC4C7614601A6173E85C92A0AC07",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.00001339294428"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "D9F260E4F8EDF98001192FAE5B99A794F53E2873DE6FEE9C6056C01BBA8E5E75",
+                "PreviousTxnID": "71C300DBFD74E158919BE7672B59C483413C53F516D3B56774F1F41A3778CEF3",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            }
+          ],
+          "TransactionIndex": 57,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104033997,
+        "Sequence": 104034210,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "304402205189C69E2EEE0314B1A4D1D24BD80286C3113ED351AA0ECE7514A256C545F5CF022030DA0E3DA6D185CAEFF332638F6768AD32B91EB77F91B53D1BFF8C6BC64A6B7B",
+        "hash": "911B5143CD2CC6ED7116D60831AC2DF2CB95C0012FEE1D887CCB84DDF7FA3561",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "c981",
+                  "IndexPrevious": "c97f",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "459AAE1593169E8594669891FE733971DEC9344F8CFEE6551EEFB3B0DC656F4C"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C6004B47C33A510C2",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c980",
+                  "PreviousTxnID": "94987F8598FA91956DC0A46AEA0AF7E232CFBD15212419DD35533B94F6C9DAE8",
+                  "PreviousTxnLgrSeq": 90150300,
+                  "Sequence": 104033997,
+                  "TakerGets": {
+                    "currency": "BTC",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0.08160413110719966"
+                  },
+                  "TakerPays": "10807205910"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "5D975E5FAC3EA40F3BBF4F0FB5E46C5C722AD21D75DC6DAAC1C55C535BA945F5"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "6004b47c33a510c2",
+                  "Flags": 0,
+                  "RootIndex": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C6004B47C33A510C2",
+                  "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                  "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C6004B47C33A510C2"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678561",
+                  "Flags": 0,
+                  "OwnerCount": 86,
+                  "Sequence": 104034211
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678571",
+                  "OwnerCount": 87,
+                  "Sequence": 104034210
+                },
+                "PreviousTxnID": "4676284472551BA2429ED8E6B9A342C4CF7E7C9842661BD0B383CECFA21CD889",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 16,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rNhKSNke78i2NXXZRE3AzjPMY3z1uVWrwt",
+        "Amount": "44",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 40000055,
+        "Fee": "10",
+        "Sequence": 89587933,
+        "SigningPubKey": "EDF62B0B5A6FD0CA9FD94121F7E22C40BCF4B165C51E97271006934043D617C853",
+        "TransactionType": "Payment",
+        "TxnSignature": "68A6879AF558EF2B13F1FCD532716DB0145AAE41BC59621FAF6C5F4939C28ACD06F85300550A0645EE471B0F7B9ED7757F56621275567E3DF898675240CB2007",
+        "hash": "93A0F90E79E1AAB9364CF189EE4370A05ED3A6289A1F99D29D1A151D62358B6A",
+        "DeliverMax": "44",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180902296",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180902252"
+                },
+                "PreviousTxnID": "7EEB99DC3FA9CEF7FF61485D248AC10346BDF23186649D06B7358B3ED50D8E6B",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rNhKSNke78i2NXXZRE3AzjPMY3z1uVWrwt",
+                  "Balance": "55069751",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89587934
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "54E15239062C6AC0084CA395905E30D5CAE927774DDF7C570CE4240E58144D77",
+                "PreviousFields": {
+                  "Balance": "55069805",
+                  "Sequence": 89587933
+                },
+                "PreviousTxnID": "46F901F9A836D960F19DF25A9EC25CCA568A2B5696EB4887DF85F66D240F2BE2",
+                "PreviousTxnLgrSeq": 90150376
+              }
+            }
+          ],
+          "TransactionIndex": 79,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "44"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "Sequence": 104034206,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TakerGets": {
+          "currency": "BCH",
+          "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+          "value": "6.916936342594393"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "3791.738741665542"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100CD90674B824D0325CBF146C5924C16B99EC6D5DA7B94A94D6E4BE6144536F53902206F9B77E3DAD88A2F2F8B41C5CF1A231CBD7FCF76D6CC97DF814BA0B446E096E7",
+        "hash": "9903496281A9038250B0D0B3F16F390A9A7766AE822C0EF1ACBBEF615C7FD3F7",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "791300A7A10D92F4B039720363FCB64932B1656AB4FA7CA10560EDAB51953F08",
+                "NewFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "FC4B99C28DF8622E6040A053A39DA16EB7A8EA2A61D569D3571379AF418C5CD1",
+                  "OwnerNode": "c982",
+                  "Sequence": 104034206,
+                  "TakerGets": {
+                    "currency": "BCH",
+                    "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+                    "value": "6.916936342594393"
+                  },
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "3791.738741665542"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "c981",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9E1545C92DE33FB8C9673211120C31C1F8E9465566DF642829D6131747757F3E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678601",
+                  "Flags": 0,
+                  "OwnerCount": 90,
+                  "Sequence": 104034207
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678611",
+                  "OwnerCount": 89,
+                  "Sequence": 104034206
+                },
+                "PreviousTxnID": "6F294B39AFE6E09C3337FC92C5974FAF861D64E9DE4C33550481BE80B6E80B11",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "FC4B99C28DF8622E6040A053A39DA16EB7A8EA2A61D569D3571379AF418C5CD1",
+                "NewFields": {
+                  "ExchangeRate": "571379af418c5cd1",
+                  "RootIndex": "FC4B99C28DF8622E6040A053A39DA16EB7A8EA2A61D569D3571379AF418C5CD1",
+                  "TakerGetsCurrency": "0000000000000000000000004243480000000000",
+                  "TakerGetsIssuer": "06CDAB9869053E0AC7764D9ACB35B182CB195414",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 12,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150381,
+        "Sequence": 104034213,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TakerGets": {
+          "currency": "EUR",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "19587.93161843738"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+          "value": "0.3692019576515472"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100869D6052C70B3EF82A5C27151187BCA4BDBC338C9CD14467138D8E507E66F9610220585B6C74B3D101C72C89682ECA83F1B0D6E590BC6B713C26CDE40E7BDA58A60B",
+        "hash": "9A491C30D9BF74F6C2329A652982C287FF515CC63C68359BD4986057BF21642A",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5006b241723d15a0",
+                  "Flags": 0,
+                  "RootIndex": "8C7111E0E30AA0E3D31C2A0973C2C7B57CCBF55988136BF05006B241723D15A0",
+                  "TakerGetsCurrency": "0000000000000000000000004555520000000000",
+                  "TakerGetsIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230",
+                  "TakerPaysCurrency": "0000000000000000000000004254430000000000",
+                  "TakerPaysIssuer": "06A148131B436B2561C85967685B098E050EED4E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "8C7111E0E30AA0E3D31C2A0973C2C7B57CCBF55988136BF05006B241723D15A0"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "c981",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9E1545C92DE33FB8C9673211120C31C1F8E9465566DF642829D6131747757F3E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678531",
+                  "Flags": 0,
+                  "OwnerCount": 85,
+                  "Sequence": 104034214
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678541",
+                  "OwnerCount": 84,
+                  "Sequence": 104034213
+                },
+                "PreviousTxnID": "B99246A4835E66203E0FBC444C576932A70735611B9092B34D14AE7165D7BD2B",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "F0845104A759D0BD2439557ECF04F204C09A92AB3758744D85C5174CC4EAA8FF",
+                "NewFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "8C7111E0E30AA0E3D31C2A0973C2C7B57CCBF55988136BF05006B241723D15A0",
+                  "OwnerNode": "c982",
+                  "Sequence": 104034213,
+                  "TakerGets": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "19587.93161843738"
+                  },
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.3692019576515472"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 19,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150381,
+        "Sequence": 104034215,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+          "value": "1.687023567910084"
+        },
+        "TakerPays": {
+          "currency": "EUR",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "95546.90474646077"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100933FA7775FA9E1F87BF572C8DCC1C6B4B015073E32DBDB201BEBF36FF3BA8F0D022029477627AADE94C165C8C5838FA151D7C0E36B9D686610502604E56B713E49E5",
+        "hash": "9B0EE5E8034C12B6669D709553581696F024BACFD7FCF1C23B574F1C770DE9F7",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "c981",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9E1545C92DE33FB8C9673211120C31C1F8E9465566DF642829D6131747757F3E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678511",
+                  "Flags": 0,
+                  "OwnerCount": 87,
+                  "Sequence": 104034216
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678521",
+                  "OwnerCount": 86,
+                  "Sequence": 104034215
+                },
+                "PreviousTxnID": "205C8FA2160FBCA935145A72418B9B15CB4BF841EEBF27ADE9FFA77D6B56875E",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "BBA711BACAB1F1994F0AE114A16F42584C942E89C77AE17A2B3706DC7553CEAD",
+                "NewFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "DB071D30B72F44A1ABFF0937C2C53B4D9B6A4EE2F4BC490E59141F0C701F3876",
+                  "OwnerNode": "c982",
+                  "Sequence": 104034215,
+                  "TakerGets": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "1.687023567910084"
+                  },
+                  "TakerPays": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "95546.90474646077"
+                  }
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DB071D30B72F44A1ABFF0937C2C53B4D9B6A4EE2F4BC490E59141F0C701F3876",
+                "NewFields": {
+                  "ExchangeRate": "59141f0c701f3876",
+                  "RootIndex": "DB071D30B72F44A1ABFF0937C2C53B4D9B6A4EE2F4BC490E59141F0C701F3876",
+                  "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                  "TakerGetsIssuer": "06A148131B436B2561C85967685B098E050EED4E",
+                  "TakerPaysCurrency": "0000000000000000000000004555520000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 21,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 7381800,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "MAG",
+          "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+          "value": "0.0000000006309226183723641"
+        },
+        "TakerPays": {
+          "currency": "NET",
+          "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+          "value": "0.000000002009491977936183"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "789F58A82CF505AD7A924764A9AC2570F9B0F848E9A47F64087239C0BB81CD81A3A325C97255E69A13538CC2684ECE445DC9A7F0804E7689B0BFA552B1A86D08",
+        "hash": "9D90B824387DC4EF5B57513EDED9D267833D476D6E4A39205F8D221F713022DB",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "54.11364476410335"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rnMdA7on8XggvQ1uNRzsdJpK9Uekp1yfTs",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "221F33435CE1B8386DC3CD646F889CD8531A55F2EB6CB823434C11830246D136",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "54.11364677359917"
+                  }
+                },
+                "PreviousTxnID": "61FBF21D3D668C910637EF07E324BE0FE0F2268069EA91B0B9882D7422556B39",
+                "PreviousTxnLgrSeq": 90150357
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.01699009449286619"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "MAG",
+                    "issuer": "rnMdA7on8XggvQ1uNRzsdJpK9Uekp1yfTs",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "MAG",
+                    "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+                    "value": "0"
+                  },
+                  "LowNode": "20e"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "574958BA3EFA9277632587EBC6B9F8FDDF43C7B04E865118203D10C7433CEEA5",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.01699009386194357"
+                  }
+                },
+                "PreviousTxnID": "61FBF21D3D668C910637EF07E324BE0FE0F2268069EA91B0B9882D7422556B39",
+                "PreviousTxnLgrSeq": 90150357
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.002022989039021662"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "MAG",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "HighNode": "8",
+                  "LowLimit": {
+                    "currency": "MAG",
+                    "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+                    "value": "0"
+                  },
+                  "LowNode": "214"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "6AEDB0D2B26C22AC4401CBDCEB4181C26081FE867AC3A8C233488A6D66724DE8",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.00202298966994428"
+                  }
+                },
+                "PreviousTxnID": "0348B0D3BC9B797816F5E00C5C6C869A6DBCD221D392F6C2CAE253F742771373",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000002045323230373766"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "7E7F2D4E27869445BE12682DFCB1420364E2EB5355BD8B4EA40A6B6DC236D2B1",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000000035827410373766"
+                  }
+                },
+                "PreviousTxnID": "8D86E76165B6EEF660A1799E93A7398211201C25C7198EB34764A04CD19517D1",
+                "PreviousTxnLgrSeq": 90150357
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "9D90B824387DC4EF5B57513EDED9D267833D476D6E4A39205F8D221F713022DB",
+                  "Balance": "420568268",
+                  "Flags": 0,
+                  "OwnerCount": 142,
+                  "Sequence": 7381801
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "0348B0D3BC9B797816F5E00C5C6C869A6DBCD221D392F6C2CAE253F742771373",
+                  "Balance": "420568278",
+                  "Sequence": 7381800
+                },
+                "PreviousTxnID": "0348B0D3BC9B797816F5E00C5C6C869A6DBCD221D392F6C2CAE253F742771373",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 46,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104034060,
+        "Sequence": 104034201,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "30440220381EF003E58E2DA74F5CD7F0DC1273E8E95BF095910E49E7BB1FF8AA02F3BCCC0220505A509C7C3F4DFEF094C6BF736B8EDD84F58CB2C5B3D5A0D1BDB4D3D0FE65A7",
+        "hash": "9ED3E3B17C8C736F314BBB18DDE2924E4D2FE37E03FDC7A5BB2E68623D953408",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "FC4B99C28DF8622E6040A053A39DA16EB7A8EA2A61D569D3570C55801B0AC3A8",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c980",
+                  "PreviousTxnID": "1A9B064C2AB091F6448E7F97A4D49703E57D710809C637C3358CCB120D4E8606",
+                  "PreviousTxnLgrSeq": 90150323,
+                  "Sequence": 104034060,
+                  "TakerGets": {
+                    "currency": "BCH",
+                    "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+                    "value": "5.302927198764928"
+                  },
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "1841.021699807741"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "20BC4E3F64A8E0E7FE2A5552FDD652E00376CF0A9EB85AB32CEF27C81DD0CA42"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "c981",
+                  "IndexPrevious": "c97f",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "459AAE1593169E8594669891FE733971DEC9344F8CFEE6551EEFB3B0DC656F4C"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678651",
+                  "Flags": 0,
+                  "OwnerCount": 91,
+                  "Sequence": 104034202
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678661",
+                  "OwnerCount": 92,
+                  "Sequence": 104034201
+                },
+                "PreviousTxnID": "ABA071B02E41DD4975BC0148B70DA5B622A9CF86DB8319078A4481500E01E2DB",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "570c55801b0ac3a8",
+                  "Flags": 0,
+                  "RootIndex": "FC4B99C28DF8622E6040A053A39DA16EB7A8EA2A61D569D3570C55801B0AC3A8",
+                  "TakerGetsCurrency": "0000000000000000000000004243480000000000",
+                  "TakerGetsIssuer": "06CDAB9869053E0AC7764D9ACB35B182CB195414",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "FC4B99C28DF8622E6040A053A39DA16EB7A8EA2A61D569D3570C55801B0AC3A8"
+              }
+            }
+          ],
+          "TransactionIndex": 7,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rGyyL5gmtQqrK77mWTQo5xaKu8KFbLaXKy",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 90150391,
+        "OfferSequence": 88006724,
+        "Sequence": 0,
+        "SigningPubKey": "ED84DB2F2C0EBBEE4078E6005CE70A9A36644C9B4FA25BF23DE16A0A3999295756",
+        "TakerGets": {
+          "currency": "*G*",
+          "issuer": "rGoPBCtspEgKJ8Yp6RajAmiuSbLt5Esi5w",
+          "value": "3022021.6508048"
+        },
+        "TakerPays": "453203",
+        "TicketSequence": 88006746,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "E6E02AC6DC82BF23D80F514E3EB4C120C864C1AFF6BD235767EF7471903F5984C74FCBEAB6D35F8537D2EB0D082C312C5B7A3C75DD841C3687EA037ECD55F304",
+        "hash": "9FDD2B489E8B96408A6C1F461379817359D6B9BCDD64D21275B5AD44EC8120DA",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "71a2",
+                  "Owner": "rGyyL5gmtQqrK77mWTQo5xaKu8KFbLaXKy",
+                  "RootIndex": "90EE64B2DAB58873DB7B825B150453672712E974286D27B2713351E0A23E982F"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1E9C694FB351C72A3A4D3A9AA9F15FB48486FA61D045B86144DF56B63314EA98"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rGyyL5gmtQqrK77mWTQo5xaKu8KFbLaXKy",
+                  "BookDirectory": "FD74AFD25F1654FDC112410AB0106D079BC27A71DAC0E822540553F81DC50800",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "71ac",
+                  "PreviousTxnID": "408A53E5454916E22097B9F5C12363C9CE6E69B2A2DE94F689A1A59D502D2D4D",
+                  "PreviousTxnLgrSeq": 90150374,
+                  "Sequence": 88006724,
+                  "TakerGets": {
+                    "currency": "*G*",
+                    "issuer": "rGoPBCtspEgKJ8Yp6RajAmiuSbLt5Esi5w",
+                    "value": "3021957.724878309"
+                  },
+                  "TakerPays": "453203"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "6C3C2EF957CFC43289C74DBAA9C3FBD612CE9C643BDEC618E34766C68DAF6049"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "A101F67832DE9DCFDD0C28A03B5F3D96E207B21FFE8E21315144997867870113",
+                "NewFields": {
+                  "Account": "rGyyL5gmtQqrK77mWTQo5xaKu8KFbLaXKy",
+                  "BookDirectory": "FD74AFD25F1654FDC112410AB0106D079BC27A71DAC0E822540553F81DC50800",
+                  "OwnerNode": "71ac",
+                  "Sequence": 88006746,
+                  "TakerGets": {
+                    "currency": "*G*",
+                    "issuer": "rGoPBCtspEgKJ8Yp6RajAmiuSbLt5Esi5w",
+                    "value": "3021957.724878309"
+                  },
+                  "TakerPays": "453203"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rGyyL5gmtQqrK77mWTQo5xaKu8KFbLaXKy",
+                  "Balance": "1775959199",
+                  "Flags": 0,
+                  "OwnerCount": 43,
+                  "Sequence": 88006751,
+                  "TicketCount": 4
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AF321CED1111BBC4AC593F6005A5BD077218EF9F3FEE02E7881B3026594CFC3A",
+                "PreviousFields": {
+                  "Balance": "1775959211",
+                  "OwnerCount": 44,
+                  "TicketCount": 5
+                },
+                "PreviousTxnID": "C708DD53A50E3322D7B8A1F99787606BCB2C26AE74815E67163276E686ACC30D",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rGyyL5gmtQqrK77mWTQo5xaKu8KFbLaXKy",
+                  "Flags": 0,
+                  "OwnerNode": "71ac",
+                  "PreviousTxnID": "D5B0AF281BD72C388E22B28B7788BAF57181468BEE370C54DF10F4B39E93C6B1",
+                  "PreviousTxnLgrSeq": 90150280,
+                  "TicketSequence": 88006746
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "CF2EF92DEEDDFB9C7140624E9F4D5EF75130F40C29B89ADF4D935DDDE8A8B4E9"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "540553f81dc50800",
+                  "Flags": 0,
+                  "RootIndex": "FD74AFD25F1654FDC112410AB0106D079BC27A71DAC0E822540553F81DC50800",
+                  "TakerGetsCurrency": "0000000000000000000000002A472A0000000000",
+                  "TakerGetsIssuer": "AD4F8A0C027A9CC609E4561F55E0E974B99FF268",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "FD74AFD25F1654FDC112410AB0106D079BC27A71DAC0E822540553F81DC50800"
+              }
+            }
+          ],
+          "TransactionIndex": 88,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 148560026,
+        "Sequence": 148560036,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "111522"
+        },
+        "TakerPays": "200000000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304402204A983649D90F7528A652E3C33BBBF29A61CA62904348C7ADDCCEDAD25050D57902206F2A8407848AD9E88646C87D26A8519656D919E3E55465C84EC49E0CB5A83E39",
+        "hash": "A6997147285DE582DDE1F7894620F4D6056E0246C4F743FB9F04DDEF8BF37B64",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "36386886716",
+                  "Flags": 0,
+                  "OwnerCount": 15,
+                  "Sequence": 148560037
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "36386886736",
+                  "Sequence": 148560036
+                },
+                "PreviousTxnID": "E869D53E3DCFCFBE1668F39FA163B64D6AAC88076CE7089F66775C7A7006A003",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5b065edaa4cdaa82",
+                  "Flags": 0,
+                  "RootIndex": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5B065EDAA4CDAA82",
+                  "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+                  "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5B065EDAA4CDAA82"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5B065F0F0E05D388",
+                "NewFields": {
+                  "ExchangeRate": "5b065f0f0e05d388",
+                  "RootIndex": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5B065F0F0E05D388",
+                  "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+                  "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5B065EDAA4CDAA82",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "9DA9BD02F03151D65ED45073A3A351251F8450E950688D3F2D805CD4B278AF7F",
+                  "PreviousTxnLgrSeq": 90150376,
+                  "Sequence": 148560026,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "111536"
+                  },
+                  "TakerPays": "200000000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "90CB97F17E98FD18997957EDF0EC2E09E433D244648A76CE4775E933E0FC7864"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "E64C421B5D5145BE67ECCE7915E258E8A04FDFD75D4C59F99B98249B8CAD33B8",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5B065F0F0E05D388",
+                  "Sequence": 148560036,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "111522"
+                  },
+                  "TakerPays": "200000000000"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 32,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 148560028,
+        "Sequence": 148560038,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "112021.98"
+        },
+        "TakerPays": "200000000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100CCDC6D771B3F9B88F4E95F9D6BA5AA86A5ADDCB693584E379502AEEBC85514CD02204C52451CAD5AD108C37A650894B0333F339E63C67E374530E6982A79198A454B",
+        "hash": "A7D055A13BCBF24772D3A20B3D4DF379EBEE6E1A55B97241E0290927D5C53293",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "36386886676",
+                  "Flags": 0,
+                  "OwnerCount": 15,
+                  "Sequence": 148560039
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "36386886696",
+                  "Sequence": 148560038
+                },
+                "PreviousTxnID": "B6CBC51F93428B22B36CB8F85A0F8D6FBF02F9291858ED71A0BEA3E7F9FD7954",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "9960A1ABB5DBD1957F19915BA1E33B0CAB8769EBC8157E2E5D8A3D11F5F73639",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5B0657C76D88B1E3",
+                  "Sequence": 148560038,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "112021.98"
+                  },
+                  "TakerPays": "200000000000"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5B0657C76D88B1E3",
+                "NewFields": {
+                  "ExchangeRate": "5b0657c76d88b1e3",
+                  "RootIndex": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5B0657C76D88B1E3",
+                  "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+                  "TakerGetsIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5b0657c9b4cf7048",
+                  "Flags": 0,
+                  "RootIndex": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5B0657C9B4CF7048",
+                  "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+                  "TakerGetsIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5B0657C9B4CF7048"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5B0657C9B4CF7048",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "69472DCE9B7157E2B52E56CBB108E02675DB300DD21964AC7EA1FBBC3135566D",
+                  "PreviousTxnLgrSeq": 90150376,
+                  "Sequence": 148560028,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "112021.366"
+                  },
+                  "TakerPays": "200000000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "FC92B5858E4473556CA053256AC067E1657506DA4968B93D2C8DDFD3153FFCB7"
+              }
+            }
+          ],
+          "TransactionIndex": 34,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 12933002,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "NET",
+          "issuer": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+          "value": "0.000005581981562252972"
+        },
+        "TakerPays": {
+          "currency": "NET",
+          "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+          "value": "1261492133512515e-30"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "4F0588310348F46737C3E3A39BBCE68FEF5CC6373517386D2C6E9EF0440977C358D7D668CB0D19D3F1571C667540D03260D8D132EEC8C6E48CB540FA57CB7106",
+        "hash": "A8795BE7B734E569323E704CD10D18B8F05C481922F32EF1178014A707DBD054",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                  "RootIndex": "1B6E7CB1A25AE631B406C9723A9EBB194D5A8958A7F4DED8B0E230FB469F71A1"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1B6E7CB1A25AE631B406C9723A9EBB194D5A8958A7F4DED8B0E230FB469F71A1"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1048576,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c",
+                  "PreviousTxnID": "BFBA0ECCBCE78BB031A62D8277FDFA16606796918116EC9A11E6D2ACBC381919",
+                  "PreviousTxnLgrSeq": 90150378
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "368163F2B47E0164381E9A12A6ACA1A020B269224FC4A81F0385FCD03DEDB8D4",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000004650497723145133"
+                  },
+                  "Flags": 1114112
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.9507766172387856"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rM19JiFRZwGvkmvA2DpUeoRV9kp4wNYCGn",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "536F527E0772D25643641ADB0148E8FAD55EDA5D7DACF63FDDF1309C7B88C661",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.9507766172398365"
+                  }
+                },
+                "PreviousTxnID": "5A0E612CE34CFF1A4AF26CEF48CB8D055971407EB0E0F0C4C818FBC3C94755B1",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A78BDBB60A871C387C2698A23483A6F44105D6994E613389A513A6BD2C81869B",
+                "PreviousTxnID": "BFBA0ECCBCE78BB031A62D8277FDFA16606796918116EC9A11E6D2ACBC381919",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "ACCFDC0A49FC44784C23419CC58BD96F38A0129D6AEF387271DEDB2E737B09D2",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1050900000000000e-27"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+                  "RootIndex": "B8262C6AD2FDF8D4F8CE480B0E9E06A37FB20F516C178A1D98FC0212A5E2EEDD"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B8262C6AD2FDF8D4F8CE480B0E9E06A37FB20F516C178A1D98FC0212A5E2EEDD"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "A8795BE7B734E569323E704CD10D18B8F05C481922F32EF1178014A707DBD054",
+                  "Balance": "1187998108",
+                  "Flags": 0,
+                  "OwnerCount": 52,
+                  "Sequence": 12933003
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "BFBA0ECCBCE78BB031A62D8277FDFA16606796918116EC9A11E6D2ACBC381919",
+                  "Balance": "1187998118",
+                  "Sequence": 12933002
+                },
+                "PreviousTxnID": "BFBA0ECCBCE78BB031A62D8277FDFA16606796918116EC9A11E6D2ACBC381919",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "ED8EA8C2531782F3455F9B5E9FF32E99CAE15DDFB3B10A0661BE8E17E2C15151",
+                "PreviousTxnID": "56AF3F97E43677CA3F5FD816E7C049B558CA95C70E9394703195F377757BA271",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-4207087.05649059"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rM19JiFRZwGvkmvA2DpUeoRV9kp4wNYCGn",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F18BA5D9C5ABED0982A7D2B4AEA3D87EE8FC681499F24F185312F5AA5781A996",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-4207087.05648594"
+                  }
+                },
+                "PreviousTxnID": "5A0E612CE34CFF1A4AF26CEF48CB8D055971407EB0E0F0C4C818FBC3C94755B1",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            }
+          ],
+          "TransactionIndex": 63,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 12933006,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "2165132924730421e-28"
+        },
+        "TakerPays": {
+          "currency": "XDX",
+          "issuer": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+          "value": "2208797284770713e-26"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "5C6AD3AE8E2C53C2A20CF385AEAD1A7525D48AD6AE6B4ED46D404FBC32C0D0E57FADF69A2C274A450904C6980770E080BEC92F89593A70F34585680755430803",
+        "hash": "A9A209E309DD7FBD258B15E179FEE46AD96DBC9D118DCEC31AC7D97D226CAD16",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "e0",
+                  "Owner": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                  "RootIndex": "37B9EF2F6DAA50068F42E9BC0E00318605224E840A0171B2F7D9901D05432E38"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "07300B9A4762019DA71C90C04CC143818086350BCAC12733C50BA586F5B4DE60"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "096644062FE21891EB63D15CD0C6929DA64024D17927CE252D73BD741A87846F",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000000008867365563372514"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "XDX",
+                    "issuer": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+                    "value": "0"
+                  },
+                  "HighNode": "f02",
+                  "LowLimit": {
+                    "currency": "XDX",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "8725.716827807249"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "XDX",
+                    "issuer": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+                    "value": "0"
+                  },
+                  "HighNode": "efe",
+                  "LowLimit": {
+                    "currency": "XDX",
+                    "issuer": "rNMzDSPiQQa1Ti7ypKgVCyw6BB4Bj7xSVk",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "0E9C1DF70B0BCEFD17433570A380F4411D44CBD965BFD013B53867F42F914F8D",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XDX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "8725.716827816116"
+                  }
+                },
+                "PreviousTxnID": "73E7AA1E714FC3B0FAFBEBC296FEAF346CFD97FBF95677BC4816A0C98CE4572B",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.08553154574949816"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rNMzDSPiQQa1Ti7ypKgVCyw6BB4Bj7xSVk",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "LowNode": "e0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "1864F80DEE9924CCC5DD96C5AFFA63722AC82F0F56614E78B97396B979225877",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.08553154574941122"
+                  }
+                },
+                "PreviousTxnID": "73E7AA1E714FC3B0FAFBEBC296FEAF346CFD97FBF95677BC4816A0C98CE4572B",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "756727A846E5AD37BEF80E11730FD2161803B0771D168769F9B4E2E26DEEB8D8",
+                "PreviousTxnID": "34CF594A8F713082658A9EF40CDAB0E51C8390CDBD660C8CAB6F53C81EDAD9C3",
+                "PreviousTxnLgrSeq": 90150372
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "A9A209E309DD7FBD258B15E179FEE46AD96DBC9D118DCEC31AC7D97D226CAD16",
+                  "Balance": "1187998068",
+                  "Flags": 0,
+                  "OwnerCount": 52,
+                  "Sequence": 12933007
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "F165A6530065D4ACA7BC5BACE419965F3BCEA0F176C438BF0E9A682C6CC87028",
+                  "Balance": "1187998078",
+                  "Sequence": 12933006
+                },
+                "PreviousTxnID": "F165A6530065D4ACA7BC5BACE419965F3BCEA0F176C438BF0E9A682C6CC87028",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1048576,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c",
+                  "PreviousTxnID": "F165A6530065D4ACA7BC5BACE419965F3BCEA0F176C438BF0E9A682C6CC87028",
+                  "PreviousTxnLgrSeq": 90150378
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D63A73BFE673289DA86434524C38EBA61561FC4C7614601A6173E85C92A0AC07",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "8694261946292211e-29"
+                  },
+                  "Flags": 1114112
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "D9F260E4F8EDF98001192FAE5B99A794F53E2873DE6FEE9C6056C01BBA8E5E75",
+                "PreviousTxnID": "F165A6530065D4ACA7BC5BACE419965F3BCEA0F176C438BF0E9A682C6CC87028",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "f01",
+                  "Owner": "rMJAXYsbNzhwp7FfYnAsYP5ty3R9XnurPo",
+                  "RootIndex": "08FE718A3C070C1E1DA13EF37C7EA90148F28A8E01879E94258DB573AA304957"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F1DC51C2DD326A767B6E4ABA79A4B67D9F773353E1E4DB2DE91FFA5D08A7EBA6"
+              }
+            }
+          ],
+          "TransactionIndex": 67,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "Sequence": 104034200,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TakerGets": {
+          "currency": "EUR",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "9853.030289288576"
+        },
+        "TakerPays": {
+          "currency": "BTC",
+          "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+          "value": "0.1857142521460126"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100FAEFB238E711FF8850182EEC7339B95CF15243C5D46E80C9FD1AAC2E5633629E02201048FA373B48167BE68D6C2A164F14FFF812F8E3EAED933A896DD2180282E14E",
+        "hash": "ABA071B02E41DD4975BC0148B70DA5B622A9CF86DB8319078A4481500E01E2DB",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "8C7111E0E30AA0E3D31C2A0973C2C7B57CCBF55988136BF05006B241723D15A0",
+                "NewFields": {
+                  "ExchangeRate": "5006b241723d15a0",
+                  "RootIndex": "8C7111E0E30AA0E3D31C2A0973C2C7B57CCBF55988136BF05006B241723D15A0",
+                  "TakerGetsCurrency": "0000000000000000000000004555520000000000",
+                  "TakerGetsIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230",
+                  "TakerPaysCurrency": "0000000000000000000000004254430000000000",
+                  "TakerPaysIssuer": "06A148131B436B2561C85967685B098E050EED4E"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "91112BFDFEBA12FC774B8B7B57213EAC6CDB4F4019988513BD4BC3667078084F",
+                "NewFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "8C7111E0E30AA0E3D31C2A0973C2C7B57CCBF55988136BF05006B241723D15A0",
+                  "OwnerNode": "c982",
+                  "Sequence": 104034200,
+                  "TakerGets": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "9853.030289288576"
+                  },
+                  "TakerPays": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.1857142521460126"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "c981",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9E1545C92DE33FB8C9673211120C31C1F8E9465566DF642829D6131747757F3E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678661",
+                  "Flags": 0,
+                  "OwnerCount": 92,
+                  "Sequence": 104034201
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678671",
+                  "OwnerCount": 91,
+                  "Sequence": 104034200
+                },
+                "PreviousTxnID": "426FFD2D6EFB1F65CFDDF98EA657520E699C26B075A13C9F94F43552117292BD",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 6,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rsMt22tM5DoD7Y1xGbLrYCz3GSu2gj9m4w",
+        "Fee": "221",
+        "Flags": 0,
+        "LastLedgerSequence": 90150384,
+        "OfferSequence": 72401075,
+        "Sequence": 72401077,
+        "SigningPubKey": "027C7A69E43CAC0FD5E20D682EBCB10AD316134F77095061177D994F1C5D7F515E",
+        "TakerGets": {
+          "currency": "BTC",
+          "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+          "value": "0.004795"
+        },
+        "TakerPays": "500000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100E024595670407E510C614390047BF9845976051A666D8DB8265892F92112537A02207BCE3041EFC2BCCB023C4756F10B4E0181605E5F2B8B1D4BE2D13F592FB429C7",
+        "hash": "AFB2684956B2A818328185C263AE75FE68613555AE2ABF2E618D1EF932F18665",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rsMt22tM5DoD7Y1xGbLrYCz3GSu2gj9m4w",
+                  "BookDirectory": "DCBE2F8E6D6301D83DA0FB697299BFEECD45EF73EFD3EC726003B65C35686E36",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "0F97DEDDC50E5DB1A19A8F458A261BDA2667147A51598834176E43DEB6003C2D",
+                  "PreviousTxnLgrSeq": 90150282,
+                  "Sequence": 72401075,
+                  "TakerGets": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.004785"
+                  },
+                  "TakerPays": "500000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "068B36139EAF13E8640BB51522F27F66A75F7C59324077419CD135D6066D2CB7"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rsMt22tM5DoD7Y1xGbLrYCz3GSu2gj9m4w",
+                  "Balance": "5294382682",
+                  "Flags": 0,
+                  "OwnerCount": 3,
+                  "Sequence": 72401078
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "45D792E0A222EAD4779B48F8A3C7978C589AF7511EB9C1EDB0D91B4A6B0AC9B7",
+                "PreviousFields": {
+                  "Balance": "5294382903",
+                  "Sequence": 72401077
+                },
+                "PreviousTxnID": "444649B2D634673693F7830D2AC882F2C9EA386216316260F519E5D2447EFF77",
+                "PreviousTxnLgrSeq": 90150299
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "6CFDC45F5BE156DABEFE875E06FA550F8E1C48F265DA551FC0BF0DA6EA6740B0",
+                "NewFields": {
+                  "Account": "rsMt22tM5DoD7Y1xGbLrYCz3GSu2gj9m4w",
+                  "BookDirectory": "DCBE2F8E6D6301D83DA0FB697299BFEECD45EF73EFD3EC726003B460D24292D2",
+                  "Sequence": 72401077,
+                  "TakerGets": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.004795"
+                  },
+                  "TakerPays": "500000000"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rsMt22tM5DoD7Y1xGbLrYCz3GSu2gj9m4w",
+                  "RootIndex": "BD58154E025DD5047F44A39F3F5ADE7900D19174ECED88856172BE2D9C96586F"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "BD58154E025DD5047F44A39F3F5ADE7900D19174ECED88856172BE2D9C96586F"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DCBE2F8E6D6301D83DA0FB697299BFEECD45EF73EFD3EC726003B460D24292D2",
+                "NewFields": {
+                  "ExchangeRate": "6003b460d24292d2",
+                  "RootIndex": "DCBE2F8E6D6301D83DA0FB697299BFEECD45EF73EFD3EC726003B460D24292D2",
+                  "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                  "TakerGetsIssuer": "06A148131B436B2561C85967685B098E050EED4E"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "6003b65c35686e36",
+                  "Flags": 0,
+                  "RootIndex": "DCBE2F8E6D6301D83DA0FB697299BFEECD45EF73EFD3EC726003B65C35686E36",
+                  "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                  "TakerGetsIssuer": "06A148131B436B2561C85967685B098E050EED4E",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DCBE2F8E6D6301D83DA0FB697299BFEECD45EF73EFD3EC726003B65C35686E36"
+              }
+            }
+          ],
+          "TransactionIndex": 39,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rs3RZsga1KbhSZetRsL22pkTyWyFU86Kkf",
+        "Amount": "89",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1077,
+        "Fee": "10",
+        "Sequence": 89522279,
+        "SigningPubKey": "EDF1D64EADDC52F5AA380ADF16C94443096C87E2F8854533F3ED79FD424168A12E",
+        "TransactionType": "Payment",
+        "TxnSignature": "A29F46C6FE46BA4CF803718DD7716A97A11645A426593797584BE5AA55FE6EEBD1E5B686616F77C322F9448B91CC402551E5CD554A42C5FF6DE6E6E204F8B80D",
+        "hash": "B23385B6542FF5422C41A89E29973ACC3ABA7A5442D20F2403EFA97DCACA38DB",
+        "DeliverMax": "89",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rs3RZsga1KbhSZetRsL22pkTyWyFU86Kkf",
+                  "Balance": "55108987",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89522280
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "054427CEEE4A008A9E92FC26DEEDB5FEAE6F915D5FD7836B047335C6A20AE7FA",
+                "PreviousFields": {
+                  "Balance": "55109086",
+                  "Sequence": 89522279
+                },
+                "PreviousTxnID": "16B87C1F181D85FE57BB37B11EE852D5098683B013A8D12A045A6D5E08B3E484",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180901812",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180901723"
+                },
+                "PreviousTxnID": "16B87C1F181D85FE57BB37B11EE852D5098683B013A8D12A045A6D5E08B3E484",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 42,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "89"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 148560027,
+        "Sequence": 148560037,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": "36286000000",
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "21055.31436"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "30440220126026F26A75FE10808B5BA9AA384CCD1AFF9144002E2CF82F52D3168C6ED58D02201C7B66F61CFAAF23F51AFC055064EBE282EF38BD04C17EA458058A51C8596FBF",
+        "hash": "B6CBC51F93428B22B36CB8F85A0F8D6FBF02F9291858ED71A0BEA3E7F9FD7954",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4E149E40A3F43800",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "93F53950AA2A60FCD9D4E4FAF125F2744BAB314EF114E6DB285DF02DE97595DA",
+                  "PreviousTxnLgrSeq": 90150376,
+                  "Sequence": 148560027,
+                  "TakerGets": "36286000000",
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "21058.5801"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "1ECBAF6E813D789F7E14A49DB407F589BFD4CA2BCBA00835606B2A417BB2CF15"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "36386886696",
+                  "Flags": 0,
+                  "OwnerCount": 15,
+                  "Sequence": 148560038
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "36386886716",
+                  "Sequence": 148560037
+                },
+                "PreviousTxnID": "A6997147285DE582DDE1F7894620F4D6056E0246C4F743FB9F04DDEF8BF37B64",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "82C23C1BFE78ECA8048E25A4E9DB0E7ABAACAAE0335C03B301D2F4818DFB4C1C",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4E149D6F17C61000",
+                  "Sequence": 148560037,
+                  "TakerGets": "36286000000",
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "21055.31436"
+                  }
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4E149D6F17C61000",
+                "NewFields": {
+                  "ExchangeRate": "4e149d6f17c61000",
+                  "RootIndex": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4E149D6F17C61000",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4e149e40a3f43800",
+                  "Flags": 0,
+                  "RootIndex": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4E149E40A3F43800",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4E149E40A3F43800"
+              }
+            }
+          ],
+          "TransactionIndex": 33,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104033995,
+        "Sequence": 104034212,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "3045022100C47974B234E8FE691A8A656965948ABA41566B6A4A8AC780CD7FD0C73A82E983022029589EE089EFA5DC61E6B070B2A022926D24822A12C1E68A2A525EB69DC0BE6F",
+        "hash": "B99246A4835E66203E0FBC444C576932A70735611B9092B34D14AE7165D7BD2B",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "c981",
+                  "IndexPrevious": "c97f",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "459AAE1593169E8594669891FE733971DEC9344F8CFEE6551EEFB3B0DC656F4C"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "DCBE2F8E6D6301D83DA0FB697299BFEECD45EF73EFD3EC726003C6487D636DE9",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c980",
+                  "PreviousTxnID": "72EBF4743E67D9A3011E8C08FB33D700B351171D2BFE6F35A8B9F27F9B67D1BC",
+                  "PreviousTxnLgrSeq": 90150299,
+                  "Sequence": 104033995,
+                  "TakerGets": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "1.666488362579329"
+                  },
+                  "TakerPays": "177054318559"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "99E5AE9CC7954B649EC2103F9BCA668D2D9DDE44F2C23228FE2C751A75F7DADA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678541",
+                  "Flags": 0,
+                  "OwnerCount": 84,
+                  "Sequence": 104034213
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678551",
+                  "OwnerCount": 85,
+                  "Sequence": 104034212
+                },
+                "PreviousTxnID": "257D389A36B07C2D93AE9B2A6CC0F8F526BC7B6FF740ABFB1154DA78C1CACE06",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "6003c6487d636de9",
+                  "Flags": 0,
+                  "RootIndex": "DCBE2F8E6D6301D83DA0FB697299BFEECD45EF73EFD3EC726003C6487D636DE9",
+                  "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                  "TakerGetsIssuer": "06A148131B436B2561C85967685B098E050EED4E",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DCBE2F8E6D6301D83DA0FB697299BFEECD45EF73EFD3EC726003C6487D636DE9"
+              }
+            }
+          ],
+          "TransactionIndex": 18,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rhNXgzs3QFPbuBphMx6tqZ7c83qbWNrd73",
+        "Amount": "88",
+        "Destination": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+        "DestinationTag": 1111170,
+        "Fee": "10",
+        "Sequence": 89525506,
+        "SigningPubKey": "EDEBDD15954498C672DC1A3AF3BFD6470F729B41899177EC404579A6A65765AC18",
+        "TransactionType": "Payment",
+        "TxnSignature": "55CBA3C553FEAE54FA607EE441EB21654A057F5BECDC5C7E6796FA2F36213E68826430CCEA358EB4C95B1F134D24B8F225CB223933D3ED82E8A55B5B41CD9301",
+        "hash": "B9A62E98A02E85F5A160AB16CD60963B22FB3BFBBDAD9CBB94CC4E30C5B35911",
+        "DeliverMax": "88",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+                  "Balance": "37856004",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89531841
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2A9DF02FF78FCCE946B77372B25D9C6F875895CEE6AAC1D37A7158BAA3E9BBDC",
+                "PreviousFields": {
+                  "Balance": "37855916"
+                },
+                "PreviousTxnID": "3AE1061BF61BEF17E75D9D1D58B603BD25F9410F628E96BB1C544D7F92DA98C4",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rhNXgzs3QFPbuBphMx6tqZ7c83qbWNrd73",
+                  "Balance": "55092199",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89525507
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "824B96E8418F0760DF6EF84ABFFB7D19E5C3ACF85B215950F642F0BD7358DEC0",
+                "PreviousFields": {
+                  "Balance": "55092297",
+                  "Sequence": 89525506
+                },
+                "PreviousTxnID": "734B1F2F9E904CBE88A2CAD8311DA79DDCDBE31E1A81842018FC091CF11833CA",
+                "PreviousTxnLgrSeq": 90150373
+              }
+            }
+          ],
+          "TransactionIndex": 70,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "88"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Amount": "2079",
+        "Destination": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 90150379,
+        "SendMax": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.001180712508353325"
+        },
+        "Sequence": 12932995,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TransactionType": "Payment",
+        "TxnSignature": "29C77C67AF9DF7AD759CFCBC6CF75E9843FB7098850E5EAFEB422D1BBCF9F0DA94765FBC965CD1AF3CFC72A61980C73E1D4637DB9EEB7BC2D34F04DE65E84B0C",
+        "hash": "BDB443F83282FA5BBAD7550330F7BED45A74ACA2A0BE2E434274FEAC8B3766F6",
+        "DeliverMax": "2079",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-245113.7528652705"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rHUpaqUPbwzKZdzQ8ZQCme18FrgW9pB4am",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "bd7"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "832F2523220A304ECEB7B2AE3E0D30829ACBCA0A31722FA8D952CC5BE7D9478B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-245113.7520453371"
+                  }
+                },
+                "PreviousTxnID": "562F1248B5F722736EC43ABEB330F1AEE3CA8DD549E5D05C13BA9DBDD63D4BD3",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "bff",
+                  "Owner": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                  "RootIndex": "7E1247F78EFC74FA9C0AE39F37AF433966615EB9B757D8397C068C2849A8F4A5"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "96C1FD71BCBEC8659FE7F43C7ACC7F72C3E40F9A33D7336C34C55D083AFC1610"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "EF95AD04AF97DF0DD76C5C624F93EF6F5479CDF8F30FAE612F1D434B5D6A914B",
+                  "Account": "rHUpaqUPbwzKZdzQ8ZQCme18FrgW9pB4am",
+                  "Balance": "435481095994",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 86795414
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B21B05E69AFB3F98B8D6F8066A69C4B189F3D804D8BE896AE11E60189AAFAD51",
+                "PreviousFields": {
+                  "Balance": "435481097437"
+                },
+                "PreviousTxnID": "562F1248B5F722736EC43ABEB330F1AEE3CA8DD549E5D05C13BA9DBDD63D4BD3",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B7D526FDDF9E3B3F95C3DC97C353065B0482302500BBB8051A5C090B596C6133",
+                "PreviousTxnID": "C942D5E070C73EBD0CDF21A2651F84A25B7E29282D96164E2C376887EAFB63DD",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "BDB443F83282FA5BBAD7550330F7BED45A74ACA2A0BE2E434274FEAC8B3766F6",
+                  "Balance": "1187998179",
+                  "Flags": 0,
+                  "OwnerCount": 51,
+                  "Sequence": 12932996
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "C942D5E070C73EBD0CDF21A2651F84A25B7E29282D96164E2C376887EAFB63DD",
+                  "Balance": "1187996746",
+                  "OwnerCount": 52,
+                  "Sequence": 12932995
+                },
+                "PreviousTxnID": "C942D5E070C73EBD0CDF21A2651F84A25B7E29282D96164E2C376887EAFB63DD",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 2097152,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "c00",
+                  "PreviousTxnID": "C942D5E070C73EBD0CDF21A2651F84A25B7E29282D96164E2C376887EAFB63DD",
+                  "PreviousTxnLgrSeq": 90150378
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "C6172C3C124263E8824878551FF6376348439DDB4492A13DB6B5BF7E30CCC208",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0008211633497887062"
+                  },
+                  "Flags": 2228224
+                }
+              }
+            }
+          ],
+          "DeliveredAmount": "1443",
+          "TransactionIndex": 56,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "1443"
+        }
+      },
+      {
+        "Account": "rweJHjm5WDjKcfyGSW72xeAkWztE5d2qkP",
+        "Amount": "7002",
+        "Destination": "rNxp4h8apvRis6mJf9Sh8C6iRxfrDWN7AV",
+        "DestinationTag": 401236629,
+        "Fee": "10",
+        "Sequence": 89523255,
+        "SigningPubKey": "ED884D872930844EF8285AF8DCCD78697D04A1BF1DCFF16A00F1BE344AC290DB13",
+        "TransactionType": "Payment",
+        "TxnSignature": "FA152283CF5E41EC7134B6E26654A63AC86C8F0E6FBFB3201BDD5049FBB2E467C14F8E2E8F548B4239136B81ED4019E98DE3F0B2B4BE24BAB9847FDB7F53B50D",
+        "hash": "BE32C819136834418ABF0042DF9F6C46D454D521392594A4EECA53285BE5337D",
+        "DeliverMax": "7002",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rweJHjm5WDjKcfyGSW72xeAkWztE5d2qkP",
+                  "Balance": "55118405",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89523256
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2195E6CEEA3CABA6C3EE430DB01F543D20A6869E3D86656942617F8DF347FBF9",
+                "PreviousFields": {
+                  "Balance": "55125417",
+                  "Sequence": 89523255
+                },
+                "PreviousTxnID": "317AFA368A630579C0E84661FACF40D09A53527C990692BFE9E07834CBF79112",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rNxp4h8apvRis6mJf9Sh8C6iRxfrDWN7AV",
+                  "Balance": "31169546803",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 77292675
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "59EDFBD7E3AA8EF84600C7AABD24DBC8229C19A1FF956C83D6B04390CF7C7E34",
+                "PreviousFields": {
+                  "Balance": "31169539801"
+                },
+                "PreviousTxnID": "EA36DB633AF90376042B0FD7A001D1FDDEFCF4525FDC815D4F859EE38BD80582",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            }
+          ],
+          "TransactionIndex": 38,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "7002"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 12933001,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "XRL",
+          "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+          "value": "0.000001175919994125901"
+        },
+        "TakerPays": {
+          "currency": "NET",
+          "issuer": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+          "value": "0.000000004651651301877477"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "9400E38E81691AD59BF30AFC12C1510426113BBA2DD9EAE4035B6ADEF87C888B56769C862F36ABA41E3222D272CCE005B20B8701ECE83AA2CEBA815AEF2FE30D",
+        "hash": "BFBA0ECCBCE78BB031A62D8277FDFA16606796918116EC9A11E6D2ACBC381919",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "368163F2B47E0164381E9A12A6ACA1A020B269224FC4A81F0385FCD03DEDB8D4",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000004650497723145133"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+                    "value": "0"
+                  },
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A78BDBB60A871C387C2698A23483A6F44105D6994E613389A513A6BD2C81869B",
+                "PreviousTxnID": "5A0E612CE34CFF1A4AF26CEF48CB8D055971407EB0E0F0C4C818FBC3C94755B1",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+                  "RootIndex": "B8262C6AD2FDF8D4F8CE480B0E9E06A37FB20F516C178A1D98FC0212A5E2EEDD"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B8262C6AD2FDF8D4F8CE480B0E9E06A37FB20F516C178A1D98FC0212A5E2EEDD"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "BFBA0ECCBCE78BB031A62D8277FDFA16606796918116EC9A11E6D2ACBC381919",
+                  "Balance": "1187998118",
+                  "Flags": 0,
+                  "OwnerCount": 52,
+                  "Sequence": 12933002
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "C755A2391006D255C841EBD693D00E0181FB25E650E9D3CD75460BF2CA11FC9D",
+                  "Balance": "1187998128",
+                  "OwnerCount": 51,
+                  "Sequence": 12933001
+                },
+                "PreviousTxnID": "C755A2391006D255C841EBD693D00E0181FB25E650E9D3CD75460BF2CA11FC9D",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.5039113114694676"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "XRL",
+                    "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "XRL",
+                    "issuer": "rDFNguSG5Z1KDz6GymYrym2GcQADYt1ius",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D696689500FB5E2B25F6FC91A0D5605DBDA2D4E65FF5B130B16B9E999817ABE3",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.5039101355494735"
+                  }
+                },
+                "PreviousTxnID": "F8011BE814CED565B7FBEA87CADF62FB0AA2EDB3A5E52B28D7D30644ACB6126B",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5699.980206083916"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "XRL",
+                    "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "XRL",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "c4"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "FCF9919AFEE1083CEC8CE802290093F96AECA1B415F9F64C6405E3F960FE56C4",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5699.980207259836"
+                  }
+                },
+                "PreviousTxnID": "C755A2391006D255C841EBD693D00E0181FB25E650E9D3CD75460BF2CA11FC9D",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1.993344223559295"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rDFNguSG5Z1KDz6GymYrym2GcQADYt1ius",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "FE3BCD820D92FF96E3458D3BCD2C5E7E566C641C11B4CF00453CDE13C970E09C",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1.993348874057018"
+                  }
+                },
+                "PreviousTxnID": "F8011BE814CED565B7FBEA87CADF62FB0AA2EDB3A5E52B28D7D30644ACB6126B",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            }
+          ],
+          "TransactionIndex": 62,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104034064,
+        "Sequence": 104034198,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "3044022002CC66C0B426FB3561E98372EA4F1C67C70451E514A16BDD238CC2756AC3BC59022014CDB05DF7A65E7DF47EBD298BDFEE56DE40D3E700863EFBAC7A09AB6BDA5209",
+        "hash": "BFDE938DC09A87DBA0CA5625F0FD73BFBB97CA4D4FB02415C27F0EC3AF6AC464",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "DB071D30B72F44A1ABFF0937C2C53B4D9B6A4EE2F4BC490E591425CA8A0C2F40",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c981",
+                  "PreviousTxnID": "6A8CE753F358EFA020825588C3E8D384038ADA6414E64D73EA2ADB7D3A124293",
+                  "PreviousTxnLgrSeq": 90150325,
+                  "Sequence": 104034064,
+                  "TakerGets": {
+                    "currency": "BTC",
+                    "issuer": "rchGBxcD1A1C2tdxF6papQYZ8kjRKMYcL",
+                    "value": "0.8246768050864738"
+                  },
+                  "TakerPays": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "46767.84520253237"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "259BCBD523CC91C63D471EEC70E590DA956ED30F9FDC2B285265229F2106DBA2"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678681",
+                  "Flags": 0,
+                  "OwnerCount": 92,
+                  "Sequence": 104034199
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678691",
+                  "OwnerCount": 93,
+                  "Sequence": 104034198
+                },
+                "PreviousTxnID": "63B35726DDF88FF9BFD3F4A5C1BB3EA2A18C6F0EF5F956145E13260D0C966B61",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "c982",
+                  "IndexPrevious": "c980",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "D2F5F8819C62765B668C36155555525E6FE527C513A8084409BE785FCDBCAB1F"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "591425ca8a0c2f40",
+                  "Flags": 0,
+                  "RootIndex": "DB071D30B72F44A1ABFF0937C2C53B4D9B6A4EE2F4BC490E591425CA8A0C2F40",
+                  "TakerGetsCurrency": "0000000000000000000000004254430000000000",
+                  "TakerGetsIssuer": "06A148131B436B2561C85967685B098E050EED4E",
+                  "TakerPaysCurrency": "0000000000000000000000004555520000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DB071D30B72F44A1ABFF0937C2C53B4D9B6A4EE2F4BC490E591425CA8A0C2F40"
+              }
+            }
+          ],
+          "TransactionIndex": 4,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rD37r1cciGqmdBpqou2DneEiWA1iQsAphP",
+        "Amount": "371457084",
+        "Destination": "rJn2zAPdFA193sixJwuFixRkYDUtx3apQh",
+        "DestinationTag": 500444041,
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 90150396,
+        "Sequence": 83716790,
+        "SigningPubKey": "EDAC31E2166ED326B5DDC85257804CE91BBA98725C33FBB469B5A93B85FAA4828D",
+        "TransactionType": "Payment",
+        "TxnSignature": "B7F49D7C41D46CB244BE7C1DA59F5B3BDE96E2E012DBE6D2C72B54CA89F5F28B8B70111BD6C2405C0C4B8E4192292517B140768FC660F44F093CF1DBB7F87C06",
+        "hash": "C0C64078F96B3AF627AFB25807610A09D378A5807C642A43D1203B01FFCB2BF9",
+        "DeliverMax": "371457084",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rD37r1cciGqmdBpqou2DneEiWA1iQsAphP",
+                  "Balance": "3754215505582",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 83716791
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A950B1061997F92CE4F80448E57F858027C9459B4F05DE374BAAEDC0A9C9D83A",
+                "PreviousFields": {
+                  "Balance": "3754586962681",
+                  "Sequence": 83716790
+                },
+                "PreviousTxnID": "B9D56BE83CC0CDE38148DD2D94BFBDDF4853D9D4B6DE875955BA1B221C470FCD",
+                "PreviousTxnLgrSeq": 90150367
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rJn2zAPdFA193sixJwuFixRkYDUtx3apQh",
+                  "Balance": "4245591964463",
+                  "Flags": 131072,
+                  "OwnerCount": 1,
+                  "Sequence": 117143
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C19B36F6B6F2EEC9F4E2AF875E533596503F4541DBA570F06B26904FDBBE9C52",
+                "PreviousFields": {
+                  "Balance": "4245220507379"
+                },
+                "PreviousTxnID": "3DF9D9A7DDD4A2EDD4EED1A3CBBAE51C5FA0A1FF57F66FDE31F432B1CCECC19C",
+                "PreviousTxnLgrSeq": 90150375
+              }
+            }
+          ],
+          "TransactionIndex": 80,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "371457084"
+        }
+      },
+      {
+        "Account": "rK2kLnCN4yjv1j2x79wXxRVXnFbwsjUWXo",
+        "Amount": {
+          "currency": "DFC",
+          "issuer": "rEEso92XqyM3oar4L2oC4fWQsG6oZViA4k",
+          "value": "100000"
+        },
+        "Destination": "rEEso92XqyM3oar4L2oC4fWQsG6oZViA4k",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 90150396,
+        "Sequence": 86541534,
+        "SigningPubKey": "03E50D796A4A6825F53F49EB20E127A7B727B1E65A16143375A5DE697F82F8E33C",
+        "TransactionType": "Payment",
+        "TxnSignature": "3044022047F455B29FF18D385F492E1A6F88E575654DCA7C828CC0850D72DB674A2CCC89022078F9F4E767CAE430566ACBED8C1F3E1261BE691407494B49C933B9456F73BE30",
+        "hash": "C1877726AF9FD1E3A35A95FF7D74FFCA9AAEB8FC58E558BC82A5E666B14FC610",
+        "DeliverMax": {
+          "currency": "DFC",
+          "issuer": "rEEso92XqyM3oar4L2oC4fWQsG6oZViA4k",
+          "value": "100000"
+        },
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rK2kLnCN4yjv1j2x79wXxRVXnFbwsjUWXo",
+                  "Balance": "22743715",
+                  "Flags": 0,
+                  "OwnerCount": 1,
+                  "Sequence": 86541535
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "22B22B184A1CB865E148C474EEBCCA1C504B5E2AF4AB8B52465E5A1B47B0E241",
+                "PreviousFields": {
+                  "Balance": "22743727",
+                  "Sequence": 86541534
+                },
+                "PreviousTxnID": "42448028443BE44B6E8DE99FA3A190F44C2EA7709D19219AF883E1F028750C4B",
+                "PreviousTxnLgrSeq": 90150375
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "DFC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-3387750255861906e-2"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "DFC",
+                    "issuer": "rK2kLnCN4yjv1j2x79wXxRVXnFbwsjUWXo",
+                    "value": "3392400000000000e-2"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "DFC",
+                    "issuer": "rEEso92XqyM3oar4L2oC4fWQsG6oZViA4k",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F02816B447CA4E2D8DB9FD55207BFA58753CC2298A9BA858C8E3967A77741143",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "DFC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-3387750265861906e-2"
+                  }
+                },
+                "PreviousTxnID": "42448028443BE44B6E8DE99FA3A190F44C2EA7709D19219AF883E1F028750C4B",
+                "PreviousTxnLgrSeq": 90150375
+              }
+            }
+          ],
+          "TransactionIndex": 75,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "DFC",
+            "issuer": "rEEso92XqyM3oar4L2oC4fWQsG6oZViA4k",
+            "value": "100000"
+          }
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 7381803,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "434F524500000000000000000000000000000000",
+          "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+          "value": "0.00002111098083070419"
+        },
+        "TakerPays": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "0.0000000001663293579709686"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "298A2AE955D37D81F3FFF74092A49B641DB77E1B1E24C1AD6E515FA96F88CA288C884B8A0653AD12D07DE89C25ADA54904E07750FAAD335118BC43649D747C02",
+        "hash": "C611B0FD5BC0A1A1F75CB0DE3798FB45827E02DB1689EA0A99DB56C36CDEFB20",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.6715382298522294"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "de",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rwLNFf9Y8HuqmQbdYxY8SBBVUGok5LU8oC",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "343772A1C317807B02D1689D1B2A598A7C1BFC95F5D8BC7BEA5B033C7096A64E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.6715383961403392"
+                  }
+                },
+                "PreviousTxnID": "71C300DBFD74E158919BE7672B59C483413C53F516D3B56774F1F41A3778CEF3",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.376476744925303"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "9"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "68062CBD2811E4D5FB502D7C86E4BB04DA46A2AAE9BE2B400045A57E3B5DBA8B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.376476578637193"
+                  }
+                },
+                "PreviousTxnID": "D8BD8AFEA89A8770263B59CA7A4E9F908C0FB4B8A41BFD2086419EB65724159B",
+                "PreviousTxnLgrSeq": 90150376
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-197.3126607868724"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "HighNode": "8",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "e9a"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B5AE9624630077C320F4F84D35562B165941C6E7D64BA7722A9CCDF0595F2F7E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-197.3126818978532"
+                  }
+                },
+                "PreviousTxnID": "46491A71799B0F167CCBBAEEC92F0C73A71E406EC46D57A0962F6ADA6FD56C13",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "C611B0FD5BC0A1A1F75CB0DE3798FB45827E02DB1689EA0A99DB56C36CDEFB20",
+                  "Balance": "420568238",
+                  "Flags": 0,
+                  "OwnerCount": 142,
+                  "Sequence": 7381804
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "46491A71799B0F167CCBBAEEC92F0C73A71E406EC46D57A0962F6ADA6FD56C13",
+                  "Balance": "420568248",
+                  "Sequence": 7381803
+                },
+                "PreviousTxnID": "46491A71799B0F167CCBBAEEC92F0C73A71E406EC46D57A0962F6ADA6FD56C13",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-85.23250828912336"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rwLNFf9Y8HuqmQbdYxY8SBBVUGok5LU8oC",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "e4e"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "EC005772123FC5ADC04081406EE2E72BA803EAFC0140950FEC24ECCB47285351",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-85.23248717814253"
+                  }
+                },
+                "PreviousTxnID": "71C300DBFD74E158919BE7672B59C483413C53F516D3B56774F1F41A3778CEF3",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            }
+          ],
+          "TransactionIndex": 49,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104034061,
+        "Sequence": 104034202,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "3045022100A59DFC7946897C6D446D900440F11EAB8B847DD114A55CA64B9B346120150FE302200717EA59B04BF5F04E12300DA5D5EEBA60C5D49B022FCCEB48B88638043400E3",
+        "hash": "C61488A005AB31645CAB9CFF27E7212839C5315A81C87DC25AAE0793C577AC24",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "FC4B99C28DF8622E6040A053A39DA16EB7A8EA2A61D569D357138626D65E8788",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c981",
+                  "PreviousTxnID": "1F529CB3845D0804D91C8840F56E372E616646383853DDF602E01630AE4DAF46",
+                  "PreviousTxnLgrSeq": 90150323,
+                  "Sequence": 104034061,
+                  "TakerGets": {
+                    "currency": "BCH",
+                    "issuer": "rcyS4CeCZVYvTiKcxj6Sx32ibKwcDHLds",
+                    "value": "6.89968374441567"
+                  },
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "3791.739086345558"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "0FE39EC2D9494EFE95CFAD92DD19B292DC843FC6211F925355AD184A10C19652"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678641",
+                  "Flags": 0,
+                  "OwnerCount": 90,
+                  "Sequence": 104034203
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678651",
+                  "OwnerCount": 91,
+                  "Sequence": 104034202
+                },
+                "PreviousTxnID": "9ED3E3B17C8C736F314BBB18DDE2924E4D2FE37E03FDC7A5BB2E68623D953408",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "c982",
+                  "IndexPrevious": "c980",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "D2F5F8819C62765B668C36155555525E6FE527C513A8084409BE785FCDBCAB1F"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "57138626d65e8788",
+                  "Flags": 0,
+                  "RootIndex": "FC4B99C28DF8622E6040A053A39DA16EB7A8EA2A61D569D357138626D65E8788",
+                  "TakerGetsCurrency": "0000000000000000000000004243480000000000",
+                  "TakerGetsIssuer": "06CDAB9869053E0AC7764D9ACB35B182CB195414",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "FC4B99C28DF8622E6040A053A39DA16EB7A8EA2A61D569D357138626D65E8788"
+              }
+            }
+          ],
+          "TransactionIndex": 8,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 104034162,
+        "Sequence": 104034203,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "3045022100DF9FC1892E4AF41B8533E137D790850C081355B6EA524332881DD89CAD1F4FF002207CB8836CDEE974D1ABD353A95E40D9765F54002D4E6D6A062E47CD51C472FA20",
+        "hash": "C69C19D4D65986DB586C03DE5576C8B3A957AB7BA57F208F073B816213872EAD",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "38D06F9EAB40629B223D38A77C895FB39D07FCFCB8D6AE935C13BA3925995AD4",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "c982",
+                  "PreviousTxnID": "E4C9F77A2D1E25DB9555D01340F8142C9199395B8FEAFCEAB55493022D0BEB2F",
+                  "PreviousTxnLgrSeq": 90150372,
+                  "Sequence": 104034162,
+                  "TakerGets": {
+                    "currency": "DSH",
+                    "issuer": "rcXY84C4g14iFp6taFXjjQGVeHqSCh9RX",
+                    "value": "40.55893579408421"
+                  },
+                  "TakerPays": "2252148136"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "0FAB0772F0D8F7CDD7333437DAFCAE6AE1656DBEEE813D19B68EE2EBD94E0ED7"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5c13ba3925995ad4",
+                  "Flags": 0,
+                  "RootIndex": "38D06F9EAB40629B223D38A77C895FB39D07FCFCB8D6AE935C13BA3925995AD4",
+                  "TakerGetsCurrency": "0000000000000000000000004453480000000000",
+                  "TakerGetsIssuer": "06B80F0F1D98AEDA846ED981F741C398FB2C4FD1",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "38D06F9EAB40629B223D38A77C895FB39D07FCFCB8D6AE935C13BA3925995AD4"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "c981",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9E1545C92DE33FB8C9673211120C31C1F8E9465566DF642829D6131747757F3E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "312119678631",
+                  "Flags": 0,
+                  "OwnerCount": 89,
+                  "Sequence": 104034204
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "312119678641",
+                  "OwnerCount": 90,
+                  "Sequence": 104034203
+                },
+                "PreviousTxnID": "C61488A005AB31645CAB9CFF27E7212839C5315A81C87DC25AAE0793C577AC24",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 9,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rGyyL5gmtQqrK77mWTQo5xaKu8KFbLaXKy",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 90150391,
+        "OfferSequence": 88006734,
+        "Sequence": 0,
+        "SigningPubKey": "ED84DB2F2C0EBBEE4078E6005CE70A9A36644C9B4FA25BF23DE16A0A3999295756",
+        "TakerGets": "10577194",
+        "TakerPays": {
+          "currency": "ZRP",
+          "issuer": "rZapJ1PZ297QAEXRGu3SZkAiwXbA7BNoe",
+          "value": "12.4439524"
+        },
+        "TicketSequence": 88006729,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "1C1DEBAB066AB3111ED1AFCCE7D9DB01EE34226FB8D396A1FD03B9DE622745843CA3D0D7FB8BBEB95CCFB891B98D2E3BC3AE4B35D88425DEAE63E632806DA80B",
+        "hash": "C708DD53A50E3322D7B8A1F99787606BCB2C26AE74815E67163276E686ACC30D",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "71a2",
+                  "Owner": "rGyyL5gmtQqrK77mWTQo5xaKu8KFbLaXKy",
+                  "RootIndex": "90EE64B2DAB58873DB7B825B150453672712E974286D27B2713351E0A23E982F"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1E9C694FB351C72A3A4D3A9AA9F15FB48486FA61D045B86144DF56B63314EA98"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f042e0541532ddd",
+                  "Flags": 0,
+                  "RootIndex": "2CC8983E6E0C011B8877381F7B01F83912F70299340C042F4F042E0541532DDD",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000005A52500000000000",
+                  "TakerPaysIssuer": "061180DE652FE04047D10A9AEFD56DF3D23AD33C"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "2CC8983E6E0C011B8877381F7B01F83912F70299340C042F4F042E0541532DDD"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rGyyL5gmtQqrK77mWTQo5xaKu8KFbLaXKy",
+                  "BookDirectory": "2CC8983E6E0C011B8877381F7B01F83912F70299340C042F4F042E0541532DDD",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "71ac",
+                  "PreviousTxnID": "B84FBDB359FE71D5434792CD7453FF5F10054078E288A61A0F4D87CE98620B7A",
+                  "PreviousTxnLgrSeq": 90150374,
+                  "Sequence": 88006734,
+                  "TakerGets": "10577095",
+                  "TakerPays": {
+                    "currency": "ZRP",
+                    "issuer": "rZapJ1PZ297QAEXRGu3SZkAiwXbA7BNoe",
+                    "value": "12.4439524"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "47EEADB9818CAD7EEC5AB1F5FCD099418B0F75878DDEC96E87C282CAD98E7C97"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "9A809762D29DE24088709C14221C8E1C4D2627048257F7AD7F0CE9722ABE8543",
+                "NewFields": {
+                  "Account": "rGyyL5gmtQqrK77mWTQo5xaKu8KFbLaXKy",
+                  "BookDirectory": "2CC8983E6E0C011B8877381F7B01F83912F70299340C042F4F042E0541532DDD",
+                  "OwnerNode": "71ac",
+                  "Sequence": 88006729,
+                  "TakerGets": "10577095",
+                  "TakerPays": {
+                    "currency": "ZRP",
+                    "issuer": "rZapJ1PZ297QAEXRGu3SZkAiwXbA7BNoe",
+                    "value": "12.4439524"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rGyyL5gmtQqrK77mWTQo5xaKu8KFbLaXKy",
+                  "Balance": "1775959211",
+                  "Flags": 0,
+                  "OwnerCount": 44,
+                  "Sequence": 88006751,
+                  "TicketCount": 5
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AF321CED1111BBC4AC593F6005A5BD077218EF9F3FEE02E7881B3026594CFC3A",
+                "PreviousFields": {
+                  "Balance": "1775959223",
+                  "OwnerCount": 45,
+                  "TicketCount": 6
+                },
+                "PreviousTxnID": "B84FBDB359FE71D5434792CD7453FF5F10054078E288A61A0F4D87CE98620B7A",
+                "PreviousTxnLgrSeq": 90150374
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rGyyL5gmtQqrK77mWTQo5xaKu8KFbLaXKy",
+                  "Flags": 0,
+                  "OwnerNode": "71ac",
+                  "PreviousTxnID": "D5B0AF281BD72C388E22B28B7788BAF57181468BEE370C54DF10F4B39E93C6B1",
+                  "PreviousTxnLgrSeq": 90150280,
+                  "TicketSequence": 88006729
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "B8B992E4847BE7883037D4BE57C97B2D59B0673BCA73C4C6084F252889CBC524"
+              }
+            }
+          ],
+          "TransactionIndex": 87,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 12933000,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": "1",
+        "TakerPays": {
+          "currency": "XRL",
+          "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+          "value": "0.0000000009799333284382514"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "12D8B395CA2B3E23F49CCC1657FB7992CB73BF49D62499B687D6BE662E1A81D604A89A380980A611BED7C1BF6887263422EB35DF5106F5AC3AB4C151D50D2101",
+        "hash": "C755A2391006D255C841EBD693D00E0181FB25E650E9D3CD75460BF2CA11FC9D",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rP8oBvFndK8PaNmy3hzR3yUZEEPw54441d",
+                  "Balance": "105312579",
+                  "Flags": 8388608,
+                  "OwnerCount": 36,
+                  "Sequence": 83482356
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "42DCE2DD8CDA516C665E097A383050A2EBF97CC217EB18638EEAC377D46B806D",
+                "PreviousFields": {
+                  "Balance": "105312578"
+                },
+                "PreviousTxnID": "7F6282717BDC54623522FC2D2F79B37AA935496BF996538E236876308CA1EB4A",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-13862594434.48161"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "XRL",
+                    "issuer": "rP8oBvFndK8PaNmy3hzR3yUZEEPw54441d",
+                    "value": "26000000000"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "XRL",
+                    "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "7A85483151BB3ED9F08601CAD00C37950E93A04659C7AD2DB45AECAEBD92B13F",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-13862594435.48161"
+                  }
+                },
+                "PreviousTxnID": "7F6282717BDC54623522FC2D2F79B37AA935496BF996538E236876308CA1EB4A",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rP8oBvFndK8PaNmy3hzR3yUZEEPw54441d",
+                  "BookDirectory": "DFBD7714A3D903789CB517FCE64B9E23C650CEEA56C51CC355038D7EA4C68000",
+                  "BookNode": "0",
+                  "Flags": 131072,
+                  "OwnerNode": "0",
+                  "Sequence": 83482245,
+                  "TakerGets": {
+                    "currency": "XRL",
+                    "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+                    "value": "9867594431.481657"
+                  },
+                  "TakerPays": "9867593819"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "AD4A2866FC092883010A61255500FAD3E2E24C34EA95254211C2D62FA1BFD736",
+                "PreviousFields": {
+                  "TakerGets": {
+                    "currency": "XRL",
+                    "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+                    "value": "9867594432.481657"
+                  },
+                  "TakerPays": "9867593820"
+                },
+                "PreviousTxnID": "7F6282717BDC54623522FC2D2F79B37AA935496BF996538E236876308CA1EB4A",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "C755A2391006D255C841EBD693D00E0181FB25E650E9D3CD75460BF2CA11FC9D",
+                  "Balance": "1187998128",
+                  "Flags": 0,
+                  "OwnerCount": 51,
+                  "Sequence": 12933001
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "FCD8CFD0902448D8C470725C68511E85BE2ED8EC4FDDC5F172BE2D49456E7895",
+                  "Balance": "1187998139",
+                  "Sequence": 12933000
+                },
+                "PreviousTxnID": "FCD8CFD0902448D8C470725C68511E85BE2ED8EC4FDDC5F172BE2D49456E7895",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5699.980207259836"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "XRL",
+                    "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "XRL",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "c4"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "FCF9919AFEE1083CEC8CE802290093F96AECA1B415F9F64C6405E3F960FE56C4",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5698.980207259836"
+                  }
+                },
+                "PreviousTxnID": "F8011BE814CED565B7FBEA87CADF62FB0AA2EDB3A5E52B28D7D30644ACB6126B",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            }
+          ],
+          "TransactionIndex": 61,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 12932994,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "5553444300000000000000000000000000000000",
+          "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+          "value": "0.001005316048518379"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.0000009854029809298796"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "2205796CAC7C105BCCDFDE8083EBE45DE9365A2838C64841108F25A42445F79458B9D0092558295994A8C1EF66880C58C4F4E0B4A3A952D63D97C713C7EF2704",
+        "hash": "C942D5E070C73EBD0CDF21A2651F84A25B7E29282D96164E2C376887EAFB63DD",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-533.2044348784242"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rnAHo4WfTcmbvwKPuKRyvAFPiDEznJJSxq",
+                    "value": "1000000000"
+                  },
+                  "HighNode": "2",
+                  "LowLimit": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "0"
+                  },
+                  "LowNode": "b8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "3A30FAC83F13BFBC45C683DB49CB9BD62B74AA1A651F174AD97E4A46D754B7CA",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-533.2035970421331"
+                  }
+                },
+                "PreviousTxnID": "86B677B694E67F4DA1A2C345CCBDCAE5D7994921772A1322DA4FB7293C2369B1",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 2097152,
+                  "HighLimit": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "0"
+                  },
+                  "LowNode": "169",
+                  "PreviousTxnID": "73552ED92ADB71A7563296A4643EB97230D6496FBD64CDDB1403545ACE2FFCCF",
+                  "PreviousTxnLgrSeq": 90150378
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "6EEFBC49B3F475E7DF6C906307DE385FB08661D21E0109E8A51FFBB700B904F6",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0008403498"
+                  },
+                  "Flags": 2228224
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rnAHo4WfTcmbvwKPuKRyvAFPiDEznJJSxq",
+                  "BookDirectory": "B0C2569CA035483D3B7E98A8B13317FB2DF15CCAF1FBB55C55039FF60C6F9BAA",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "7",
+                  "Sequence": 86957,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "28.34593864858572"
+                  },
+                  "TakerPays": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "28.92147599128097"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "8433C9F781A74045ED8F1B571CDBBA15CB16200500ACAFD8B00CBC613302B605",
+                "PreviousFields": {
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "28.34675981193551"
+                  },
+                  "TakerPays": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "28.9223138275721"
+                  }
+                },
+                "PreviousTxnID": "86B677B694E67F4DA1A2C345CCBDCAE5D7994921772A1322DA4FB7293C2369B1",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "bff",
+                  "Owner": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                  "RootIndex": "7E1247F78EFC74FA9C0AE39F37AF433966615EB9B757D8397C068C2849A8F4A5"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "96C1FD71BCBEC8659FE7F43C7ACC7F72C3E40F9A33D7336C34C55D083AFC1610"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-928.8432621281354"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rnAHo4WfTcmbvwKPuKRyvAFPiDEznJJSxq",
+                    "value": "1000000000"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "b18"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "98DD1524038EAD3289F324EB8DDC1C2AB425DA8524FE3378374DE1F7081E906D",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-928.8440845232302"
+                  }
+                },
+                "PreviousTxnID": "86B677B694E67F4DA1A2C345CCBDCAE5D7994921772A1322DA4FB7293C2369B1",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A14493C8BFD5BFDEAA3A0CF3CA9BF9D0E776C0FF04A3707844E8EC6CA87C399F",
+                "PreviousTxnID": "73552ED92ADB71A7563296A4643EB97230D6496FBD64CDDB1403545ACE2FFCCF",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "168",
+                  "Owner": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                  "RootIndex": "11E2D9655996752410DFEB6D347CFAC68CB8CCC4B32DEAE013D46FEE55365BED"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "A40401935620DD6727398991FAB466E4225D4BCDA4F86EE6603B63475E2D2AB3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B7D526FDDF9E3B3F95C3DC97C353065B0482302500BBB8051A5C090B596C6133",
+                "PreviousTxnID": "562F1248B5F722736EC43ABEB330F1AEE3CA8DD549E5D05C13BA9DBDD63D4BD3",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "C942D5E070C73EBD0CDF21A2651F84A25B7E29282D96164E2C376887EAFB63DD",
+                  "Balance": "1187996746",
+                  "Flags": 0,
+                  "OwnerCount": 52,
+                  "Sequence": 12932995
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "73552ED92ADB71A7563296A4643EB97230D6496FBD64CDDB1403545ACE2FFCCF",
+                  "Balance": "1187996756",
+                  "Sequence": 12932994
+                },
+                "PreviousTxnID": "73552ED92ADB71A7563296A4643EB97230D6496FBD64CDDB1403545ACE2FFCCF",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "C6172C3C124263E8824878551FF6376348439DDB4492A13DB6B5BF7E30CCC208",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0008211633497887062"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "c00"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 55,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 148560029,
+        "Sequence": 148560039,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": "36286000000",
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "20795.386021622"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304502210096625BD3D2D190E9C708C37EE2CF7B362069BDA942EB3D07134CDC43E486DE5A022077D91AB6987AE5E85B65D126ED1BC88AB0289FBEBF168D6CA762D853A04AED61",
+        "hash": "C9B9B2C3C27E17EA5320DBDE2EB8FC548AFBA621C0F3DFA85C6CEE4CC0E0B1F5",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "36386886656",
+                  "Flags": 0,
+                  "OwnerCount": 15,
+                  "Sequence": 148560040
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "36386886676",
+                  "Sequence": 148560039
+                },
+                "PreviousTxnID": "A7D055A13BCBF24772D3A20B3D4DF379EBEE6E1A55B97241E0290927D5C53293",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E145C48AE8BA080",
+                "NewFields": {
+                  "ExchangeRate": "4e145c48ae8ba080",
+                  "RootIndex": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E145C48AE8BA080",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4e145c4ed41ba880",
+                  "Flags": 0,
+                  "RootIndex": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E145C4ED41BA880",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E145C4ED41BA880"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "AE57C40BBC108545C3A021152FB6A83244F15559B5C849C9A617F784A50545A2",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E145C48AE8BA080",
+                  "Sequence": 148560039,
+                  "TakerGets": "36286000000",
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "20795.386021622"
+                  }
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E145C4ED41BA880",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "551A5EA8C15DB8CEC8C0CE0C561716379992749771390CAF4596748D87EF86C9",
+                  "PreviousTxnLgrSeq": 90150377,
+                  "Sequence": 148560029,
+                  "TakerGets": "36286000000",
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "20795.481816662"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "D696F29FFEF364FF41854F854FF792D14C7540708FF627DB23ABFC09D008D007"
+              }
+            }
+          ],
+          "TransactionIndex": 35,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 90150396,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7B226D6F64756C65223A2258574D2041737369737465642054726164696E67222C22616363657373223A2258574D204E4654204469616D6F6E64222C2276657273696F6E223A2276302E352E302062657461222C227374726174656779223A224261736963227D"
+            }
+          }
+        ],
+        "Sequence": 77858010,
+        "SigningPubKey": "ED3DCAF22FDDABE246DA4599A938559C95DA2BD90A2799354C9176B69E4F16BCAF",
+        "TakerGets": "10000000",
+        "TakerPays": {
+          "currency": "SGB",
+          "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+          "value": "877.58930315"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "9BA3F0D3246A3ABCD0F1AFE8139DC8E6361D4B223AE871F129DD6949AB3BCCD462211D565770DD75BC8F96BBBD15D2AB3739BC60D92CC1CCAF8CE5EB2CD1F20F",
+        "hash": "CE6D88514150E98F1D0E7002D3F38BB51F620549908E92AF2CE16A572AC93704",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+                  "Balance": "237723949",
+                  "Flags": 0,
+                  "OwnerCount": 17,
+                  "Sequence": 77858011
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "0943A7CA0445F090EFA54DF215581407714AE7E396207B491C049F9EB75BB6A5",
+                "PreviousFields": {
+                  "Balance": "237723964",
+                  "OwnerCount": 16,
+                  "Sequence": 77858010
+                },
+                "PreviousTxnID": "4EA0C25DA4CEC179C6DAB5DA9E0E8E230DC31846A29216380A7C27D4EC2F1E9F",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+                  "RootIndex": "FB7FD5BD320C1FD457BA3FA9416E901182140B8712DE967A67ADB9A7DBB2AAFD"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "81831B6ECB29F00B5C9F237E6AA794AF27C90F7A5D7F9F05A92E712767302A03"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "A6BFCA061E062526916956017862BD0B9630A86F6C5F0455501F2DA0D2BAB8E0",
+                "NewFields": {
+                  "ExchangeRate": "501f2da0d2bab8e0",
+                  "RootIndex": "A6BFCA061E062526916956017862BD0B9630A86F6C5F0455501F2DA0D2BAB8E0",
+                  "TakerPaysCurrency": "0000000000000000000000005347420000000000",
+                  "TakerPaysIssuer": "06C9E89FEF0D5C8CE1E752F3A279627D51A0E7B4"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "D467D55ADFC39EF2D43AAF249632F6EC487A5099ACA2564D02CC3DDFFB1A31A0",
+                "NewFields": {
+                  "Account": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+                  "BookDirectory": "A6BFCA061E062526916956017862BD0B9630A86F6C5F0455501F2DA0D2BAB8E0",
+                  "OwnerNode": "1",
+                  "Sequence": 77858010,
+                  "TakerGets": "10000000",
+                  "TakerPays": {
+                    "currency": "SGB",
+                    "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+                    "value": "877.58930315"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 26,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rKM8GLFDo11xaYDvmKH8bUn2tHQnjjSQ7S",
+        "Amount": "88",
+        "Destination": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+        "DestinationTag": 1111208,
+        "Fee": "10",
+        "Sequence": 89637775,
+        "SigningPubKey": "ED2BBCB0F31C4B98DE6A39B87F5AA9500402D2F8117418D27543FCC727E8D2B051",
+        "TransactionType": "Payment",
+        "TxnSignature": "FB811D5FD469C90CB1A4AA5FDDBBA0FA856B9D0C6CE56C90B24DFE36AE7525D3EC7DE87756A63D19E6D7516A6543EA1C4ACE41AE93D1A1C2EADB8C54FDAE440E",
+        "hash": "D1614E4FECFF2E6F33ADFB3B86D82421AB566AAB9E7B68C34424BD76A961DAB7",
+        "DeliverMax": "88",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+                  "Balance": "37856092",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89531841
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2A9DF02FF78FCCE946B77372B25D9C6F875895CEE6AAC1D37A7158BAA3E9BBDC",
+                "PreviousFields": {
+                  "Balance": "37856004"
+                },
+                "PreviousTxnID": "B9A62E98A02E85F5A160AB16CD60963B22FB3BFBBDAD9CBB94CC4E30C5B35911",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rKM8GLFDo11xaYDvmKH8bUn2tHQnjjSQ7S",
+                  "Balance": "52780652",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89637776
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E414E4606B8E1F72ACB8F3292F6E264AFD712582A64BE6987DA0C972CFF00F91",
+                "PreviousFields": {
+                  "Balance": "52780750",
+                  "Sequence": 89637775
+                },
+                "PreviousTxnID": "B8C4537398EC8EE629C52894A66C9AD617AE9C5C5AB6A240B360813204DE2CEA",
+                "PreviousTxnLgrSeq": 90150360
+              }
+            }
+          ],
+          "TransactionIndex": 76,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "88"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 12932998,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "5A52505900000000000000000000000000000000",
+          "issuer": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+          "value": "0.03723746497512281"
+        },
+        "TakerPays": {
+          "currency": "7853504543544152000000000000000000000000",
+          "issuer": "rh5jzTCdMRCVjQ7LT6zucjezC47KATkuvv",
+          "value": "0.00001793133218636926"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "7DD987D9996F93719417081581644488E268613AB99B49FDC2EF19B030BE74C1BC121E3157D0EF895DC01CD612924A60C1AE432397953A408CD10078101CCC0B",
+        "hash": "D19538656EA7D324A014960BF219802FFD48859A4BEB68254CA26BEA5186584D",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-37181.95137469958"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "raGweGmVeji2xyqzgybQiBqDyRFtRgGVAB",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+                    "value": "0"
+                  },
+                  "LowNode": "87"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "00795CB8BE260417DD9AC12EDCBBF8905BC0BBBE6177084B42E2D26D8B8CD556",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-37181.92558828897"
+                  }
+                },
+                "PreviousTxnID": "14A222F5BEB0BC8FB105CDCC1BE7B06EBF375C63876AA8E44FAAB083F48B81B7",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-17906.75895754653"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "raGweGmVeji2xyqzgybQiBqDyRFtRgGVAB",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rh5jzTCdMRCVjQ7LT6zucjezC47KATkuvv",
+                    "value": "0"
+                  },
+                  "LowNode": "3ea"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "6871BC86D75571249554E52D87CBF37BE29083515860777B41CEAE20EA0446BC",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-17906.77137165797"
+                  }
+                },
+                "PreviousTxnID": "14A222F5BEB0BC8FB105CDCC1BE7B06EBF375C63876AA8E44FAAB083F48B81B7",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "90848E9A1185CCEF2B55329945A8D6075A88A10A854FF6DB890994AAD4CED060",
+                "PreviousTxnID": "811E7ABE83FC0F35B9D543D33F1A0A1FD9F2EFFFA0BE7A8702EA197F96CF0404",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "40a",
+                  "Owner": "rh5jzTCdMRCVjQ7LT6zucjezC47KATkuvv",
+                  "RootIndex": "2BD70BEEC95186EDCE5F825DECA520D2521F1536E753B1F8186466B69F265963"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "A38DAA262DA6F3D89E5B9D27D3468F9A7154F2C7687D460BBA16CF7D66F9A1A0"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "D19538656EA7D324A014960BF219802FFD48859A4BEB68254CA26BEA5186584D",
+                  "Balance": "1187997968",
+                  "Flags": 0,
+                  "OwnerCount": 52,
+                  "Sequence": 12932999
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "811E7ABE83FC0F35B9D543D33F1A0A1FD9F2EFFFA0BE7A8702EA197F96CF0404",
+                  "Balance": "1187997978",
+                  "Sequence": 12932998
+                },
+                "PreviousTxnID": "811E7ABE83FC0F35B9D543D33F1A0A1FD9F2EFFFA0BE7A8702EA197F96CF0404",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "8f",
+                  "Owner": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+                  "RootIndex": "4492BEF2FF8CE6639BB5E6AA330E8163DC45BED13660B310A2C5503C03534CA6"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "C3F0C59D3E02E306BD82ABA89093BEB615F70ADA0ECDE4E08A9470FB277D2744"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "CBF1F1A0ECB93ECD4D8E7BEE7C38428397927FA7C29C6DBAC6B2CB9A650F3194",
+                "PreviousTxnID": "51097F12ACDBE43CC2F14359FD860948AFE9A84AA235AACC9CC9277870751607",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 2097152,
+                  "HighLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+                    "value": "0"
+                  },
+                  "LowNode": "90",
+                  "PreviousTxnID": "811E7ABE83FC0F35B9D543D33F1A0A1FD9F2EFFFA0BE7A8702EA197F96CF0404",
+                  "PreviousTxnLgrSeq": 90150378
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "E5D9EA1D087FA02C08D319E9DBD3167D791173D848A08EC9EB6F4F77F4CFA48C",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.02578641060829358"
+                  },
+                  "Flags": 2228224
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F11C48DF65500A5D3FA812A1EF7ABA87124713D537D048889DC0BDDCCC58722C",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.01241411143983539"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rh5jzTCdMRCVjQ7LT6zucjezC47KATkuvv",
+                    "value": "0"
+                  },
+                  "LowNode": "40b"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 59,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Amount": "1",
+        "Destination": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 90150379,
+        "SendMax": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "2374487419614009e-27"
+        },
+        "Sequence": 12933008,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TransactionType": "Payment",
+        "TxnSignature": "1B556CBD3A96B6FE655564BA13CAAF9EADAB84ACA2AE9F19F8A2880BAA441326F894DA576FC03C6A23D3DD273B6DE103777C29C088F12069E9852FA7D1C1030E",
+        "hash": "D540F1E21A145F5CC9B95BEEF142A766C83E76E09A0E1DA6C2C2027FA7DB2B22",
+        "DeliverMax": "1",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.00000009596669017964013"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "0"
+                  },
+                  "LowNode": "2387"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "9A6C3769BB8CF0725767B6A272158F3D8FF28954928CEFC249B2FC2C1E34E3FA",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.00000009596906466705974"
+                  }
+                },
+                "PreviousTxnID": "11DE80F7F3C0305E0CA8286CA64089B96C50FBEC8F0631C2F793D455870A4177",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "630D4F2C7A2F80C4367BAC35219CE2C1274B59330694769A79B0C94A59789AAF",
+                  "Account": "rs9ineLqrCzeAGS1bxsrW8x2n3bRJYAh3Q",
+                  "Balance": "47201376900",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 86795329
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A88F25E5AD1D3945FB52291910763E286C55DBE1157E8F19D00F3CA964C6BC45",
+                "PreviousFields": {
+                  "Balance": "47201376899"
+                },
+                "PreviousTxnID": "4928FBD0A77F65E5DB9F65399726C20E4D8A705445EBB185560C94E8C420539D",
+                "PreviousTxnLgrSeq": 90150308
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "D540F1E21A145F5CC9B95BEEF142A766C83E76E09A0E1DA6C2C2027FA7DB2B22",
+                  "Balance": "1187998047",
+                  "Flags": 0,
+                  "OwnerCount": 51,
+                  "Sequence": 12933009
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "11DE80F7F3C0305E0CA8286CA64089B96C50FBEC8F0631C2F793D455870A4177",
+                  "Balance": "1187998058",
+                  "Sequence": 12933008
+                },
+                "PreviousTxnID": "11DE80F7F3C0305E0CA8286CA64089B96C50FBEC8F0631C2F793D455870A4177",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "DeliveredAmount": "-1",
+          "TransactionIndex": 69,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "-1"
+        }
+      },
+      {
+        "Account": "r476GSXdCnhs8M55irwNqhQRSu4Djrmh63",
+        "Amount": "89",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1139,
+        "Fee": "10",
+        "Sequence": 89120187,
+        "SigningPubKey": "EDD253AB2FD5713C557BEA6B0099B80A7DF6AF6375ED3D1DA7C7AD885193B684B6",
+        "TransactionType": "Payment",
+        "TxnSignature": "02CFC4253033CADBC1BC399C0F085C754D48BE6D6BF5B153D7C4A98030FB0FD8CE14C4F21B75048BD5CC9016550E607FA43D4738EB5A74FBAD96E7F92B9BE908",
+        "hash": "DFAC74D36AF4815ACD658439673C0AC0E26F66E00C9D6B57EF202581DD74A047",
+        "DeliverMax": "89",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180902165",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180902076"
+                },
+                "PreviousTxnID": "4561ED0814EDC216CEB2C33B4314A33181A000AA10018C79D70CAAD5FB02461F",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r476GSXdCnhs8M55irwNqhQRSu4Djrmh63",
+                  "Balance": "52410293",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89120188
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "63CA584080D9CA571C34A0A2477FC533B728BB01ACD43A07097502396047D7C7",
+                "PreviousFields": {
+                  "Balance": "52410392",
+                  "Sequence": 89120187
+                },
+                "PreviousTxnID": "36E4872DDECD725F09BAEB27E70AD29471BFFC4A8B22B34CC4A7760159372908",
+                "PreviousTxnLgrSeq": 90150374
+              }
+            }
+          ],
+          "TransactionIndex": 77,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "89"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 90150380,
+        "OfferSequence": 148560025,
+        "Sequence": 148560035,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": "36286000000",
+        "TakerPays": {
+          "currency": "5553445400000000000000000000000000000000",
+          "issuer": "rcvxE9PS9YBwxtGg1qNeewV6ZB3wGubZq",
+          "value": "21136.093962912"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304402204041F833E11190F12813DE0A05196CD6B6325A5710C868FDD5EC0615A2A7CD6E02204ADFAD47D43C8287F4AD660862073DF9932DA29806EDEDD0BD7014E6E7655F10",
+        "hash": "E869D53E3DCFCFBE1668F39FA163B64D6AAC88076CE7089F66775C7A7006A003",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "36386886736",
+                  "Flags": 0,
+                  "OwnerCount": 15,
+                  "Sequence": 148560036
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "36386886756",
+                  "Sequence": 148560035
+                },
+                "PreviousTxnID": "C5989435D114758AFA32334867B98213B3AB7F60521866808116E1079D9605BA",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4e14b1a9ff001d00",
+                  "Flags": 0,
+                  "RootIndex": "2410509CE58C2F04403737A3FD84B17D66C423554EEF919D4E14B1A9FF001D00",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "5553445400000000000000000000000000000000",
+                  "TakerPaysIssuer": "06CB988E900D81BAE9217E6FE6B60CD2DDA12767"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "2410509CE58C2F04403737A3FD84B17D66C423554EEF919D4E14B1A9FF001D00"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "2410509CE58C2F04403737A3FD84B17D66C423554EEF919D4E14B1AE599B7800",
+                "NewFields": {
+                  "ExchangeRate": "4e14b1ae599b7800",
+                  "RootIndex": "2410509CE58C2F04403737A3FD84B17D66C423554EEF919D4E14B1AE599B7800",
+                  "TakerPaysCurrency": "5553445400000000000000000000000000000000",
+                  "TakerPaysIssuer": "06CB988E900D81BAE9217E6FE6B60CD2DDA12767"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "3CA4FCA028ECAABDA338966DFAB104FF37FF09C3872A3B319A79D87EF05BCBCE",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "2410509CE58C2F04403737A3FD84B17D66C423554EEF919D4E14B1AE599B7800",
+                  "Sequence": 148560035,
+                  "TakerGets": "36286000000",
+                  "TakerPays": {
+                    "currency": "5553445400000000000000000000000000000000",
+                    "issuer": "rcvxE9PS9YBwxtGg1qNeewV6ZB3wGubZq",
+                    "value": "21136.093962912"
+                  }
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "2410509CE58C2F04403737A3FD84B17D66C423554EEF919D4E14B1A9FF001D00",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "424E48A52B23FA39E603C40C933192B7FE8CA58EE50B43B1967D516503EA7697",
+                  "PreviousTxnLgrSeq": 90150376,
+                  "Sequence": 148560025,
+                  "TakerGets": "36286000000",
+                  "TakerPays": {
+                    "currency": "5553445400000000000000000000000000000000",
+                    "issuer": "rcvxE9PS9YBwxtGg1qNeewV6ZB3wGubZq",
+                    "value": "21136.026108092"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "430F4C42F08A12682AA82B9671CDD70D40870CCC1D185F0CF0E8B9D005F849BD"
+              }
+            }
+          ],
+          "TransactionIndex": 31,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rDYkhQBXwbJqEMj39QYGmZQPQThR44HT",
+        "Amount": "89",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1065,
+        "Fee": "10",
+        "Sequence": 89121233,
+        "SigningPubKey": "EDED81D06CC744B3916C146372204DC27F02720559A8DB3338BB36112E0BC0AF95",
+        "TransactionType": "Payment",
+        "TxnSignature": "EBE57FDCE71EAD2681FDA2B8CD751DC14819EBAAAD316D8D30AC7C15ED305562208DE01BF81DF5494552B4EB5B5CA459CBB3D361BAEB07C3C506FA526386A60D",
+        "hash": "E9CEC850BBDDDF5600CD8C514A717824A83CD44F4382EEFFC6D4BBC11853FD88",
+        "DeliverMax": "89",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rDYkhQBXwbJqEMj39QYGmZQPQThR44HT",
+                  "Balance": "52391126",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89121234
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "04DB180343A980921C743469BD0BA3ADA7D0BED2F75D1E834CA5EFBEDDCBE47E",
+                "PreviousFields": {
+                  "Balance": "52391225",
+                  "Sequence": 89121233
+                },
+                "PreviousTxnID": "609D1C7DF1368926262B1DB8D563731C53A670CB7CD5AE54F1143C37FAAA9A3D",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180901326",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180901237"
+                },
+                "PreviousTxnID": "BC38A90D6B707A95F0937912E1761D0F4D189F5CF7C7A00D1347A9922F5D5A0E",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "89"
+        }
+      },
+      {
+        "Account": "rausnfdnkZTqCZSrsfhWuVCUf794zadJ92",
+        "Amount": "89",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1097,
+        "Fee": "10",
+        "Sequence": 89636635,
+        "SigningPubKey": "EDADA59599427CCA1DC45683248F1A1F86C8FFE39AC2C351642E7B5F28041B128F",
+        "TransactionType": "Payment",
+        "TxnSignature": "019DEB9FF4EC351C7C4BB27066E6329F0711CB3A1A279B66832A2924106D1B8482B5657C04CCA9A2DFAA4BA0702B4248946CFAE323B0772F76E624CF6451F10B",
+        "hash": "EE535246B0C713909707A3F938057D6157EB40D868344E091A4EE6A08C8FEF28",
+        "DeliverMax": "89",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rausnfdnkZTqCZSrsfhWuVCUf794zadJ92",
+                  "Balance": "52767935",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89636636
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "3B5A1CF1E84566A6D4920452D9891F13F1F4FD7F3C0B9297214DFE6EA37488D0",
+                "PreviousFields": {
+                  "Balance": "52768034",
+                  "Sequence": 89636635
+                },
+                "PreviousTxnID": "5FB7B7142E809DD4E774E222F7FBCC5A5C54EE7C338868F4D1BB56C4D3AE3764",
+                "PreviousTxnLgrSeq": 90150376
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "180901502",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "180901413"
+                },
+                "PreviousTxnID": "6C7EE4F2E7BA797FC8BDDC8BE7AA1226A7ED1C02055F45F44ACB09439235374A",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 27,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "89"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 12933005,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "434F524500000000000000000000000000000000",
+          "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+          "value": "2290043136406854e-26"
+        },
+        "TakerPays": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "1804277437275351e-31"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "95DAB78DDFAB3653D0CFDF37D50D7EFD836F4234A610598AFDAE80725EDCDB1B2DBD6F2043E3C5732758073352F0472AD62926F6C96282B00BE5698ADB323B0D",
+        "hash": "F165A6530065D4ACA7BC5BACE419965F3BCEA0F176C438BF0E9A682C6CC87028",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "e0",
+                  "Owner": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                  "RootIndex": "37B9EF2F6DAA50068F42E9BC0E00318605224E840A0171B2F7D9901D05432E38"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "07300B9A4762019DA71C90C04CC143818086350BCAC12733C50BA586F5B4DE60"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1E1ADBD847116F2C0DF91CCB7165719E2285397499705C85414A745A3AC80F43",
+                "PreviousTxnID": "47F35FC9B5D65C51A4474811AA177BD907FCF2FA1ACFD6C893F2C589DFA6C0F8",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.6715382298521425"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "de",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rwLNFf9Y8HuqmQbdYxY8SBBVUGok5LU8oC",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "343772A1C317807B02D1689D1B2A598A7C1BFC95F5D8BC7BEA5B033C7096A64E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.6715382298522294"
+                  }
+                },
+                "PreviousTxnID": "C611B0FD5BC0A1A1F75CB0DE3798FB45827E02DB1689EA0A99DB56C36CDEFB20",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "ea0",
+                  "Owner": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                  "RootIndex": "5DD87298A566F5805C113F1E887578A4AF0123F117D08E74F3A0698F1AD100ED"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B2FBE6A2AD61B0BBC3C6EECCAD32590841ADA8E5AE4811728B29F85AA95A747F"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "F165A6530065D4ACA7BC5BACE419965F3BCEA0F176C438BF0E9A682C6CC87028",
+                  "Balance": "1187998078",
+                  "Flags": 0,
+                  "OwnerCount": 52,
+                  "Sequence": 12933006
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "47F35FC9B5D65C51A4474811AA177BD907FCF2FA1ACFD6C893F2C589DFA6C0F8",
+                  "Balance": "1187998088",
+                  "Sequence": 12933005
+                },
+                "PreviousTxnID": "47F35FC9B5D65C51A4474811AA177BD907FCF2FA1ACFD6C893F2C589DFA6C0F8",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D63A73BFE673289DA86434524C38EBA61561FC4C7614601A6173E85C92A0AC07",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "8694261946292211e-29"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "D9F260E4F8EDF98001192FAE5B99A794F53E2873DE6FEE9C6056C01BBA8E5E75",
+                "PreviousTxnID": "811E7ABE83FC0F35B9D543D33F1A0A1FD9F2EFFFA0BE7A8702EA197F96CF0404",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-85.2325082891344"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rwLNFf9Y8HuqmQbdYxY8SBBVUGok5LU8oC",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "e4e"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "EC005772123FC5ADC04081406EE2E72BA803EAFC0140950FEC24ECCB47285351",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-85.23250828912336"
+                  }
+                },
+                "PreviousTxnID": "C611B0FD5BC0A1A1F75CB0DE3798FB45827E02DB1689EA0A99DB56C36CDEFB20",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 2097152,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "ea1",
+                  "PreviousTxnID": "47F35FC9B5D65C51A4474811AA177BD907FCF2FA1ACFD6C893F2C589DFA6C0F8",
+                  "PreviousTxnLgrSeq": 90150378
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F7649E56EB86403211BE414801DA87DD2B143701E72EE2553D87DD748E698848",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1103773976379842e-26"
+                  },
+                  "Flags": 2228224
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 66,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rDYkhQBXwbJqEMj39QYGmZQPQThR44HT",
+        "Amount": "87",
+        "Destination": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+        "DestinationTag": 1111135,
+        "Fee": "10",
+        "Sequence": 89121234,
+        "SigningPubKey": "EDED81D06CC744B3916C146372204DC27F02720559A8DB3338BB36112E0BC0AF95",
+        "TransactionType": "Payment",
+        "TxnSignature": "B6A45EA2C738F5CF1BA258D75D814A62C58D5DD4061B51BEB776EC18135B5E77E00036C772A791211991649AF3B5A18F5B8B144C5EAB109C8B9062A6BF809601",
+        "hash": "F89307CD760EBBCCD6C64DA8A417EF7D693E6413B743248CB1846043DC33A723",
+        "DeliverMax": "87",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rDYkhQBXwbJqEMj39QYGmZQPQThR44HT",
+                  "Balance": "52391029",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89121235
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "04DB180343A980921C743469BD0BA3ADA7D0BED2F75D1E834CA5EFBEDDCBE47E",
+                "PreviousFields": {
+                  "Balance": "52391126",
+                  "Sequence": 89121234
+                },
+                "PreviousTxnID": "E9CEC850BBDDDF5600CD8C514A717824A83CD44F4382EEFFC6D4BBC11853FD88",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+                  "Balance": "37855655",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89531841
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2A9DF02FF78FCCE946B77372B25D9C6F875895CEE6AAC1D37A7158BAA3E9BBDC",
+                "PreviousFields": {
+                  "Balance": "37855568"
+                },
+                "PreviousTxnID": "B28ACE08126DD2FDEC8F69E7DD64AE615128C0E5BFA7AEACDF52CD9F64D571FB",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            }
+          ],
+          "TransactionIndex": 1,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "87"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90150379,
+        "Sequence": 12933003,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "NET",
+          "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+          "value": "1513790560215018e-27"
+        },
+        "TakerPays": {
+          "currency": "262",
+          "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+          "value": "1007590788019748e-30"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "58248178618191DF507E8941643CD63A5B106A499F081D7E19BC1B080AF4A78C37B91B55DFC5617C0EDD4F1D809BF5721CA77153EE7BABEB8C32B9E73330C30B",
+        "hash": "FCCE9775345CD7E093A062444636EC54095D6533B212E3D5F16EF1590D92427C",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                  "RootIndex": "1B6E7CB1A25AE631B406C9723A9EBB194D5A8958A7F4DED8B0E230FB469F71A1"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1B6E7CB1A25AE631B406C9723A9EBB194D5A8958A7F4DED8B0E230FB469F71A1"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2E3957320EEE887014DF3E881746846EB526FC454748916C461BAADC6DE81B2C",
+                "PreviousTxnID": "99D252B646D3300ED79DC418AF9C73828641CDE03AE9B012A85ED5228B690FE8",
+                "PreviousTxnLgrSeq": 90150364
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                  "RootIndex": "372150E433D95E6EDBBA7BFF24ADDE0E649E23282D9BE56862C4C0BE242350B5"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "604501E686FB1F4A23F3F60BF4949100D5F80883730A043BE5D537288092A4BE"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1.226438319439676"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rGN8wfCoi7pJ2Eei9uA8ZcChHRJfLuzanu",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "944A055528510CEB85DDFD5B6D67EDF8DAF23B368766F37C698802502C7BBDA6",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1.226438319438625"
+                  }
+                },
+                "PreviousTxnID": "5E4BA18476053A38116B6CCB9C893E61CE537B02C9D03F08BB0103509F080A89",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.8163321606177207"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rGN8wfCoi7pJ2Eei9uA8ZcChHRJfLuzanu",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "9473E7A7DF990F7AD640AB094F152F31D3DF0C82F144214BC7394543B178DE73",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.8163321606184202"
+                  }
+                },
+                "PreviousTxnID": "5E4BA18476053A38116B6CCB9C893E61CE537B02C9D03F08BB0103509F080A89",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "968094565752D3F13D0F072C005830CC4C81B87EBF471026B2B583BE4F008F9E",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "6995000000000000e-28"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1048576,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c",
+                  "PreviousTxnID": "A8795BE7B734E569323E704CD10D18B8F05C481922F32EF1178014A707DBD054",
+                  "PreviousTxnLgrSeq": 90150378
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "ACCFDC0A49FC44784C23419CC58BD96F38A0129D6AEF387271DEDB2E737B09D2",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1050900000000000e-27"
+                  },
+                  "Flags": 1114112
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "FCCE9775345CD7E093A062444636EC54095D6533B212E3D5F16EF1590D92427C",
+                  "Balance": "1187998098",
+                  "Flags": 0,
+                  "OwnerCount": 52,
+                  "Sequence": 12933004
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "A8795BE7B734E569323E704CD10D18B8F05C481922F32EF1178014A707DBD054",
+                  "Balance": "1187998108",
+                  "Sequence": 12933003
+                },
+                "PreviousTxnID": "A8795BE7B734E569323E704CD10D18B8F05C481922F32EF1178014A707DBD054",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "ED8EA8C2531782F3455F9B5E9FF32E99CAE15DDFB3B10A0661BE8E17E2C15151",
+                "PreviousTxnID": "A8795BE7B734E569323E704CD10D18B8F05C481922F32EF1178014A707DBD054",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            }
+          ],
+          "TransactionIndex": 64,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Amount": "314",
+        "Destination": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 90150379,
+        "SendMax": {
+          "currency": "7853504543544152000000000000000000000000",
+          "issuer": "rh5jzTCdMRCVjQ7LT6zucjezC47KATkuvv",
+          "value": "0.02151759862364312"
+        },
+        "Sequence": 12932999,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TransactionType": "Payment",
+        "TxnSignature": "CB0C2046B06D15F2509B6E3AD77A76300A25629F11313007FB6A167EC41C8CEE0C21F9BBD14FBD8D43AA51F6F904FF49F357E6EC00A0BAB1C645F57574E94901",
+        "hash": "FCD8CFD0902448D8C470725C68511E85BE2ED8EC4FDDC5F172BE2D49456E7895",
+        "DeliverMax": "314",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rN7TeoTfALuuUqKTav1UKvTB1mmyC4XQaf",
+                  "Balance": "260802525",
+                  "Flags": 0,
+                  "OwnerCount": 20,
+                  "Sequence": 74681914
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "9AA5162E44BA7F67D5F2AC2B68CAA7984B90142E04C9A4C51B07234CF9D8080D",
+                "PreviousFields": {
+                  "Balance": "260802706"
+                },
+                "PreviousTxnID": "51097F12ACDBE43CC2F14359FD860948AFE9A84AA235AACC9CC9277870751607",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "40a",
+                  "Owner": "rh5jzTCdMRCVjQ7LT6zucjezC47KATkuvv",
+                  "RootIndex": "2BD70BEEC95186EDCE5F825DECA520D2521F1536E753B1F8186466B69F265963"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "A38DAA262DA6F3D89E5B9D27D3468F9A7154F2C7687D460BBA16CF7D66F9A1A0"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "FCD8CFD0902448D8C470725C68511E85BE2ED8EC4FDDC5F172BE2D49456E7895",
+                  "Balance": "1187998139",
+                  "Flags": 0,
+                  "OwnerCount": 51,
+                  "Sequence": 12933000
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "D19538656EA7D324A014960BF219802FFD48859A4BEB68254CA26BEA5186584D",
+                  "Balance": "1187997968",
+                  "OwnerCount": 52,
+                  "Sequence": 12932999
+                },
+                "PreviousTxnID": "D19538656EA7D324A014960BF219802FFD48859A4BEB68254CA26BEA5186584D",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1295.540389319822"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rN7TeoTfALuuUqKTav1UKvTB1mmyC4XQaf",
+                    "value": "88888647"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rh5jzTCdMRCVjQ7LT6zucjezC47KATkuvv",
+                    "value": "0"
+                  },
+                  "LowNode": "373"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "C0E94ED25CAE1C1EB7E7E58A9243716DFCD17A8010B28B055C2E25C42AEB6ABF",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1295.527975208382"
+                  }
+                },
+                "PreviousTxnID": "51097F12ACDBE43CC2F14359FD860948AFE9A84AA235AACC9CC9277870751607",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "CBF1F1A0ECB93ECD4D8E7BEE7C38428397927FA7C29C6DBAC6B2CB9A650F3194",
+                "PreviousTxnID": "D19538656EA7D324A014960BF219802FFD48859A4BEB68254CA26BEA5186584D",
+                "PreviousTxnLgrSeq": 90150378
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rN7TeoTfALuuUqKTav1UKvTB1mmyC4XQaf",
+                  "BookDirectory": "187F38E9CA7BFE343636752BE1E7CAB1C198F6887F73565450186062E769FC40",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "1",
+                  "Sequence": 74681913,
+                  "TakerGets": "9996640",
+                  "TakerPays": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rh5jzTCdMRCVjQ7LT6zucjezC47KATkuvv",
+                    "value": "685.9073433561712"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "E46E69CCD80FA8072177D2C4382286EACC92398B81FEF54F44E18A839496A853",
+                "PreviousFields": {
+                  "TakerGets": "9996821",
+                  "TakerPays": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rh5jzTCdMRCVjQ7LT6zucjezC47KATkuvv",
+                    "value": "685.919757467611"
+                  }
+                },
+                "PreviousTxnID": "51097F12ACDBE43CC2F14359FD860948AFE9A84AA235AACC9CC9277870751607",
+                "PreviousTxnLgrSeq": 90150377
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 2097152,
+                  "HighLimit": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rh5jzTCdMRCVjQ7LT6zucjezC47KATkuvv",
+                    "value": "0"
+                  },
+                  "LowNode": "40b",
+                  "PreviousTxnID": "D19538656EA7D324A014960BF219802FFD48859A4BEB68254CA26BEA5186584D",
+                  "PreviousTxnLgrSeq": 90150378
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F11C48DF65500A5D3FA812A1EF7ABA87124713D537D048889DC0BDDCCC58722C",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "7853504543544152000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.01241411143983539"
+                  },
+                  "Flags": 2228224
+                }
+              }
+            }
+          ],
+          "DeliveredAmount": "181",
+          "TransactionIndex": 60,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "181"
+        }
+      }
+    ]
+  }
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-90156059.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/ledger-result-90156059.json
@@ -1,0 +1,9198 @@
+{
+  "ledger_hash": "1ABD49DE9EDBB24897A2031336EEBA7472E92A49E08912039825E9FC9E0DEA85",
+  "ledger_index": 90156059,
+  "validated": true,
+  "ledger": {
+    "account_hash": "8191DF7AF3769F9B69519722991BFE902454F963E18E01BEDD179296D932D53B",
+    "close_flags": 0,
+    "close_time": 777360540,
+    "close_time_human": "2024-Aug-19 05:29:00.000000000 UTC",
+    "close_time_resolution": 10,
+    "close_time_iso": "2024-08-19T05:29:00Z",
+    "ledger_hash": "1ABD49DE9EDBB24897A2031336EEBA7472E92A49E08912039825E9FC9E0DEA85",
+    "parent_close_time": 777360532,
+    "parent_hash": "ABD0A6E562AB3DB5DB06C364CAE7A24C36BAA51BACC1A8C32C8BEA4489290108",
+    "total_coins": "99987293880571125",
+    "transaction_hash": "6AA2DE12312E584CC7212EAED0019B9A94CBCDEBA784B9B1D003B01FF684382A",
+    "ledger_index": "90156059",
+    "closed": true,
+    "transactions": [
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 7423366,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "OVO",
+          "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+          "value": "0.0001250255099493724"
+        },
+        "TakerPays": {
+          "currency": "5452535259000000000000000000000000000000",
+          "issuer": "rLBnhMjV6ifEHYeV4gaS6jPKerZhQddFxW",
+          "value": "0.0000000004186265522595381"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "18944B0D854D12892152CAE3507A334109146CCD8F648139F4B9FD15ABC761D4F4BD6278835FE7A9CBEA2B724FDA3A1448968DEE025B50E4676760EA761D3003",
+        "hash": "001D94CAD812C393206DA188B6785055BB060E1D976A100F5B8890FAF3794F28",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "22069.32776090293"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rLBnhMjV6ifEHYeV4gaS6jPKerZhQddFxW",
+                    "value": "0"
+                  },
+                  "HighNode": "156d",
+                  "LowLimit": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rairUgekyesGP6sBQc6kSb26NqJq5ypg3v",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "20D4C4BDAA7601AB3772775C563E1A4808EDDAD4FF8BFCFA691821FC14DE77BF",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "22069.32776132145"
+                  }
+                },
+                "PreviousTxnID": "60AC7BA6A20CA71E13BDAAD1D08F0E934465615E3BB4C57291B4557F5ABEE6DE",
+                "PreviousTxnLgrSeq": 90156055
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "6591133.737129236"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "OVO",
+                    "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+                    "value": "0"
+                  },
+                  "HighNode": "335",
+                  "LowLimit": {
+                    "currency": "OVO",
+                    "issuer": "rairUgekyesGP6sBQc6kSb26NqJq5ypg3v",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "8B3ECAF987B55A2E0CA4F53930F186915444E055F8F7E376A8BACD3FF1242E21",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "6591133.73700421"
+                  }
+                },
+                "PreviousTxnID": "60AC7BA6A20CA71E13BDAAD1D08F0E934465615E3BB4C57291B4557F5ABEE6DE",
+                "PreviousTxnLgrSeq": 90156055
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "565808.9581283492"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "OVO",
+                    "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+                    "value": "0"
+                  },
+                  "HighNode": "33e",
+                  "LowLimit": {
+                    "currency": "OVO",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "CF7D03A277BB38033EE1039387650B3720EB33056781C1BE75B19A4FC6B999AD",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "565808.9582533747"
+                  }
+                },
+                "PreviousTxnID": "E173F5C1EFBAA334615006D4CF8D03B461DC7EA9866D33F9592F075996A28AD5",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "001D94CAD812C393206DA188B6785055BB060E1D976A100F5B8890FAF3794F28",
+                  "Balance": "420152608",
+                  "Flags": 0,
+                  "OwnerCount": 143,
+                  "Sequence": 7423367
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "E173F5C1EFBAA334615006D4CF8D03B461DC7EA9866D33F9592F075996A28AD5",
+                  "Balance": "420152618",
+                  "Sequence": 7423366
+                },
+                "PreviousTxnID": "E173F5C1EFBAA334615006D4CF8D03B461DC7EA9866D33F9592F075996A28AD5",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.007207489439770223"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rLBnhMjV6ifEHYeV4gaS6jPKerZhQddFxW",
+                    "value": "0"
+                  },
+                  "HighNode": "1572",
+                  "LowLimit": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "0"
+                  },
+                  "LowNode": "10"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F2394E748205610732195F7C7E3193D6A249F303DD2A92D67DE66A6F2E707125",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.007207070917034555"
+                  }
+                },
+                "PreviousTxnID": "60AC7BA6A20CA71E13BDAAD1D08F0E934465615E3BB4C57291B4557F5ABEE6DE",
+                "PreviousTxnLgrSeq": 90156055
+              }
+            }
+          ],
+          "TransactionIndex": 8,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 7423362,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "NET",
+          "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+          "value": "0.000002416067116629678"
+        },
+        "TakerPays": {
+          "currency": "262",
+          "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+          "value": "0.00000000156707451794543"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3F478613261AC5FDF105CC160DC7F470C3CF916406001F9763FFA291A8B320C7C2E00E654C657F9F51F69EC778B887E6BDF2C9C398046809AC91A60E2FA28608",
+        "hash": "017F4531E83EE1B66AE7B85818B54E5767097B632521C0BE13C918531FDD2C3E",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "9.363240059079277"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "52DB81328A8EFF7305F672D5E8D9C6129B933D4CBC78C440D6EC6862C1B01883",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "9.363238492004759"
+                  }
+                },
+                "PreviousTxnID": "7089A1EA10B8EAD60785967EFB1F13E57268BE5E1BF51DAF71ACD3B8D774F05F",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000000000192289375122"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "7E7F2D4E27869445BE12682DFCB1420364E2EB5355BD8B4EA40A6B6DC236D2B1",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000024162594060048"
+                  }
+                },
+                "PreviousTxnID": "3B58AD64D77C27707F6D6081E160C118E39D1278D7CA4CEA90C0897F93E7DBA1",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1.24241419338448"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rGN8wfCoi7pJ2Eei9uA8ZcChHRJfLuzanu",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "944A055528510CEB85DDFD5B6D67EDF8DAF23B368766F37C698802502C7BBDA6",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1.242411777317363"
+                  }
+                },
+                "PreviousTxnID": "1DCD3AE1C3BF28BB1F467D70F25CB97240CB4EA31404BE4CDDB6F19633BFE176",
+                "PreviousTxnLgrSeq": 90156056
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.8058351623022142"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rGN8wfCoi7pJ2Eei9uA8ZcChHRJfLuzanu",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "9473E7A7DF990F7AD640AB094F152F31D3DF0C82F144214BC7394543B178DE73",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.8058367293767324"
+                  }
+                },
+                "PreviousTxnID": "1DCD3AE1C3BF28BB1F467D70F25CB97240CB4EA31404BE4CDDB6F19633BFE176",
+                "PreviousTxnLgrSeq": 90156056
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "017F4531E83EE1B66AE7B85818B54E5767097B632521C0BE13C918531FDD2C3E",
+                  "Balance": "420152648",
+                  "Flags": 0,
+                  "OwnerCount": 143,
+                  "Sequence": 7423363
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "3B58AD64D77C27707F6D6081E160C118E39D1278D7CA4CEA90C0897F93E7DBA1",
+                  "Balance": "420152658",
+                  "Sequence": 7423362
+                },
+                "PreviousTxnID": "3B58AD64D77C27707F6D6081E160C118E39D1278D7CA4CEA90C0897F93E7DBA1",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 4,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Amount": "854",
+        "Destination": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 90156060,
+        "SendMax": {
+          "currency": "434F524500000000000000000000000000000000",
+          "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+          "value": "0.007853224894738053"
+        },
+        "Sequence": 12994735,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TransactionType": "Payment",
+        "TxnSignature": "508C6749BF159A7B2CDBD257A65902637759B59E8586AE8E4BC3AC98D364CF2C3D8653C8CB334086BA6D862AAD927F7D6E05DCDB8C51D024F1C374646549E40D",
+        "hash": "021EA6C5BE9AE7209B23BF4F39BB738FFA45EB4B1CD6EAFFCFFB471FEF11AC10",
+        "DeliverMax": "854",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMffDj93JAQvogvJ2k8196DeAt5HcpdDQC",
+                  "Balance": "283506160",
+                  "Flags": 0,
+                  "OwnerCount": 24,
+                  "Sequence": 76158366
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "075E8FCFD124B5C1BFDCD999226F7D3D190ED74A71474A28F4D704022AC83FBC",
+                "PreviousFields": {
+                  "Balance": "283506654"
+                },
+                "PreviousTxnID": "09A3924FA3F679EB55914AFC2BDD944BE8B3C443DB1D2C38EF8C798A9FBE5863",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1E1ADBD847116F2C0DF91CCB7165719E2285397499705C85414A745A3AC80F43",
+                "PreviousTxnID": "8C165A484298A7B9696971C77522401F0BD094377E178D9D29A5F63A1F3A64C9",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-53.03798729611395"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rMffDj93JAQvogvJ2k8196DeAt5HcpdDQC",
+                    "value": "1000000"
+                  },
+                  "HighNode": "a45",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "ad0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "431A90E2C48B0F2F2B7A95E55E41F54CEBBA1A1C3BDFE48CE45091350568127E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-53.03344560153352"
+                  }
+                },
+                "PreviousTxnID": "09A3924FA3F679EB55914AFC2BDD944BE8B3C443DB1D2C38EF8C798A9FBE5863",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMffDj93JAQvogvJ2k8196DeAt5HcpdDQC",
+                  "BookDirectory": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F4F20ACEA4283CE40",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "a45",
+                  "Sequence": 76158365,
+                  "TakerGets": "9996239",
+                  "TakerPays": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "91.93866507073247"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "4EEB87528A6B72703D4DB70BF0FFC79E6AC4DA40DB047DAD8DDF12BD8E95460F",
+                "PreviousFields": {
+                  "TakerGets": "9996733",
+                  "TakerPays": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "91.9432067653129"
+                  }
+                },
+                "PreviousTxnID": "09A3924FA3F679EB55914AFC2BDD944BE8B3C443DB1D2C38EF8C798A9FBE5863",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "ea0",
+                  "Owner": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                  "RootIndex": "5DD87298A566F5805C113F1E887578A4AF0123F117D08E74F3A0698F1AD100ED"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B2FBE6A2AD61B0BBC3C6EECCAD32590841ADA8E5AE4811728B29F85AA95A747F"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "021EA6C5BE9AE7209B23BF4F39BB738FFA45EB4B1CD6EAFFCFFB471FEF11AC10",
+                  "Balance": "1467511993",
+                  "Flags": 0,
+                  "OwnerCount": 49,
+                  "Sequence": 12994736
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "8C165A484298A7B9696971C77522401F0BD094377E178D9D29A5F63A1F3A64C9",
+                  "Balance": "1467511509",
+                  "OwnerCount": 50,
+                  "Sequence": 12994735
+                },
+                "PreviousTxnID": "8C165A484298A7B9696971C77522401F0BD094377E178D9D29A5F63A1F3A64C9",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 2097152,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "ea1",
+                  "PreviousTxnID": "8C165A484298A7B9696971C77522401F0BD094377E178D9D29A5F63A1F3A64C9",
+                  "PreviousTxnLgrSeq": 90156059
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F7649E56EB86403211BE414801DA87DD2B143701E72EE2553D87DD748E698848",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0045416945804255"
+                  },
+                  "Flags": 2228224
+                }
+              }
+            }
+          ],
+          "DeliveredAmount": "494",
+          "TransactionIndex": 23,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "494"
+        }
+      },
+      {
+        "Account": "rpS5T1YgEaxPLSmN4Po6Ufhwa46ZcuLWMj",
+        "Amount": "45",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 5000138,
+        "Fee": "10",
+        "Sequence": 89647874,
+        "SigningPubKey": "EDDA62B07E16F4D5F4FF791331A127EAF0F2801B0F188705E1084E2E484FF164A2",
+        "TransactionType": "Payment",
+        "TxnSignature": "BB9CD21D95E0AD9817ABD8A1A121FEFBE067012A12B268753C21037BDF57603BED0BBEB06AF2B7354831ED098663EA2207C5E4F70773E9DE46B3951F97FBF806",
+        "hash": "03823BE4331FED41C2F8F818ADCC85CD42CD4BD71B61A23427F92981E891CAA1",
+        "DeliverMax": "45",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "188398739",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "188398694"
+                },
+                "PreviousTxnID": "47BE22CB2CD3AE79929B04328D583EEA1D0E5A7437D868BB535E67F477F6C600",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpS5T1YgEaxPLSmN4Po6Ufhwa46ZcuLWMj",
+                  "Balance": "51814194",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89647875
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A635C954A25D04700BDE078F690258A967EBCF0498FBDAC646DDDAEFA1AF6FD8",
+                "PreviousFields": {
+                  "Balance": "51814249",
+                  "Sequence": 89647874
+                },
+                "PreviousTxnID": "EF8B402670234627D258D277628C3E262827D043F267CE4183701D933A2AC4E9",
+                "PreviousTxnLgrSeq": 90156052
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "45"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994746,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "NET",
+          "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+          "value": "1520019986234183e-27"
+        },
+        "TakerPays": {
+          "currency": "262",
+          "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+          "value": "9858933846664533e-31"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "214F8A363C8B089CEB87CB7F421333D3B77095E6AA9CD106F3B1D53531273476BCC41F33FD21CB142EC42AA161B122D706770C0F42033347B10DA11A65B9620D",
+        "hash": "06897F546B9394C4EC95A010FCACC50B03CA2D85A06BAD86D19F5B19D5BDB3B4",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                  "RootIndex": "1B6E7CB1A25AE631B406C9723A9EBB194D5A8958A7F4DED8B0E230FB469F71A1"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1B6E7CB1A25AE631B406C9723A9EBB194D5A8958A7F4DED8B0E230FB469F71A1"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1.242414193385535"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rGN8wfCoi7pJ2Eei9uA8ZcChHRJfLuzanu",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "944A055528510CEB85DDFD5B6D67EDF8DAF23B368766F37C698802502C7BBDA6",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1.24241419338448"
+                  }
+                },
+                "PreviousTxnID": "017F4531E83EE1B66AE7B85818B54E5767097B632521C0BE13C918531FDD2C3E",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.8058351623015299"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rGN8wfCoi7pJ2Eei9uA8ZcChHRJfLuzanu",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "9473E7A7DF990F7AD640AB094F152F31D3DF0C82F144214BC7394543B178DE73",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.8058351623022142"
+                  }
+                },
+                "PreviousTxnID": "017F4531E83EE1B66AE7B85818B54E5767097B632521C0BE13C918531FDD2C3E",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000005835748364402258"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "968094565752D3F13D0F072C005830CC4C81B87EBF471026B2B583BE4F008F9E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000005835741521402258"
+                  }
+                },
+                "PreviousTxnID": "407136A4552F108C0909F0573AD133C7851494E11B85CF95BE2E9FAC576055F7",
+                "PreviousTxnLgrSeq": 90156054
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1048576,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c",
+                  "PreviousTxnID": "6852BF4B3607C58349DE80B518BD7DCB90D437253B583D68DD1F52A8AA15B806",
+                  "PreviousTxnLgrSeq": 90156059
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "ACCFDC0A49FC44784C23419CC58BD96F38A0129D6AEF387271DEDB2E737B09D2",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1055400000000000e-27"
+                  },
+                  "Flags": 1114112
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "06897F546B9394C4EC95A010FCACC50B03CA2D85A06BAD86D19F5B19D5BDB3B4",
+                  "Balance": "1467511882",
+                  "Flags": 0,
+                  "OwnerCount": 49,
+                  "Sequence": 12994747
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "6852BF4B3607C58349DE80B518BD7DCB90D437253B583D68DD1F52A8AA15B806",
+                  "Balance": "1467511892",
+                  "OwnerCount": 50,
+                  "Sequence": 12994746
+                },
+                "PreviousTxnID": "6852BF4B3607C58349DE80B518BD7DCB90D437253B583D68DD1F52A8AA15B806",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "ED8EA8C2531782F3455F9B5E9FF32E99CAE15DDFB3B10A0661BE8E17E2C15151",
+                "PreviousTxnID": "6852BF4B3607C58349DE80B518BD7DCB90D437253B583D68DD1F52A8AA15B806",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 34,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 7423359,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "434F524500000000000000000000000000000000",
+          "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+          "value": "0.00002469380201067369"
+        },
+        "TakerPays": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "0.0000000002114225309744177"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "F59A40E9BDD40BCE9C69AEC840C85FDF65609892BBB828E1575E6DACC3DFF1B996448FC93F68DB7B30B5D30CDF3A5F4AE5DB53C3DEB5B8F8097B9387029BB507",
+        "hash": "09A3924FA3F679EB55914AFC2BDD944BE8B3C443DB1D2C38EF8C798A9FBE5863",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMffDj93JAQvogvJ2k8196DeAt5HcpdDQC",
+                  "Balance": "283506654",
+                  "Flags": 0,
+                  "OwnerCount": 24,
+                  "Sequence": 76158366
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "075E8FCFD124B5C1BFDCD999226F7D3D190ED74A71474A28F4D704022AC83FBC",
+                "PreviousFields": {
+                  "Balance": "283506657"
+                },
+                "PreviousTxnID": "887B2038A23B889E51EB64891F3E182A2A0EA89DCA8EAE6F44FAE6AA5A85C3B1",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "14.46082580321028"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "dc",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rnv4kx1H76k43HYKZa3wrKhVnWNvA4kQpm",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "318E00F1D5FCAAD58867D5AA41CF32A319597C463F8DB9CBB4D0851A3258AD50",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "14.46082603940326"
+                  }
+                },
+                "PreviousTxnID": "887B2038A23B889E51EB64891F3E182A2A0EA89DCA8EAE6F44FAE6AA5A85C3B1",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-53.03344560153352"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rMffDj93JAQvogvJ2k8196DeAt5HcpdDQC",
+                    "value": "1000000"
+                  },
+                  "HighNode": "a45",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "ad0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "431A90E2C48B0F2F2B7A95E55E41F54CEBBA1A1C3BDFE48CE45091350568127E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-53.03342090773151"
+                  }
+                },
+                "PreviousTxnID": "887B2038A23B889E51EB64891F3E182A2A0EA89DCA8EAE6F44FAE6AA5A85C3B1",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMffDj93JAQvogvJ2k8196DeAt5HcpdDQC",
+                  "BookDirectory": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F4F20ACEA4283CE40",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "a45",
+                  "Sequence": 76158365,
+                  "TakerGets": "9996733",
+                  "TakerPays": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "91.9432067653129"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "4EEB87528A6B72703D4DB70BF0FFC79E6AC4DA40DB047DAD8DDF12BD8E95460F",
+                "PreviousFields": {
+                  "TakerGets": "9996736",
+                  "TakerPays": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "91.94323145911491"
+                  }
+                },
+                "PreviousTxnID": "887B2038A23B889E51EB64891F3E182A2A0EA89DCA8EAE6F44FAE6AA5A85C3B1",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.376268189314441"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "9"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "68062CBD2811E4D5FB502D7C86E4BB04DA46A2AAE9BE2B400045A57E3B5DBA8B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.376267953121463"
+                  }
+                },
+                "PreviousTxnID": "81A435E00151AD03C4E8C935EF8407E84E4BD17FABE05A4441CF0D29DF8AEB6B",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "B416780D1A45F7BA8665AA6967CD1F346087B495EAC1B0D4FD8AC421444D04A5",
+                  "Account": "rnv4kx1H76k43HYKZa3wrKhVnWNvA4kQpm",
+                  "Balance": "183607771",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 86806716
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A64DC21AF513694977C5F654D42828F1D178E9DBBA85B270DCB95378669834F7",
+                "PreviousFields": {
+                  "Balance": "183607768"
+                },
+                "PreviousTxnID": "887B2038A23B889E51EB64891F3E182A2A0EA89DCA8EAE6F44FAE6AA5A85C3B1",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-197.2967082652185"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "HighNode": "8",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "e9a"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B5AE9624630077C320F4F84D35562B165941C6E7D64BA7722A9CCDF0595F2F7E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-197.2967329590205"
+                  }
+                },
+                "PreviousTxnID": "7089A1EA10B8EAD60785967EFB1F13E57268BE5E1BF51DAF71ACD3B8D774F05F",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "09A3924FA3F679EB55914AFC2BDD944BE8B3C443DB1D2C38EF8C798A9FBE5863",
+                  "Balance": "420152678",
+                  "Flags": 0,
+                  "OwnerCount": 143,
+                  "Sequence": 7423360
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "81A435E00151AD03C4E8C935EF8407E84E4BD17FABE05A4441CF0D29DF8AEB6B",
+                  "Balance": "420152688",
+                  "Sequence": 7423359
+                },
+                "PreviousTxnID": "81A435E00151AD03C4E8C935EF8407E84E4BD17FABE05A4441CF0D29DF8AEB6B",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            }
+          ],
+          "TransactionIndex": 1,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 90156061,
+        "OfferSequence": 148592491,
+        "Sequence": 148592501,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": "33794000000",
+        "TakerPays": {
+          "currency": "EUR",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "18208.54514"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100B1E9BA529D67CCD8BA587BA4545C0DA5166605AFFD7ED56F21312ACF523E90C4022078F719C11F19346C8D47D7BB2CC2C09D3D2184169DE927864454D9303D11B7AC",
+        "hash": "0B250DC9DED1606A3DA8A4CA6BE1101A6902634C4CA1351D2AC57FB38822CA8D",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "33894335281",
+                  "Flags": 0,
+                  "OwnerCount": 15,
+                  "Sequence": 148592502
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "33894335301",
+                  "Sequence": 148592501
+                },
+                "PreviousTxnID": "4DC065FB5FB200E290E18B4F2613BAD6CA3EAD8204E38860ACB78B1F3239F3D9",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624E1324A15B717800",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "2D6243A7993C245591A24BF871F14B617C756131E283B75F8EC0720B23D73863",
+                  "PreviousTxnLgrSeq": 90156057,
+                  "Sequence": 148592491,
+                  "TakerGets": "33794000000",
+                  "TakerPays": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "18209.22102"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "36A02DAC540A977A2D47E4E859AFDDC744504E0963B4236699CEF44AABBB9323"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "4193635FFF058E0D29F26797D99E541579EE62E153FA3EC317A438C559A8D638",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624E132472CA83A800",
+                  "Sequence": 148592501,
+                  "TakerGets": "33794000000",
+                  "TakerPays": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "18208.54514"
+                  }
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624E132472CA83A800",
+                "NewFields": {
+                  "ExchangeRate": "4e132472ca83a800",
+                  "RootIndex": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624E132472CA83A800",
+                  "TakerPaysCurrency": "0000000000000000000000004555520000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4e1324a15b717800",
+                  "Flags": 0,
+                  "RootIndex": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624E1324A15B717800",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000004555520000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624E1324A15B717800"
+              }
+            }
+          ],
+          "TransactionIndex": 49,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 7423368,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "58464C4F4B490000000000000000000000000000",
+          "issuer": "rUtXeAXonpFpgKubAa7LxcLd7NFep92T1t",
+          "value": "27.44657183246495"
+        },
+        "TakerPays": {
+          "currency": "5852646F67650000000000000000000000000000",
+          "issuer": "rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA",
+          "value": "0.00000005980159239652894"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "04D5533B268152FA60DF29026AF53FA325568279E938827B05D43F666BEE930FB0790264E601400EAF0FF88590F472DA1DA2AAFEA5E6506679760171DC8D580A",
+        "hash": "0B96B87375B27786DDD774523057F6E1401B7B9B1D47C67DA09937D466A51FD1",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "17393854.46646543"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rUtXeAXonpFpgKubAa7LxcLd7NFep92T1t",
+                    "value": "0"
+                  },
+                  "HighNode": "983",
+                  "LowLimit": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "0"
+                  },
+                  "LowNode": "a"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "065135AE781A0ADA10F03EFC0CC720C9256FF3C3165FC3892365F5281770D40D",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "17393881.91303726"
+                  }
+                },
+                "PreviousTxnID": "BFB3F0E4D55727984A8ADFE3CCC2A334790094F6AA43643B19BB90F7A10CFEAB",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-7056939.039990143"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rHpYmgLg9AczoBEmRDWg1fNodoFzFNGyn9",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rUtXeAXonpFpgKubAa7LxcLd7NFep92T1t",
+                    "value": "0"
+                  },
+                  "LowNode": "981"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "418410059709A9057C902149162116CC96A540A28A2AD0C8E3DAFF5C749EC8F5",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-7056911.593418311"
+                  }
+                },
+                "PreviousTxnID": "922D9C29442A4BDB5ADB59A3A8A6622326CB02695963A8C2C50D1853DC9E7BED",
+                "PreviousTxnLgrSeq": 90156047
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "15.38354831710346"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA",
+                    "value": "0"
+                  },
+                  "HighNode": "9e8",
+                  "LowLimit": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rHpYmgLg9AczoBEmRDWg1fNodoFzFNGyn9",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "472F648D78D1472A3A65380834D1E05624C755CF17AA49F06C3D05F998A16281",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "15.38360810398908"
+                  }
+                },
+                "PreviousTxnID": "922D9C29442A4BDB5ADB59A3A8A6622326CB02695963A8C2C50D1853DC9E7BED",
+                "PreviousTxnLgrSeq": 90156047
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "353292.1536476749"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA",
+                    "value": "0"
+                  },
+                  "HighNode": "9f0",
+                  "LowLimit": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "0"
+                  },
+                  "LowNode": "c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "9213259D89AA378C0C89F4BA32CD40186B517B11960B2FDB9B654422562ED630",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "353292.153587888"
+                  }
+                },
+                "PreviousTxnID": "81A435E00151AD03C4E8C935EF8407E84E4BD17FABE05A4441CF0D29DF8AEB6B",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "0B96B87375B27786DDD774523057F6E1401B7B9B1D47C67DA09937D466A51FD1",
+                  "Balance": "420152588",
+                  "Flags": 0,
+                  "OwnerCount": 143,
+                  "Sequence": 7423369
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "BFB3F0E4D55727984A8ADFE3CCC2A334790094F6AA43643B19BB90F7A10CFEAB",
+                  "Balance": "420152598",
+                  "Sequence": 7423368
+                },
+                "PreviousTxnID": "BFB3F0E4D55727984A8ADFE3CCC2A334790094F6AA43643B19BB90F7A10CFEAB",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 10,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Amount": "2",
+        "Destination": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 90156060,
+        "SendMax": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.000000851208691667739"
+        },
+        "Sequence": 12994742,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TransactionType": "Payment",
+        "TxnSignature": "B9B2CB13E9FE44AC1CC80200977CA1E8451AA0505CDA6DDA5CD61B718D9F2AAD07A87EA480577FC8BE67B3315E446C4256AA4F4CA8141019DD0E875442124304",
+        "hash": "0FD1E5BD2ED0C3B468549102C2B80D98B7503FF2C70F4FF9ABD89189BE58716D",
+        "DeliverMax": "2",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-245429.8538971388"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rHUpaqUPbwzKZdzQ8ZQCme18FrgW9pB4am",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "bd7"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "832F2523220A304ECEB7B2AE3E0D30829ACBCA0A31722FA8D952CC5BE7D9478B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-245429.8538964757"
+                  }
+                },
+                "PreviousTxnID": "C70AC215D79B154B19FC75DC25B4EECB4B7D5A24E7F62B61A809DDD1279CD27A",
+                "PreviousTxnLgrSeq": 90156019
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "bff",
+                  "Owner": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                  "RootIndex": "7E1247F78EFC74FA9C0AE39F37AF433966615EB9B757D8397C068C2849A8F4A5"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "96C1FD71BCBEC8659FE7F43C7ACC7F72C3E40F9A33D7336C34C55D083AFC1610"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "EF95AD04AF97DF0DD76C5C624F93EF6F5479CDF8F30FAE612F1D434B5D6A914B",
+                  "Account": "rHUpaqUPbwzKZdzQ8ZQCme18FrgW9pB4am",
+                  "Balance": "436392565770",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 86795414
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B21B05E69AFB3F98B8D6F8066A69C4B189F3D804D8BE896AE11E60189AAFAD51",
+                "PreviousFields": {
+                  "Balance": "436392565771"
+                },
+                "PreviousTxnID": "C70AC215D79B154B19FC75DC25B4EECB4B7D5A24E7F62B61A809DDD1279CD27A",
+                "PreviousTxnLgrSeq": 90156019
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B7D526FDDF9E3B3F95C3DC97C353065B0482302500BBB8051A5C090B596C6133",
+                "PreviousTxnID": "211A97EFC1E1E92211FC8C0AED6AF83C40DD2D3D34465FA30E42856510F41896",
+                "PreviousTxnLgrSeq": 90156036
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "0FD1E5BD2ED0C3B468549102C2B80D98B7503FF2C70F4FF9ABD89189BE58716D",
+                  "Balance": "1467511923",
+                  "Flags": 0,
+                  "OwnerCount": 49,
+                  "Sequence": 12994743
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "98E0F956171CEEBA795DC91E59163B77952A65DE16956F926A68C83C5569C4DF",
+                  "Balance": "1467511932",
+                  "OwnerCount": 50,
+                  "Sequence": 12994742
+                },
+                "PreviousTxnID": "98E0F956171CEEBA795DC91E59163B77952A65DE16956F926A68C83C5569C4DF",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 2097152,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "c00",
+                  "PreviousTxnID": "98E0F956171CEEBA795DC91E59163B77952A65DE16956F926A68C83C5569C4DF",
+                  "PreviousTxnLgrSeq": 90156059
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "C6172C3C124263E8824878551FF6376348439DDB4492A13DB6B5BF7E30CCC208",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0000006640573587981671"
+                  },
+                  "Flags": 2228224
+                }
+              }
+            }
+          ],
+          "DeliveredAmount": "1",
+          "TransactionIndex": 30,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "1"
+        }
+      },
+      {
+        "Account": "rwjyDXa3YsdZUJcJSDkyRRvt1qwPfxVNKY",
+        "Amount": "1",
+        "Destination": "rNxp4h8apvRis6mJf9Sh8C6iRxfrDWN7AV",
+        "DestinationTag": 430637286,
+        "Fee": "25",
+        "Flags": 2147483648,
+        "LastLedgerSequence": 90156072,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "5768656E20796F75207365652074686973206D6573736167652C207765206861766520616C7265616479206265656E206172726573746564206F72207475726E6564206F757273656C76657320696E2E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "546F20616C6C20476174654875622075736572732C"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "476174654875622069732061207368616D656C6573732063686561742E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "496E20323031372C2047617465487562206C6F7374207E354D2055534420637573746F6D6572206173736574732062656361757365207468657920646964206E6F7420756E6465727374616E64205061727469616C205061796D656E742066656174757265"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "496E20323032322C2077652073656E74207E31334D205553442061737365747320746F204761746548756220776974682074686569722070726F6D697365733A"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "312E206E6F206C6F6E6765722074616B65206C6567616C20616374696F6E20616761696E7374207573"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "322E206E6F206675727468657220636C61696D7320666F7220636F6D70656E736174696F6E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "332E206B65657020354D2055534420616E64206169722064726F7020746865206C6566742061737365747320746F20616C6C2047617465487562207573657273"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "342E20646F206E6F74207368617265206F757220696E666F726D6174696F6E20776974682074686972642070617274696573"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "352E206D616B6520616E20616E6E6F756E63656D656E7420726567617264696E67207468652061626F76652061677265656D656E7473"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "77652073656E742074686520636F696E732C20627574204761746548756220646964206E6F74206B6565702074686569722070726F6D69736573"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "6E6F20616E6E6F756E63656D656E742C206E6F206169722064726F702C20636F6E74696E756520746F20746872656174656E2075732077697468206C6567616C20616374696F6E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "476174654875622061736B20666F72206D6F726520616E64206D6F726520636F696E732E20416E20696E7361746961626C6520626C61636B6D61696C657221"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "57652068617665206E6F206D6F726520636F696E732C2074686520747275746820697320746865206F6E6C79207468696E672077652063616E207368617265"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "54686520747275746820697320746865206F6E6C79207468696E672077652063616E2073686172652E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "54686520747275746820697320746865206F6E6C79207468696E672077652063616E2073686172652E"
+            }
+          }
+        ],
+        "Sequence": 90846092,
+        "SigningPubKey": "03924D5111DD356B7B68E7E68A16848968B8492D812728627A3582572B14C798BF",
+        "TransactionType": "Payment",
+        "TxnSignature": "3045022100B9F96F252220941249A8AD735E06755059A67B808384710A65E1DBC48203EB9F02204EE21997ED685E9BE74282B346C6889A07B34D69D1C51AA7AF452954297F433D",
+        "hash": "100AF7E7D2A05BBF06B04632EDE96E7D572BCCCEB2F9D6805D6E38765C47C4B1",
+        "DeliverMax": "1",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rNxp4h8apvRis6mJf9Sh8C6iRxfrDWN7AV",
+                  "Balance": "13997245661",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 77292712
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "59EDFBD7E3AA8EF84600C7AABD24DBC8229C19A1FF956C83D6B04390CF7C7E34",
+                "PreviousFields": {
+                  "Balance": "13997245660"
+                },
+                "PreviousTxnID": "1C2B197DF52D878649B798F34BEE22077A037DFD0FE3CFF39FBEA92964F6F8D4",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rwjyDXa3YsdZUJcJSDkyRRvt1qwPfxVNKY",
+                  "Balance": "4918228236",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 90846093
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1E70E44C3D201A11890678AC660EAD84642373F8D9B261ADEFA324306792F2B",
+                "PreviousFields": {
+                  "Balance": "4918228262",
+                  "Sequence": 90846092
+                },
+                "PreviousTxnID": "8F21BBE8C33C0BEDA655B526B00CC610929C2AE68BD9182522AC943C3D396F23",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 43,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "1"
+        }
+      },
+      {
+        "Account": "r3rDYkhQBXwbJqEMj39QYGmZQPQThR44HT",
+        "Amount": "88",
+        "Destination": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+        "DestinationTag": 1111232,
+        "Fee": "10",
+        "Sequence": 89124748,
+        "SigningPubKey": "EDED81D06CC744B3916C146372204DC27F02720559A8DB3338BB36112E0BC0AF95",
+        "TransactionType": "Payment",
+        "TxnSignature": "0DC864C88F5D8C0AD8DDE16001668DDA6AC4691ACE415A1F0D604F1A428EC0B49F1077A9DF9C0F9CB1ADE284DE4195416B1A5286C54448294BCF930BC2819407",
+        "hash": "13F73CBB3F5897D0F27CD9E418DB561F203C14D7EDE0EF62FF90D007E8CECA5C",
+        "DeliverMax": "88",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rDYkhQBXwbJqEMj39QYGmZQPQThR44HT",
+                  "Balance": "51233936",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89124749
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "04DB180343A980921C743469BD0BA3ADA7D0BED2F75D1E834CA5EFBEDDCBE47E",
+                "PreviousFields": {
+                  "Balance": "51234034",
+                  "Sequence": 89124748
+                },
+                "PreviousTxnID": "6812DCFE69D2C1E52EC8E905DBE94D9C3D6BF07006A2A6ED5A5A361A9947C7B1",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+                  "Balance": "43091148",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89531841
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2A9DF02FF78FCCE946B77372B25D9C6F875895CEE6AAC1D37A7158BAA3E9BBDC",
+                "PreviousFields": {
+                  "Balance": "43091060"
+                },
+                "PreviousTxnID": "3C5C3196A8470AE4276EB77796F4E4D893CF05D4C9E089C7983BAC5E763749AB",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 40,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "88"
+        }
+      },
+      {
+        "Account": "rrsVFfD7FBbxV5o9wsEX5KeyCzxVW1gQRh",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 90156077,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7B226D6F64756C65223A2258574D2041737369737465642054726164696E67222C22616363657373223A2258574D204E4654204469616D6F6E64222C2276657273696F6E223A2276302E352E302062657461222C227374726174656779223A224261736963227D"
+            }
+          }
+        ],
+        "Sequence": 77938653,
+        "SigningPubKey": "ED1DEFDBA32B4575026B040299AA59E27CE027DF664D7930508510ADA775CCE8AE",
+        "TakerGets": "10000000",
+        "TakerPays": {
+          "currency": "5852646F67650000000000000000000000000000",
+          "issuer": "rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA",
+          "value": "432796.06"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "A5BB33B5AE54CC337A168CF1352E8BB09873B9D78B55EBBB09F815EB8287D139E9E33A81C2DEB81E891797161CE38A2148AF31CD1336D6CC14322EB5CEB42B06",
+        "hash": "161A64F8EF2DA831AF57EF676C3DED0346FFF7468846F427C82B80540875C30E",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rrsVFfD7FBbxV5o9wsEX5KeyCzxVW1gQRh",
+                  "RootIndex": "9F9309201C8741EB9C26CB9A7EACCB29E5CCFDA44DCAADBAA230C3990D417FCF"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "8D391D73E35018389D35AA8626BA709E8E521ADBA03156450D1F9271EF3F2EA5"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F2D91B1CAE9365A0546D4D7E953BB7B756106CD80933E979530F6041DA2A3600",
+                "NewFields": {
+                  "ExchangeRate": "530f6041da2a3600",
+                  "RootIndex": "F2D91B1CAE9365A0546D4D7E953BB7B756106CD80933E979530F6041DA2A3600",
+                  "TakerPaysCurrency": "5852646F67650000000000000000000000000000",
+                  "TakerPaysIssuer": "D98817F9CF03AE03FC31F43C8DCEEADF277D5EE7"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rrsVFfD7FBbxV5o9wsEX5KeyCzxVW1gQRh",
+                  "Balance": "242071878",
+                  "Flags": 0,
+                  "OwnerCount": 44,
+                  "Sequence": 77938654
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "F6A1A63EFDB065C0D4143A34072CD6F65FBEAD0526C769BF91D37F7053BBFA86",
+                "PreviousFields": {
+                  "Balance": "242071893",
+                  "OwnerCount": 43,
+                  "Sequence": 77938653
+                },
+                "PreviousTxnID": "818BBAC9E596204E6B04B415B8F55D07DF2A4D30148689BDD3B4158EF2EBB263",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "F925FBCEF5BC96CD42A5B0E7CAA641E53A98993D200920E7DF2782AB33AC83A0",
+                "NewFields": {
+                  "Account": "rrsVFfD7FBbxV5o9wsEX5KeyCzxVW1gQRh",
+                  "BookDirectory": "F2D91B1CAE9365A0546D4D7E953BB7B756106CD80933E979530F6041DA2A3600",
+                  "OwnerNode": "1",
+                  "Sequence": 77938653,
+                  "TakerGets": "10000000",
+                  "TakerPays": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA",
+                    "value": "432796.06"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 14,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rG3sG9KRuWjPdrnqyWUvwwrn1uhY2wiraL",
+        "Amount": "88",
+        "Destination": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+        "DestinationTag": 1111257,
+        "Fee": "10",
+        "Sequence": 89641423,
+        "SigningPubKey": "ED28CB2C35D962283E6A5B8C9BB2FBA4B32ECBABD2FDEF32B3E18C09BA7ADA04AE",
+        "TransactionType": "Payment",
+        "TxnSignature": "932417003837E1B981BD501A317AFCD1B63AE40BA508B034C9B4053871FDAFA25E32249D091E321415059D06B08F2AFCE562FD57DC0736054E31188F1F728203",
+        "hash": "1FBD2B85E5B282D2D6D7EBA356F213E62A22EBFB17A5B5A30F5BB7F8D9004A44",
+        "DeliverMax": "88",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+                  "Balance": "43091324",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89531841
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2A9DF02FF78FCCE946B77372B25D9C6F875895CEE6AAC1D37A7158BAA3E9BBDC",
+                "PreviousFields": {
+                  "Balance": "43091236"
+                },
+                "PreviousTxnID": "45C3EB6969A23F2A1639E11CF9424CE007DBA08789B6A6CEBD8EB447E9E3ADFD",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rG3sG9KRuWjPdrnqyWUvwwrn1uhY2wiraL",
+                  "Balance": "51631886",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89641424
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "3BBCAE7404698B45415EA13FDAD1B603F363B7EFB2CF47F9AB81CA7E5F6001A3",
+                "PreviousFields": {
+                  "Balance": "51631984",
+                  "Sequence": 89641423
+                },
+                "PreviousTxnID": "6AD7257FD80F48CD13848A5FBD51CBAB6FB1421A5A95DD3CA9B9D480E13E7105",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            }
+          ],
+          "TransactionIndex": 53,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "88"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994739,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "0.00000006837520366252542"
+        },
+        "TakerPays": {
+          "currency": "58434F5245000000000000000000000000000000",
+          "issuer": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+          "value": "0.000000009762560279618764"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "EE79E075AEC58C7AE3BF29D825629C5A2AFBFEF772CB5C49DD9F8374B92FE8C94549A33F0914A7291DC67F0CB1697BA1D54FF8E246A1B91E78A9032680BF9705",
+        "hash": "272EA89713D998812DF34E0A30F9E1F53AD24B7977661EF7DEE8681F5DB4A92D",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "99f",
+                  "Owner": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+                  "RootIndex": "C0DA491E53EA9440740C19AAF40FD7AB7132224EFFEF4B224280BF80C03C7BF8"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "979C3C6EC438DABC913A71490D84B69C2A8EEB02ED871BB22BE79FD7C81A047A"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "AC0346AB66951F5FC37BC58EE00CEC66E878B2CFA770BFD503CD7730022B17BA",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000009760139253683009"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+                    "value": "0"
+                  },
+                  "HighNode": "9a0",
+                  "LowLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-40.52211998282901"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rKrECNmeMob1mWD1zFgJ4q9W2jexpaeTgh",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+                    "value": "0"
+                  },
+                  "LowNode": "98d"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "ACB6AE6604056B8CCC7114C852F7046680F0CBD9B69553DE5E972EB42D0D5CC7",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-40.52212974296826"
+                  }
+                },
+                "PreviousTxnID": "980830D683F62BF7C68C2578ADF50F15418FAA2EC3E423E3063C9ABC8C484762",
+                "PreviousTxnLgrSeq": 90156036
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "272EA89713D998812DF34E0A30F9E1F53AD24B7977661EF7DEE8681F5DB4A92D",
+                  "Balance": "1467511952",
+                  "Flags": 0,
+                  "OwnerCount": 51,
+                  "Sequence": 12994740
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "C3A090E476C1F22998D0A0CB0352BAE75C3792FF4432C814A23D1D9E3A1D483C",
+                  "Balance": "1467511962",
+                  "OwnerCount": 50,
+                  "Sequence": 12994739
+                },
+                "PreviousTxnID": "C3A090E476C1F22998D0A0CB0352BAE75C3792FF4432C814A23D1D9E3A1D483C",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000001181223731471715"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D63A73BFE673289DA86434524C38EBA61561FC4C7614601A6173E85C92A0AC07",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000001864975768096969"
+                  }
+                },
+                "PreviousTxnID": "C3A090E476C1F22998D0A0CB0352BAE75C3792FF4432C814A23D1D9E3A1D483C",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.283806334319199"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rKrECNmeMob1mWD1zFgJ4q9W2jexpaeTgh",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "LowNode": "df"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "DCD5395F9A97C7AE0FBE2531ECBBC9CE7D188D74FADBE376F3E56F66EBEA14DA",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.2838062659439953"
+                  }
+                },
+                "PreviousTxnID": "980830D683F62BF7C68C2578ADF50F15418FAA2EC3E423E3063C9ABC8C484762",
+                "PreviousTxnLgrSeq": 90156036
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E0093B8AB888B3827399F6A36072CB9EB55AC8B9A0C326EB8113732B7A88394F",
+                "PreviousTxnID": "38222CEA3F9F228A4AE5EC982059DB6B04953A3AA7826F3C78129F58ECA114A3",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 27,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r476GSXdCnhs8M55irwNqhQRSu4Djrmh63",
+        "Amount": "44",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1000002,
+        "Fee": "10",
+        "Sequence": 89123850,
+        "SigningPubKey": "EDD253AB2FD5713C557BEA6B0099B80A7DF6AF6375ED3D1DA7C7AD885193B684B6",
+        "TransactionType": "Payment",
+        "TxnSignature": "4085D502DDC55A76911DEC131E3E7E443F54FF06AF523D0A4792BC5976206280737E8EBC71DDB9110282B69CC12BFF4EF940A5C6942381C59388831631194102",
+        "hash": "2CBF30B5E35736C95B671D762F1F55F9D48C006D5B51A1E785BFF604381E991B",
+        "DeliverMax": "44",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "188399270",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "188399226"
+                },
+                "PreviousTxnID": "2EB0574A1CBA0A5848EEA7066C071B176F436E913B9C1D27E017FC44E5AFDEF4",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r476GSXdCnhs8M55irwNqhQRSu4Djrmh63",
+                  "Balance": "51233129",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89123851
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "63CA584080D9CA571C34A0A2477FC533B728BB01ACD43A07097502396047D7C7",
+                "PreviousFields": {
+                  "Balance": "51233183",
+                  "Sequence": 89123850
+                },
+                "PreviousTxnID": "3D2227472002D436295EC2F51379D6AE4CB453241B690F8F44E1AD1296E00F0A",
+                "PreviousTxnLgrSeq": 90156048
+              }
+            }
+          ],
+          "TransactionIndex": 62,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "44"
+        }
+      },
+      {
+        "Account": "rrsVFfD7FBbxV5o9wsEX5KeyCzxVW1gQRh",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 90156077,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7B226D6F64756C65223A2258574D2041737369737465642054726164696E67222C22616363657373223A2258574D204E4654204469616D6F6E64222C2276657273696F6E223A2276302E352E302062657461222C227374726174656779223A224261736963227D"
+            }
+          }
+        ],
+        "OfferSequence": 77938646,
+        "Sequence": 77938651,
+        "SigningPubKey": "ED1DEFDBA32B4575026B040299AA59E27CE027DF664D7930508510ADA775CCE8AE",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "5B7BD4C99F2A25FAD3083A9BA73757F4EBE3291482280520FC766AB89A508D2805CEC5E0697A345F6AE1AB061A824A65210B3833009DFE954B2E1EE60CE6DB01",
+        "hash": "2E88FEF40011D1E1544CD5F3A27C28AB2CC6A2116F8C764BFB984BA8597AFD62",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rrsVFfD7FBbxV5o9wsEX5KeyCzxVW1gQRh",
+                  "BookDirectory": "E52309B0DEF00F10EADE6630F4738B18DF92D5221944F70F5608C6BD76CC5F89",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "1",
+                  "PreviousTxnID": "03B796B16E7EE83B0B57411D73C004F6E97CF0C163A7F762AF059484D6815EE3",
+                  "PreviousTxnLgrSeq": 90156019,
+                  "Sequence": 77938646,
+                  "TakerGets": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA",
+                    "value": "404806.37"
+                  },
+                  "TakerPays": "10000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "5868663D44B1248B141D12370F79BAC5E4B0385B06EFABF4D47678D9B8BB30F8"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rrsVFfD7FBbxV5o9wsEX5KeyCzxVW1gQRh",
+                  "RootIndex": "9F9309201C8741EB9C26CB9A7EACCB29E5CCFDA44DCAADBAA230C3990D417FCF"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "8D391D73E35018389D35AA8626BA709E8E521ADBA03156450D1F9271EF3F2EA5"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5608c6bd76cc5f89",
+                  "Flags": 0,
+                  "RootIndex": "E52309B0DEF00F10EADE6630F4738B18DF92D5221944F70F5608C6BD76CC5F89",
+                  "TakerGetsCurrency": "5852646F67650000000000000000000000000000",
+                  "TakerGetsIssuer": "D98817F9CF03AE03FC31F43C8DCEEADF277D5EE7",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "E52309B0DEF00F10EADE6630F4738B18DF92D5221944F70F5608C6BD76CC5F89"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rrsVFfD7FBbxV5o9wsEX5KeyCzxVW1gQRh",
+                  "Balance": "242071908",
+                  "Flags": 0,
+                  "OwnerCount": 42,
+                  "Sequence": 77938652
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "F6A1A63EFDB065C0D4143A34072CD6F65FBEAD0526C769BF91D37F7053BBFA86",
+                "PreviousFields": {
+                  "Balance": "242071920",
+                  "OwnerCount": 43,
+                  "Sequence": 77938651
+                },
+                "PreviousTxnID": "71B257414F2BE28C71CCD387F18DE2F4E33F66432932C37950A1BA723905BAE5",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            }
+          ],
+          "TransactionIndex": 12,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rH3HGNeuHqkX6a32wr479g9xRumDQCBXKJ",
+        "Amount": "89",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1075,
+        "Fee": "10",
+        "Sequence": 89525481,
+        "SigningPubKey": "ED61031A7A14AD002A542BBD00342A14408D593C126058BA5D2538E28D89E11030",
+        "TransactionType": "Payment",
+        "TxnSignature": "9AC76A572AAC80F92233F5DE7AF16961E7FE9310A28B7B4F6853ABF92EF4ED02520F5EFF588C035DB80CC54A3B7CC9887E4C228B15A6CABA19591B538E204C04",
+        "hash": "2EB0574A1CBA0A5848EEA7066C071B176F436E913B9C1D27E017FC44E5AFDEF4",
+        "DeliverMax": "89",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rH3HGNeuHqkX6a32wr479g9xRumDQCBXKJ",
+                  "Balance": "54338420",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89525482
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2C6D07268901F56B837CB285CD684A7BEAE2D4678296490579070B07A4EA4FC4",
+                "PreviousFields": {
+                  "Balance": "54338519",
+                  "Sequence": 89525481
+                },
+                "PreviousTxnID": "BEE6652F6C45D25C68E876901E2931425EF2154679534AC696A1D66D7BFAC3D6",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "188399226",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "188399137"
+                },
+                "PreviousTxnID": "99EEBAF1E2F4A106B72719294DAE12FE19B8EB76EA5C8A137E60BE4254F2FDE6",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 59,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "89"
+        }
+      },
+      {
+        "Account": "rPJ2kXNTseFAD1qotRXBtv7cd3x8ZN4BkP",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 90156072,
+        "OfferSequence": 87567334,
+        "Sequence": 0,
+        "SigningPubKey": "ED430693FC7ECA8BF90BDF979181B1D6E8E698041144A82900828DB965794FF857",
+        "TakerGets": {
+          "currency": "4450415900000000000000000000000000000000",
+          "issuer": "rBvXRy3AkW7En4rByqymXW7bBLET3y2P9f",
+          "value": "1923.1406678"
+        },
+        "TakerPays": "74979308",
+        "TicketSequence": 87567330,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "93E613CEB073947395011DA40A598F41CE28B930F9F0F44309EF6F0532EFADD92AA5997A1C51791D8B914E578BDC22B1612985B77714A74AFC93A3E230C20003",
+        "hash": "30D5587662E47A1683DA3EC84D634BAA6F373051FE9FCA3655543EF7BB2769A5",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "0F16B49385CF7D30862B899CAECEC236BC4A1EFDE74591EB2D13C0CEC1690BA4",
+                "NewFields": {
+                  "Account": "rPJ2kXNTseFAD1qotRXBtv7cd3x8ZN4BkP",
+                  "BookDirectory": "F0CEC2F8B742B2364B53388454876157E2151259A2864847590DD9F01D0CE000",
+                  "OwnerNode": "47aa",
+                  "Sequence": 87567330,
+                  "TakerGets": {
+                    "currency": "4450415900000000000000000000000000000000",
+                    "issuer": "rBvXRy3AkW7En4rByqymXW7bBLET3y2P9f",
+                    "value": "1923.138093772443"
+                  },
+                  "TakerPays": "74979308"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rPJ2kXNTseFAD1qotRXBtv7cd3x8ZN4BkP",
+                  "Flags": 0,
+                  "OwnerNode": "47aa",
+                  "PreviousTxnID": "A8A8A329827B691DC0FC1E48C1A9224529E56EAC2AB43B6E16F1C18A58E1756A",
+                  "PreviousTxnLgrSeq": 90155997,
+                  "TicketSequence": 87567330
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "17237CA07FF8C0D2D84181E96773AE8DC847F3D8A28D3BDC47083C1F0DF38EE3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rPJ2kXNTseFAD1qotRXBtv7cd3x8ZN4BkP",
+                  "Balance": "1912403790",
+                  "Flags": 0,
+                  "OwnerCount": 50,
+                  "Sequence": 87567348,
+                  "TicketCount": 17
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2D0D7A8511A7CF5930081E38DB4EB8585AECB3A6646EC7CDC93B40880C28C993",
+                "PreviousFields": {
+                  "Balance": "1912403802",
+                  "OwnerCount": 51,
+                  "TicketCount": 18
+                },
+                "PreviousTxnID": "53CEBF8020E0FDEFE318C8E437C23D0C50DE3D30A2DE6B02890B095C86AA8044",
+                "PreviousTxnLgrSeq": 90156055
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rPJ2kXNTseFAD1qotRXBtv7cd3x8ZN4BkP",
+                  "BookDirectory": "F0CEC2F8B742B2364B53388454876157E2151259A2864847590DD9F01D0CE000",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "47aa",
+                  "PreviousTxnID": "51E38BAF7F28193C12BA65160444EF279D9B9C3D2DC25B2307EEF314AB7BD08B",
+                  "PreviousTxnLgrSeq": 90156055,
+                  "Sequence": 87567334,
+                  "TakerGets": {
+                    "currency": "4450415900000000000000000000000000000000",
+                    "issuer": "rBvXRy3AkW7En4rByqymXW7bBLET3y2P9f",
+                    "value": "1923.138093772443"
+                  },
+                  "TakerPays": "74979308"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "364945D5D31D67AE04CEFBB4C108ED592374C706BC0F3A839033A43486D96C2D"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "47a2",
+                  "Owner": "rPJ2kXNTseFAD1qotRXBtv7cd3x8ZN4BkP",
+                  "RootIndex": "E5891B3D122CC93DF66E0A32B2085B7420895C43D04491928CB94EDD442816FC"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9A0C78B3B975E780B9AE66FEACC74079064F07EAA60EC58A0F52F446E3A5343D"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "590dd9f01d0ce000",
+                  "Flags": 0,
+                  "RootIndex": "F0CEC2F8B742B2364B53388454876157E2151259A2864847590DD9F01D0CE000",
+                  "TakerGetsCurrency": "4450415900000000000000000000000000000000",
+                  "TakerGetsIssuer": "77D0B4B5C5C3A55A28BB4C9C2F4A93D4A256B7C3",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F0CEC2F8B742B2364B53388454876157E2151259A2864847590DD9F01D0CE000"
+              }
+            }
+          ],
+          "TransactionIndex": 64,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rK2kLnCN4yjv1j2x79wXxRVXnFbwsjUWXo",
+        "Amount": {
+          "currency": "DFC",
+          "issuer": "rEEso92XqyM3oar4L2oC4fWQsG6oZViA4k",
+          "value": "100000"
+        },
+        "Destination": "rEEso92XqyM3oar4L2oC4fWQsG6oZViA4k",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 90156077,
+        "Sequence": 86543735,
+        "SigningPubKey": "03E50D796A4A6825F53F49EB20E127A7B727B1E65A16143375A5DE697F82F8E33C",
+        "TransactionType": "Payment",
+        "TxnSignature": "3045022100D26AC519BE64BA841B853CEAF243DE23C3BDAFE3E43E527C3C7BA2EA8677C579022018000C1912775C180C45500C6A3B4E2580394FECB42AA0B49AF83F6F345FD3F9",
+        "hash": "31012F0EA4445D3E6E99E84255B642347F96EAAE2C6C613B2859C703FF8337C8",
+        "DeliverMax": {
+          "currency": "DFC",
+          "issuer": "rEEso92XqyM3oar4L2oC4fWQsG6oZViA4k",
+          "value": "100000"
+        },
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rK2kLnCN4yjv1j2x79wXxRVXnFbwsjUWXo",
+                  "Balance": "22716927",
+                  "Flags": 0,
+                  "OwnerCount": 1,
+                  "Sequence": 86543736
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "22B22B184A1CB865E148C474EEBCCA1C504B5E2AF4AB8B52465E5A1B47B0E241",
+                "PreviousFields": {
+                  "Balance": "22716939",
+                  "Sequence": 86543735
+                },
+                "PreviousTxnID": "F855FA827969AF89E7FFF53E307FDFE7705C64322D88F2636F554BE97BFD23AD",
+                "PreviousTxnLgrSeq": 90156056
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "DFC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-3387728245861906e-2"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "DFC",
+                    "issuer": "rK2kLnCN4yjv1j2x79wXxRVXnFbwsjUWXo",
+                    "value": "3392400000000000e-2"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "DFC",
+                    "issuer": "rEEso92XqyM3oar4L2oC4fWQsG6oZViA4k",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F02816B447CA4E2D8DB9FD55207BFA58753CC2298A9BA858C8E3967A77741143",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "DFC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-3387728255861906e-2"
+                  }
+                },
+                "PreviousTxnID": "F855FA827969AF89E7FFF53E307FDFE7705C64322D88F2636F554BE97BFD23AD",
+                "PreviousTxnLgrSeq": 90156056
+              }
+            }
+          ],
+          "TransactionIndex": 60,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "DFC",
+            "issuer": "rEEso92XqyM3oar4L2oC4fWQsG6oZViA4k",
+            "value": "100000"
+          }
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 90156061,
+        "OfferSequence": 148592492,
+        "Sequence": 148592502,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": {
+          "currency": "5553444300000000000000000000000000000000",
+          "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+          "value": "111433.8628"
+        },
+        "TakerPays": "200000000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100B9E4D2A2F9E96547E1431A92B44B66C844BE416BB65EC53EFB73DDFDA6BAF1FB02200FBAF807E203C221A93496DBFC878D137202D40ABA405C13F43D606B6474F4CD",
+        "hash": "319C605A90C4FDBADCDD2E31A320B44F6CDA2D402EE9663796DF8A48AAEF33D6",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1371BCEED87E4C5C53C442854276A5ABB5D41F635AB7C4475B0660594FBD85B9",
+                "NewFields": {
+                  "ExchangeRate": "5b0660594fbd85b9",
+                  "RootIndex": "1371BCEED87E4C5C53C442854276A5ABB5D41F635AB7C4475B0660594FBD85B9",
+                  "TakerGetsCurrency": "5553444300000000000000000000000000000000",
+                  "TakerGetsIssuer": "06AA7798F7A8FA6914CC1E82C556E5B0A0CCB9E3"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5b06605cef1e32b5",
+                  "Flags": 0,
+                  "RootIndex": "1371BCEED87E4C5C53C442854276A5ABB5D41F635AB7C4475B06605CEF1E32B5",
+                  "TakerGetsCurrency": "5553444300000000000000000000000000000000",
+                  "TakerGetsIssuer": "06AA7798F7A8FA6914CC1E82C556E5B0A0CCB9E3",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1371BCEED87E4C5C53C442854276A5ABB5D41F635AB7C4475B06605CEF1E32B5"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "33894335261",
+                  "Flags": 0,
+                  "OwnerCount": 15,
+                  "Sequence": 148592503
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "33894335281",
+                  "Sequence": 148592502
+                },
+                "PreviousTxnID": "0B250DC9DED1606A3DA8A4CA6BE1101A6902634C4CA1351D2AC57FB38822CA8D",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "710B4C4FE85961F11731A643EDEB7E8B4C08B451C6FB516F2F25E4AD71FBBF7A",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "1371BCEED87E4C5C53C442854276A5ABB5D41F635AB7C4475B0660594FBD85B9",
+                  "Sequence": 148592502,
+                  "TakerGets": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "111433.8628"
+                  },
+                  "TakerPays": "200000000000"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "1371BCEED87E4C5C53C442854276A5ABB5D41F635AB7C4475B06605CEF1E32B5",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "967799C7830FD75155414E21DA4DCC4DF2BE85D3B4E7B0FCFB930615523574E1",
+                  "PreviousTxnLgrSeq": 90156058,
+                  "Sequence": 148592492,
+                  "TakerGets": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "111432.8968"
+                  },
+                  "TakerPays": "200000000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "96EA65FEE8FB375D209792BB247E7FD12CF67968B3BB6F8BAB4CD14BDC7276EF"
+              }
+            }
+          ],
+          "TransactionIndex": 50,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994733,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "58434F5245000000000000000000000000000000",
+          "issuer": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+          "value": "0.006667249436902424"
+        },
+        "TakerPays": {
+          "currency": "XNX",
+          "issuer": "raDDJZ73m7ouH4CSTdiFS4fJ6GWctt2qVF",
+          "value": "0.000001947672309525069"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "A6DB62051225325B1116F2EFCA77933CDDFF0B18B080DBD3D03A2BD1829119BF04B22610825DEF9D663F67870007AD2283B9284F5751695409D91ECA01C7500C",
+        "hash": "38222CEA3F9F228A4AE5EC982059DB6B04953A3AA7826F3C78129F58ECA114A3",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XNX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-64.85040112682274"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "XNX",
+                    "issuer": "rPXDutAMakwuoWYnUwUSZ7s2SS9CpV1TcP",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "XNX",
+                    "issuer": "raDDJZ73m7ouH4CSTdiFS4fJ6GWctt2qVF",
+                    "value": "0"
+                  },
+                  "LowNode": "3"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "0A74CD8B5F2BB1C3892B64FA1B7E51165C10576620D916343D6494E777236B5B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XNX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-64.85202347803662"
+                  }
+                },
+                "PreviousTxnID": "D12F48245842EDE3CCFAEBBB7D39E1C03F91A272ABFD753DAACD51DA22232B99",
+                "PreviousTxnLgrSeq": 90156042
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-219.780747842378"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rPXDutAMakwuoWYnUwUSZ7s2SS9CpV1TcP",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+                    "value": "0"
+                  },
+                  "LowNode": "995"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "42ED8CAECFDEE8AE637E5AAA873F30E027300127F8ED4365B267F711A9DC7345",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-219.775192992878"
+                  }
+                },
+                "PreviousTxnID": "D12F48245842EDE3CCFAEBBB7D39E1C03F91A272ABFD753DAACD51DA22232B99",
+                "PreviousTxnLgrSeq": 90156042
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "73010F77D1AD803C5E44FBF9DCCCF54D7F3CBB9D6C410620621D31509AD5AB22",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "XNX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.001622351213880319"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "XNX",
+                    "issuer": "raDDJZ73m7ouH4CSTdiFS4fJ6GWctt2qVF",
+                    "value": "0"
+                  },
+                  "HighNode": "5",
+                  "LowLimit": {
+                    "currency": "XNX",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "99f",
+                  "Owner": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+                  "RootIndex": "C0DA491E53EA9440740C19AAF40FD7AB7132224EFFEF4B224280BF80C03C7BF8"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "979C3C6EC438DABC913A71490D84B69C2A8EEB02ED871BB22BE79FD7C81A047A"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A075663C31DE0712528EBA515397D67155E7B5A983A6EC5281E225E3B1F83580",
+                "PreviousTxnID": "8DF7221F03CD4A340A4907078D88997173F1D5E491A8EB9A7657503B4E4E29FF",
+                "PreviousTxnLgrSeq": 90156042
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1048576,
+                  "HighLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+                    "value": "0"
+                  },
+                  "HighNode": "9a0",
+                  "LowLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c",
+                  "PreviousTxnID": "FE15DA0666AC16B54CCB9819A1D6AAD37E2AC479D1EAF39879CE4E853B336B9B",
+                  "PreviousTxnLgrSeq": 90156059
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "AC0346AB66951F5FC37BC58EE00CEC66E878B2CFA770BFD503CD7730022B17BA",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0055548495"
+                  },
+                  "Flags": 1114112
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "4",
+                  "Owner": "raDDJZ73m7ouH4CSTdiFS4fJ6GWctt2qVF",
+                  "RootIndex": "714567716BE0B579DCED5F1669FFD2668CECBB600605E15FCA13845881095102"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B49E71C2BA5F052E1C2C2E10F1185385794455A6DF41CDC12F23995F6942AC40"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "38222CEA3F9F228A4AE5EC982059DB6B04953A3AA7826F3C78129F58ECA114A3",
+                  "Balance": "1467511519",
+                  "Flags": 0,
+                  "OwnerCount": 50,
+                  "Sequence": 12994734
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "FE15DA0666AC16B54CCB9819A1D6AAD37E2AC479D1EAF39879CE4E853B336B9B",
+                  "Balance": "1467511529",
+                  "Sequence": 12994733
+                },
+                "PreviousTxnID": "FE15DA0666AC16B54CCB9819A1D6AAD37E2AC479D1EAF39879CE4E853B336B9B",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E0093B8AB888B3827399F6A36072CB9EB55AC8B9A0C326EB8113732B7A88394F",
+                "PreviousTxnID": "FE15DA0666AC16B54CCB9819A1D6AAD37E2AC479D1EAF39879CE4E853B336B9B",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 21,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994750,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "5A52505900000000000000000000000000000000",
+          "issuer": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+          "value": "0.0000000005002827559173432"
+        },
+        "TakerPays": {
+          "currency": "POZ",
+          "issuer": "rpvbUsHkJ91rGTa9gShUQU6jzLrFBgsVe3",
+          "value": "3001515209492659e-28"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "AAC2B4110C4BD6317695C22FF51610C1470F1436363B6720954448049D3E1309B0817D2ACCE7137381D5128B3A4119D2A060D008436BFA4D88CBD7E5D44A5B0E",
+        "hash": "39721CE7F5366F98B4870EAB58279D6592871DC533349D9779FD18E295FEA268",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-2.074993135228309"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "raVh7BwvL415ZyuGboYEgBbkuqCbP8P97o",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+                    "value": "0"
+                  },
+                  "LowNode": "8f"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "279F4E92BE1B689F85BF98B9EC39D3A440D7EBAF8CDC349D3E0467CBADEA5B59",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-2.07499313481151"
+                  }
+                },
+                "PreviousTxnID": "4C032E0D756913DE48BD2C8DADA162C078730B2C0C5F6218826DB47E09C78DC1",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "POZ",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1.244923094160111"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "POZ",
+                    "issuer": "raVh7BwvL415ZyuGboYEgBbkuqCbP8P97o",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "POZ",
+                    "issuer": "rpvbUsHkJ91rGTa9gShUQU6jzLrFBgsVe3",
+                    "value": "0"
+                  },
+                  "LowNode": "d"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "54FE3F6382D116377553337EA23AEAA3CB50E8F3BB256909286A4FA6FEBB3A1E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "POZ",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1.244923094410113"
+                  }
+                },
+                "PreviousTxnID": "4C032E0D756913DE48BD2C8DADA162C078730B2C0C5F6218826DB47E09C78DC1",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "POZ",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.000047609215434687"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "POZ",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "POZ",
+                    "issuer": "rpvbUsHkJ91rGTa9gShUQU6jzLrFBgsVe3",
+                    "value": "0"
+                  },
+                  "LowNode": "10"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "832EF40972BFCC2EF109FDBF2F59A41C7C841248A0BFEA907008B63C4D6EC21E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "POZ",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.00004760896543246281"
+                  }
+                },
+                "PreviousTxnID": "4C032E0D756913DE48BD2C8DADA162C078730B2C0C5F6218826DB47E09C78DC1",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "90848E9A1185CCEF2B55329945A8D6075A88A10A854FF6DB890994AAD4CED060",
+                "PreviousTxnID": "C66A8737DAE8857289034C1A36E6CE4ECB273C90269035626E76C6E2DE06B954",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "39721CE7F5366F98B4870EAB58279D6592871DC533349D9779FD18E295FEA268",
+                  "Balance": "1467511842",
+                  "Flags": 0,
+                  "OwnerCount": 49,
+                  "Sequence": 12994751
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "C66A8737DAE8857289034C1A36E6CE4ECB273C90269035626E76C6E2DE06B954",
+                  "Balance": "1467511852",
+                  "OwnerCount": 50,
+                  "Sequence": 12994750
+                },
+                "PreviousTxnID": "C66A8737DAE8857289034C1A36E6CE4ECB273C90269035626E76C6E2DE06B954",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "8f",
+                  "Owner": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+                  "RootIndex": "4492BEF2FF8CE6639BB5E6AA330E8163DC45BED13660B310A2C5503C03534CA6"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "C3F0C59D3E02E306BD82ABA89093BEB615F70ADA0ECDE4E08A9470FB277D2744"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 2097152,
+                  "HighLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+                    "value": "0"
+                  },
+                  "LowNode": "90",
+                  "PreviousTxnID": "C66A8737DAE8857289034C1A36E6CE4ECB273C90269035626E76C6E2DE06B954",
+                  "PreviousTxnLgrSeq": 90156059
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "E5D9EA1D087FA02C08D319E9DBD3167D791173D848A08EC9EB6F4F77F4CFA48C",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0000000004167989086535497"
+                  },
+                  "Flags": 2228224
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 38,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 7423361,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "MAG",
+          "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+          "value": "0.0000000007639887809100125"
+        },
+        "TakerPays": {
+          "currency": "NET",
+          "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+          "value": "0.000000002416067116629678"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "230581F60C9EA6E1F50596324AD1A83EF8400E61A323CCF5AA0AB01138ED70ED9323D770E4B95C3317DAFA39D5AA7D08C068CE7DC48103CD76D46926AB0C7606",
+        "hash": "3B58AD64D77C27707F6D6081E160C118E39D1278D7CA4CEA90C0897F93E7DBA1",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "53.92159123897791"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rnMdA7on8XggvQ1uNRzsdJpK9Uekp1yfTs",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "221F33435CE1B8386DC3CD646F889CD8531A55F2EB6CB823434C11830246D136",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "53.92159365504961"
+                  }
+                },
+                "PreviousTxnID": "7B35B95950B1DDD3270F7EDE107F7D1E37B60F4AC97F5A08C3C722ED422A2DF3",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.01705060842549656"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "MAG",
+                    "issuer": "rnMdA7on8XggvQ1uNRzsdJpK9Uekp1yfTs",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "MAG",
+                    "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+                    "value": "0"
+                  },
+                  "LowNode": "20e"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "574958BA3EFA9277632587EBC6B9F8FDDF43C7B04E865118203D10C7433CEEA5",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.01705060766150778"
+                  }
+                },
+                "PreviousTxnID": "7B35B95950B1DDD3270F7EDE107F7D1E37B60F4AC97F5A08C3C722ED422A2DF3",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.00202402475779514"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "MAG",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "HighNode": "8",
+                  "LowLimit": {
+                    "currency": "MAG",
+                    "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+                    "value": "0"
+                  },
+                  "LowNode": "214"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "6AEDB0D2B26C22AC4401CBDCEB4181C26081FE867AC3A8C233488A6D66724DE8",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.002024025521783921"
+                  }
+                },
+                "PreviousTxnID": "C4C48398BD837B9BC1AA0EC4E080D6BC340C1FE4761B84A85208544F463B95A8",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000024162594060048"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "7E7F2D4E27869445BE12682DFCB1420364E2EB5355BD8B4EA40A6B6DC236D2B1",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000000001877060048"
+                  }
+                },
+                "PreviousTxnID": "4B1A4C5C3658DD33483C3AC2AFA8BE987962E394D0B55B3F3C9B64EFC4DE7D9E",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "3B58AD64D77C27707F6D6081E160C118E39D1278D7CA4CEA90C0897F93E7DBA1",
+                  "Balance": "420152658",
+                  "Flags": 0,
+                  "OwnerCount": 143,
+                  "Sequence": 7423362
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "C4C48398BD837B9BC1AA0EC4E080D6BC340C1FE4761B84A85208544F463B95A8",
+                  "Balance": "420152668",
+                  "Sequence": 7423361
+                },
+                "PreviousTxnID": "C4C48398BD837B9BC1AA0EC4E080D6BC340C1FE4761B84A85208544F463B95A8",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 3,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "raFvV8JRi79gcVx6m3wnnmv4wPFycRkuze",
+        "Amount": "87",
+        "Destination": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+        "DestinationTag": 1111135,
+        "Fee": "10",
+        "Sequence": 89536140,
+        "SigningPubKey": "EDF674DE02954F654A60BB47371F8D28E516689DD90D770635CD77835F27389781",
+        "TransactionType": "Payment",
+        "TxnSignature": "8B3CB01597D15BA400CD25F417FD06AFC2A3485A59BB2A2088929816850719275CFA015F5872C44DF3BBBF5D0D4A316247CDDFD9128A0592BD5383F93FA4BB0B",
+        "hash": "3C5C3196A8470AE4276EB77796F4E4D893CF05D4C9E089C7983BAC5E763749AB",
+        "DeliverMax": "87",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "raFvV8JRi79gcVx6m3wnnmv4wPFycRkuze",
+                  "Balance": "54391667",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89536141
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "06B664DF9C0907C5D6E298852D76D104143A852D52DFACEC7136F271FBF24AC4",
+                "PreviousFields": {
+                  "Balance": "54391764",
+                  "Sequence": 89536140
+                },
+                "PreviousTxnID": "37BBCB2BA1A5BE3A3ED5A56F9258250BEB1C5261083E35D05F2F2C3FC4F4DD23",
+                "PreviousTxnLgrSeq": 90156053
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+                  "Balance": "43091060",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89531841
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2A9DF02FF78FCCE946B77372B25D9C6F875895CEE6AAC1D37A7158BAA3E9BBDC",
+                "PreviousFields": {
+                  "Balance": "43090973"
+                },
+                "PreviousTxnID": "43471EEBA642BC3935E3427D47018FCFD9741D3EDE4907D72A10BB87B6CE2FC0",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            }
+          ],
+          "TransactionIndex": 18,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "87"
+        }
+      },
+      {
+        "Account": "rfrHPNAUweBQCRJ9VZfefbM7WdCH48CKWH",
+        "Amount": "88",
+        "Destination": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+        "DestinationTag": 1111192,
+        "Fee": "10",
+        "Sequence": 89534815,
+        "SigningPubKey": "ED97FEDE0B369CFD8CED6734CC890F1B51A343862989BAEAB2288B5AC339B889C6",
+        "TransactionType": "Payment",
+        "TxnSignature": "075C7E4E81EFE5891A3CA3FB97873B5B92897FD187923BDF616BAEFF8F083B2BDB86DB26D0E321BAD4FCD859F78EDD01B102F6343B50EEEE201844E4B59A5B01",
+        "hash": "45C3EB6969A23F2A1639E11CF9424CE007DBA08789B6A6CEBD8EB447E9E3ADFD",
+        "DeliverMax": "88",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+                  "Balance": "43091236",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89531841
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2A9DF02FF78FCCE946B77372B25D9C6F875895CEE6AAC1D37A7158BAA3E9BBDC",
+                "PreviousFields": {
+                  "Balance": "43091148"
+                },
+                "PreviousTxnID": "13F73CBB3F5897D0F27CD9E418DB561F203C14D7EDE0EF62FF90D007E8CECA5C",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rfrHPNAUweBQCRJ9VZfefbM7WdCH48CKWH",
+                  "Balance": "54346371",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89534816
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C8ED992936DEBA0D9CB767D19E16A3F4E7244E87A1954630450B02D59B008C5E",
+                "PreviousFields": {
+                  "Balance": "54346469",
+                  "Sequence": 89534815
+                },
+                "PreviousTxnID": "81FB9803687E822A92EF9C1A770A4BB7707A87834E2257EFDD69656DBE095159",
+                "PreviousTxnLgrSeq": 90156053
+              }
+            }
+          ],
+          "TransactionIndex": 41,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "88"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 90156061,
+        "OfferSequence": 148592490,
+        "Sequence": 148592500,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": {
+          "currency": "EUR",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "102054.2974"
+        },
+        "TakerPays": "200000000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3044022071464FF7785D8770270BEFE9B97454CD4C3632C58F6DDBE93D9A2AEB196D015F0220166F4970FD7A7FFB9B1FC6F1326B2E7EF1F4610A8DD5E20FAE48FEE27A613C7E",
+        "hash": "4DC065FB5FB200E290E18B4F2613BAD6CA3EAD8204E38860ACB78B1F3239F3D9",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "33894335301",
+                  "Flags": 0,
+                  "OwnerCount": 15,
+                  "Sequence": 148592501
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "33894335321",
+                  "Sequence": 148592500
+                },
+                "PreviousTxnID": "EEED2DC6BA004D54D1811C4D270C6809C71A66BEED7EEFD619B8AE19C3E9A9FA",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "CA462483C85A90DB76D8903681442394D8A5E2D0FFAC259C5B06F662A1C1453C",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "5E8AFD89253F86D5378592CE6EF55AE9944B966F809D223AA049583A01313953",
+                  "PreviousTxnLgrSeq": 90156057,
+                  "Sequence": 148592490,
+                  "TakerGets": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "102053.6594"
+                  },
+                  "TakerPays": "200000000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "4AC06A9580BDD7B7DE803E55D16C8C1B8086032E94C5936D70D9DDB3639FB163"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "B038B40F69D2BEAB8E4A9EFED8FD66CBF8411FC83D2FA2187421829BC52E7D52",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "CA462483C85A90DB76D8903681442394D8A5E2D0FFAC259C5B06F65FC7818EAC",
+                  "Sequence": 148592500,
+                  "TakerGets": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "102054.2974"
+                  },
+                  "TakerPays": "200000000000"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CA462483C85A90DB76D8903681442394D8A5E2D0FFAC259C5B06F65FC7818EAC",
+                "NewFields": {
+                  "ExchangeRate": "5b06f65fc7818eac",
+                  "RootIndex": "CA462483C85A90DB76D8903681442394D8A5E2D0FFAC259C5B06F65FC7818EAC",
+                  "TakerGetsCurrency": "0000000000000000000000004555520000000000",
+                  "TakerGetsIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5b06f662a1c1453c",
+                  "Flags": 0,
+                  "RootIndex": "CA462483C85A90DB76D8903681442394D8A5E2D0FFAC259C5B06F662A1C1453C",
+                  "TakerGetsCurrency": "0000000000000000000000004555520000000000",
+                  "TakerGetsIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CA462483C85A90DB76D8903681442394D8A5E2D0FFAC259C5B06F662A1C1453C"
+              }
+            }
+          ],
+          "TransactionIndex": 48,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rhk2M8y9zNQ5v6AgkpCVRkzErqsfupPubo",
+        "Amount": "44",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 5000032,
+        "Fee": "10",
+        "Sequence": 89644208,
+        "SigningPubKey": "EDB0EDB40A8293000F9B1EDBB340480299A61626E46F6FB6A31B4B28AB3588131D",
+        "TransactionType": "Payment",
+        "TxnSignature": "6719AAA272E965AB765BE69766FF7ECEE7566ADAD59AA0B907C68E1C331DF043D875365E72BB30C40F2AB96F584B5892A9C1758DFE53412903522CE4C986870F",
+        "hash": "67D1B49182EF7412BC4A81080815B687010A0ED17F742D4076F4B6704E8507A8",
+        "DeliverMax": "44",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "188398870",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "188398826"
+                },
+                "PreviousTxnID": "82F6B50B48D8988138DD941756E65AFABF83FE10E8C788E0228F0F99E988E27D",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rhk2M8y9zNQ5v6AgkpCVRkzErqsfupPubo",
+                  "Balance": "51742336",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89644209
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "8B841F5A7A3E512C6528804D6DBCB7511761327F03461A7D3321F206F61AB0B8",
+                "PreviousFields": {
+                  "Balance": "51742390",
+                  "Sequence": 89644208
+                },
+                "PreviousTxnID": "E5FCF0B05CE9A6F16F8F5E358CED4980AF71DAC464D78CD5CFF9C5A12EC21FD4",
+                "PreviousTxnLgrSeq": 90156036
+              }
+            }
+          ],
+          "TransactionIndex": 17,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "44"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994745,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "NET",
+          "issuer": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+          "value": "0.000005604940431641957"
+        },
+        "TakerPays": {
+          "currency": "NET",
+          "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+          "value": "1266683321861819e-30"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "41C6FEE06A54D4FA6FB1ED0DB8E7A7790E1324C5EAC951CE4AEAB6A9D6301A7C4FD4F5036BB4D818547DDE81FD74C9FD178BFCECD3611B5C3D92147D8436A90F",
+        "hash": "6852BF4B3607C58349DE80B518BD7DCB90D437253B583D68DD1F52A8AA15B806",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                  "RootIndex": "1B6E7CB1A25AE631B406C9723A9EBB194D5A8958A7F4DED8B0E230FB469F71A1"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1B6E7CB1A25AE631B406C9723A9EBB194D5A8958A7F4DED8B0E230FB469F71A1"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1048576,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c",
+                  "PreviousTxnID": "AE58AE3792E53657BF5AE7C7B1A7ED32E520E6B70043211203B4F748D76789F1",
+                  "PreviousTxnLgrSeq": 90156059
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "368163F2B47E0164381E9A12A6ACA1A020B269224FC4A81F0385FCD03DEDB8D4",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000004669625369596813"
+                  },
+                  "Flags": 1114112
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.9507776045737486"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rM19JiFRZwGvkmvA2DpUeoRV9kp4wNYCGn",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "536F527E0772D25643641ADB0148E8FAD55EDA5D7DACF63FDDF1309C7B88C661",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.950777604574804"
+                  }
+                },
+                "PreviousTxnID": "369064C9A5A37E7B470F8B10F63B1C067C01291BEEF4BE0D9C8ED2C8A490AB8B",
+                "PreviousTxnLgrSeq": 90156039
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A78BDBB60A871C387C2698A23483A6F44105D6994E613389A513A6BD2C81869B",
+                "PreviousTxnID": "AE58AE3792E53657BF5AE7C7B1A7ED32E520E6B70043211203B4F748D76789F1",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "ACCFDC0A49FC44784C23419CC58BD96F38A0129D6AEF387271DEDB2E737B09D2",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1055400000000000e-27"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rEd9PQjZNDC49FM6jEKqkZCnLGgPK44haR",
+                    "value": "0"
+                  },
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+                  "RootIndex": "B8262C6AD2FDF8D4F8CE480B0E9E06A37FB20F516C178A1D98FC0212A5E2EEDD"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B8262C6AD2FDF8D4F8CE480B0E9E06A37FB20F516C178A1D98FC0212A5E2EEDD"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "6852BF4B3607C58349DE80B518BD7DCB90D437253B583D68DD1F52A8AA15B806",
+                  "Balance": "1467511892",
+                  "Flags": 0,
+                  "OwnerCount": 50,
+                  "Sequence": 12994746
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "AE58AE3792E53657BF5AE7C7B1A7ED32E520E6B70043211203B4F748D76789F1",
+                  "Balance": "1467511902",
+                  "Sequence": 12994745
+                },
+                "PreviousTxnID": "AE58AE3792E53657BF5AE7C7B1A7ED32E520E6B70043211203B4F748D76789F1",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "ED8EA8C2531782F3455F9B5E9FF32E99CAE15DDFB3B10A0661BE8E17E2C15151",
+                "PreviousTxnID": "8753D55104EF3DC164ECCD1C932B9DAD2D9B2037917F37D5F0F5164876A580DE",
+                "PreviousTxnLgrSeq": 90156039
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-4207082.687641208"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rM19JiFRZwGvkmvA2DpUeoRV9kp4wNYCGn",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F18BA5D9C5ABED0982A7D2B4AEA3D87EE8FC681499F24F185312F5AA5781A996",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-4207082.687636538"
+                  }
+                },
+                "PreviousTxnID": "369064C9A5A37E7B470F8B10F63B1C067C01291BEEF4BE0D9C8ED2C8A490AB8B",
+                "PreviousTxnLgrSeq": 90156039
+              }
+            }
+          ],
+          "TransactionIndex": 33,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rpx9JThQ2y37FaGeeJP7PXDUVEXY3PHZSC",
+        "Fee": "15",
+        "NFTokenOffers": [
+          "51F31D6266241D8A67DE088CBBF2AFAF8AF35C6C99BBB483945581D7F6642C86"
+        ],
+        "Sequence": 76084006,
+        "SigningPubKey": "03B8C234E0598BC26D8A3E1BFF53EB252EC0F15EA6800E4D85AA5D7CD15D76B01E",
+        "SourceTag": 101102979,
+        "TransactionType": "NFTokenCancelOffer",
+        "TxnSignature": "3045022100C43544E569BFB92E602F7CB6AEF464CFCADCE29F19DA11D5C37E61A99500D8CC022050DEB24A1EB85812D09F27A432A0937EF331112DEB86F67027AD7F20E016BFB7",
+        "hash": "69EE0CD683EFD467BE50DFB70647CB076E00B9E566BAC52C973B5F8568AF4384",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "r9PubaiT8WALE62hoNeMgwnYzgLcnZzwYj",
+                  "RootIndex": "0BD1C7ACD828461CB5583F441910572EDE8A7DA3A5C6C809D967938B1EAEBC0E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0BD1C7ACD828461CB5583F441910572EDE8A7DA3A5C6C809D967938B1EAEBC0E"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Amount": "5000000",
+                  "Destination": "rpx9JThQ2y37FaGeeJP7PXDUVEXY3PHZSC",
+                  "Expiration": 777952618,
+                  "Flags": 0,
+                  "NFTokenID": "00080BB83A93B057906C2429C5D33080BFF9B1920A3BEF8EF8966DA60000010C",
+                  "NFTokenOfferNode": "0",
+                  "Owner": "r9PubaiT8WALE62hoNeMgwnYzgLcnZzwYj",
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "30D0BE00464877A201E7A4741D0E6DE5AEA83F4C5F28CCDCD8B390105A197FDF",
+                  "PreviousTxnLgrSeq": 90152782
+                },
+                "LedgerEntryType": "NFTokenOffer",
+                "LedgerIndex": "51F31D6266241D8A67DE088CBBF2AFAF8AF35C6C99BBB483945581D7F6642C86"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpx9JThQ2y37FaGeeJP7PXDUVEXY3PHZSC",
+                  "Balance": "87808255320",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 76084007
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "587E28972F3B63D2260C0671E59593EE6C4D27AB857D1AF230F5CAA959BB3EAC",
+                "PreviousFields": {
+                  "Balance": "87808255335",
+                  "Sequence": 76084006
+                },
+                "PreviousTxnID": "DFCE6A87E0A55155EFE36651A90D1FDCEC965559C9CF2982DB81C57BA4D3E19C",
+                "PreviousTxnLgrSeq": 90156049
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Flags": 1,
+                  "NFTokenID": "00080BB83A93B057906C2429C5D33080BFF9B1920A3BEF8EF8966DA60000010C",
+                  "RootIndex": "715BCF1731634FD6F58106FADFF9C438CA66A1D8C24B8419B90EB1B2582E5038"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "715BCF1731634FD6F58106FADFF9C438CA66A1D8C24B8419B90EB1B2582E5038"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r9PubaiT8WALE62hoNeMgwnYzgLcnZzwYj",
+                  "Balance": "74365052",
+                  "Flags": 0,
+                  "OwnerCount": 12,
+                  "Sequence": 78890836
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "909A9073933AC5777AEAF5DB0774F0BEE4EAE08845A771C3CDE0E8F2A37CD8BD",
+                "PreviousFields": {
+                  "OwnerCount": 13
+                },
+                "PreviousTxnID": "7196DC806C2F4263AF23035D9E670998738E4F03E1FE31B55E73198B0B6EFA1A",
+                "PreviousTxnLgrSeq": 90155330
+              }
+            }
+          ],
+          "TransactionIndex": 16,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 90156062,
+        "OfferSequence": 148592493,
+        "Sequence": 148592503,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": "33794000000",
+        "TakerPays": {
+          "currency": "5553444300000000000000000000000000000000",
+          "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+          "value": "20294.31082"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304402201D06C4B7B19A3AB790EB14829A45D9DAB7F6C8D1F210352AE153B7E101C1ED7602206D9DDEE54354350BA2467CB39BA933CAD99E1DE835C22395810C1572F9A073AC",
+        "hash": "6A12B76A43CEBAB082B1B9930FD3978BF54FA3EFA5159B296B8BAF44EFF0167F",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "33DFFDF31565C801C27B84E5A0202D944687663C0BDCD0144E155626FF20A800",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "D24ACED31607399B4872682F7C0DC0FC199F8B3E0A181073842E9390D11E8093",
+                  "PreviousTxnLgrSeq": 90156058,
+                  "Sequence": 148592493,
+                  "TakerGets": "33794000000",
+                  "TakerPays": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "20295.66258"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "0914DB1077CD309AB146A5650A1B9607EE11398D3514AA1806E6960916C8E2E1"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "33894335241",
+                  "Flags": 0,
+                  "OwnerCount": 15,
+                  "Sequence": 148592504
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "33894335261",
+                  "Sequence": 148592503
+                },
+                "PreviousTxnID": "319C605A90C4FDBADCDD2E31A320B44F6CDA2D402EE9663796DF8A48AAEF33D6",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "33DFFDF31565C801C27B84E5A0202D944687663C0BDCD0144E1555C9DD450800",
+                "NewFields": {
+                  "ExchangeRate": "4e1555c9dd450800",
+                  "RootIndex": "33DFFDF31565C801C27B84E5A0202D944687663C0BDCD0144E1555C9DD450800",
+                  "TakerPaysCurrency": "5553444300000000000000000000000000000000",
+                  "TakerPaysIssuer": "06AA7798F7A8FA6914CC1E82C556E5B0A0CCB9E3"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4e155626ff20a800",
+                  "Flags": 0,
+                  "RootIndex": "33DFFDF31565C801C27B84E5A0202D944687663C0BDCD0144E155626FF20A800",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "5553444300000000000000000000000000000000",
+                  "TakerPaysIssuer": "06AA7798F7A8FA6914CC1E82C556E5B0A0CCB9E3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "33DFFDF31565C801C27B84E5A0202D944687663C0BDCD0144E155626FF20A800"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "779997C5832123D4632513AA999CC2AB0B4AC987C6435BA7D3173ACD8FD76709",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "33DFFDF31565C801C27B84E5A0202D944687663C0BDCD0144E1555C9DD450800",
+                  "Sequence": 148592503,
+                  "TakerGets": "33794000000",
+                  "TakerPays": {
+                    "currency": "5553444300000000000000000000000000000000",
+                    "issuer": "rcEGREd8NmkKRE8GE424sksyt1tJVFZwu",
+                    "value": "20294.31082"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 51,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 90156061,
+        "OfferSequence": 148592488,
+        "Sequence": 148592498,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "111100.23"
+        },
+        "TakerPays": "200000000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3044022016DB191499CEE3C3B096711714DE44A56CE887DA7B85D249B9DD01BCD109FBFA02204A92678ACC95F96FECE01C98164F782D5054F721563D778E1AAEFC69BC8C9193",
+        "hash": "73788695B77933702ED53977A1A5016B93D71C0E42E675C190DC38F95478E5AE",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "33894335341",
+                  "Flags": 0,
+                  "OwnerCount": 15,
+                  "Sequence": 148592499
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "33894335361",
+                  "Sequence": 148592498
+                },
+                "PreviousTxnID": "DC6E1BADB49C694C1C3D8E1D25E611A44D26F67B38FF9BD76AE84467B15CC74F",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5B06653E3482B666",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "1C5DE7E50F7FAA5F34E213FBC8D0254F050EF82D10D71ED21B709D89A6DEE3CA",
+                  "PreviousTxnLgrSeq": 90156057,
+                  "Sequence": 148592488,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "111100.76"
+                  },
+                  "TakerPays": "200000000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "396E0949E5F4BC559CA3EB0DFE03BD5A846E3B6569DCD280E16C526D352ABDA4"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "D810334B7365F065236A066CFD949B18E71A190F5FE904B7B586A61150DCB0E3",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5B066540345FB6CC",
+                  "Sequence": 148592498,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "111100.23"
+                  },
+                  "TakerPays": "200000000000"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5b06653e3482b666",
+                  "Flags": 0,
+                  "RootIndex": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5B06653E3482B666",
+                  "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+                  "TakerGetsIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5B06653E3482B666"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5B066540345FB6CC",
+                "NewFields": {
+                  "ExchangeRate": "5b066540345fb6cc",
+                  "RootIndex": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5B066540345FB6CC",
+                  "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+                  "TakerGetsIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 46,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rHvysQt7ho5XSxXfumPYFeHVQSAYj6mFSg",
+        "Amount": "89",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1030,
+        "Fee": "10",
+        "Sequence": 89530399,
+        "SigningPubKey": "ED8ED516D81FA775E69B8459B0DB9A4A3E4B56859BF12FA2F42F1CEB75F8528F79",
+        "TransactionType": "Payment",
+        "TxnSignature": "B7C32C05F53D33A1BC84E991F886B194D43C19AEEF3F2A82A69CC2BEC3F22B0267A36398836CE559E72E996C443BDB890CE6F5AB5EC7CEB2A97491A217038202",
+        "hash": "74024CA8712093B48EE1F96529BECA9875D1095006F159A414AEF6B7536D0150",
+        "DeliverMax": "89",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rHvysQt7ho5XSxXfumPYFeHVQSAYj6mFSg",
+                  "Balance": "54339421",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89530400
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2B99B4D2A7CE5464A6071CCB038F8FAA5F352543D2DFBB86B731271404862BDC",
+                "PreviousFields": {
+                  "Balance": "54339520",
+                  "Sequence": 89530399
+                },
+                "PreviousTxnID": "9F7AA41AEA1211ACB727052486491AFFCA594685E1151DCEA43F56B6A133F0F3",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "188399092",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "188399003"
+                },
+                "PreviousTxnID": "9F7AA41AEA1211ACB727052486491AFFCA594685E1151DCEA43F56B6A133F0F3",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 55,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "89"
+        }
+      },
+      {
+        "Account": "rrsVFfD7FBbxV5o9wsEX5KeyCzxVW1gQRh",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 90156077,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7B226D6F64756C65223A2258574D2041737369737465642054726164696E67222C22616363657373223A2258574D204E4654204469616D6F6E64222C2276657273696F6E223A2276302E352E302062657461222C227374726174656779223A224261736963227D"
+            }
+          }
+        ],
+        "Sequence": 77938652,
+        "SigningPubKey": "ED1DEFDBA32B4575026B040299AA59E27CE027DF664D7930508510ADA775CCE8AE",
+        "TakerGets": {
+          "currency": "5852646F67650000000000000000000000000000",
+          "issuer": "rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA",
+          "value": "404887.34"
+        },
+        "TakerPays": "10000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "5C07D48E16C40E4D32724DB1D4066A9880927CE694CCDBE711253EBE2F309633F0B9CE232FB398C7FB8317018D3E195AAEF9CC554D73883C55A3E63318BFD502",
+        "hash": "818BBAC9E596204E6B04B415B8F55D07DF2A4D30148689BDD3B4158EF2EBB263",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "6A0D23B7C4FE2070DC08A14E0A9F4CC44C604F171C58CDBCCD0A890902744914",
+                "NewFields": {
+                  "Account": "rrsVFfD7FBbxV5o9wsEX5KeyCzxVW1gQRh",
+                  "BookDirectory": "E52309B0DEF00F10EADE6630F4738B18DF92D5221944F70F5608C64A710ADB0C",
+                  "OwnerNode": "1",
+                  "Sequence": 77938652,
+                  "TakerGets": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA",
+                    "value": "404887.34"
+                  },
+                  "TakerPays": "10000000"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rrsVFfD7FBbxV5o9wsEX5KeyCzxVW1gQRh",
+                  "RootIndex": "9F9309201C8741EB9C26CB9A7EACCB29E5CCFDA44DCAADBAA230C3990D417FCF"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "8D391D73E35018389D35AA8626BA709E8E521ADBA03156450D1F9271EF3F2EA5"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "E52309B0DEF00F10EADE6630F4738B18DF92D5221944F70F5608C64A710ADB0C",
+                "NewFields": {
+                  "ExchangeRate": "5608c64a710adb0c",
+                  "RootIndex": "E52309B0DEF00F10EADE6630F4738B18DF92D5221944F70F5608C64A710ADB0C",
+                  "TakerGetsCurrency": "5852646F67650000000000000000000000000000",
+                  "TakerGetsIssuer": "D98817F9CF03AE03FC31F43C8DCEEADF277D5EE7"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rrsVFfD7FBbxV5o9wsEX5KeyCzxVW1gQRh",
+                  "Balance": "242071893",
+                  "Flags": 0,
+                  "OwnerCount": 43,
+                  "Sequence": 77938653
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "F6A1A63EFDB065C0D4143A34072CD6F65FBEAD0526C769BF91D37F7053BBFA86",
+                "PreviousFields": {
+                  "Balance": "242071908",
+                  "OwnerCount": 42,
+                  "Sequence": 77938652
+                },
+                "PreviousTxnID": "2E88FEF40011D1E1544CD5F3A27C28AB2CC6A2116F8C764BFB984BA8597AFD62",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 13,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rsZQZkL581xM2RYt1qWrehdbVqsHWbhNH5",
+        "Amount": "87",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1000201,
+        "Fee": "10",
+        "Sequence": 89589892,
+        "SigningPubKey": "EDCA5D8717E1A5F40EDCB31C684414612FB807FF1B185541EBA52A4561BD53E879",
+        "TransactionType": "Payment",
+        "TxnSignature": "3A68CEA257E259BA64FE552065960952B257C2494B57D3461E593D54D2128E5FD83847E4CD23CAABD25D99B6800AB7492BB8DCBF0188AF1FB4E23785A5FB1405",
+        "hash": "82F6B50B48D8988138DD941756E65AFABF83FE10E8C788E0228F0F99E988E27D",
+        "DeliverMax": "87",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "188398826",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "188398739"
+                },
+                "PreviousTxnID": "03823BE4331FED41C2F8F818ADCC85CD42CD4BD71B61A23427F92981E891CAA1",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rsZQZkL581xM2RYt1qWrehdbVqsHWbhNH5",
+                  "Balance": "54285390",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89589893
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AA8E8C160248CE9F02CF503EA1160798C84012D7E31D62F45D12F9305F8A3E81",
+                "PreviousFields": {
+                  "Balance": "54285487",
+                  "Sequence": 89589892
+                },
+                "PreviousTxnID": "9D032E336D5756D1F6ECF1531CDF6E4C45B2504F543A68BFA8AC085CDCFBC506",
+                "PreviousTxnLgrSeq": 90156053
+              }
+            }
+          ],
+          "TransactionIndex": 15,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "87"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994734,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "XNX",
+          "issuer": "raDDJZ73m7ouH4CSTdiFS4fJ6GWctt2qVF",
+          "value": "0.00233697307412267"
+        },
+        "TakerPays": {
+          "currency": "434F524500000000000000000000000000000000",
+          "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+          "value": "0.000006544354078948377"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "B184920FD6F87978F14140D0FA83821C0BE1632608CA4F5BD21C89A109A5397C4625B755E4F985A0A9E4DBD4C923FD54639D5141AE29DA040F6626A41803EF01",
+        "hash": "8C165A484298A7B9696971C77522401F0BD094377E178D9D29A5F63A1F3A64C9",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1E1ADBD847116F2C0DF91CCB7165719E2285397499705C85414A745A3AC80F43",
+                "PreviousTxnID": "09681403B39B084C58D0BE6FCFD8B25B1C7831AEB2072E29C826556012536B53",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-190.51581720233"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "raDkBgSwPHwvEQpWjo2mAFDZkADnqX8ohr",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "e7b"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "30A9F05D9A98F121F43A4ADC2823A22DC7A14516F3E2D2809F9EF0AAA064D099",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-190.5203588969104"
+                  }
+                },
+                "PreviousTxnID": "8DF7221F03CD4A340A4907078D88997173F1D5E491A8EB9A7657503B4E4E29FF",
+                "PreviousTxnLgrSeq": 90156042
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XNX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1048576,
+                  "HighLimit": {
+                    "currency": "XNX",
+                    "issuer": "raDDJZ73m7ouH4CSTdiFS4fJ6GWctt2qVF",
+                    "value": "0"
+                  },
+                  "HighNode": "5",
+                  "LowLimit": {
+                    "currency": "XNX",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c",
+                  "PreviousTxnID": "38222CEA3F9F228A4AE5EC982059DB6B04953A3AA7826F3C78129F58ECA114A3",
+                  "PreviousTxnLgrSeq": 90156059
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "73010F77D1AD803C5E44FBF9DCCCF54D7F3CBB9D6C410620621D31509AD5AB22",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XNX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.001622351213880319"
+                  },
+                  "Flags": 1114112
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A075663C31DE0712528EBA515397D67155E7B5A983A6EC5281E225E3B1F83580",
+                "PreviousTxnID": "38222CEA3F9F228A4AE5EC982059DB6B04953A3AA7826F3C78129F58ECA114A3",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "ea0",
+                  "Owner": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                  "RootIndex": "5DD87298A566F5805C113F1E887578A4AF0123F117D08E74F3A0698F1AD100ED"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B2FBE6A2AD61B0BBC3C6EECCAD32590841ADA8E5AE4811728B29F85AA95A747F"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "4",
+                  "Owner": "raDDJZ73m7ouH4CSTdiFS4fJ6GWctt2qVF",
+                  "RootIndex": "714567716BE0B579DCED5F1669FFD2668CECBB600605E15FCA13845881095102"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B49E71C2BA5F052E1C2C2E10F1185385794455A6DF41CDC12F23995F6942AC40"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XNX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-67.35395403660452"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "XNX",
+                    "issuer": "raDkBgSwPHwvEQpWjo2mAFDZkADnqX8ohr",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "XNX",
+                    "issuer": "raDDJZ73m7ouH4CSTdiFS4fJ6GWctt2qVF",
+                    "value": "0"
+                  },
+                  "LowNode": "2"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B57B9883C28BFC319DAD045A0A97835A1F292EB59EAEDE5D46214E6D728E799B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XNX",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-67.35233184760954"
+                  }
+                },
+                "PreviousTxnID": "8DF7221F03CD4A340A4907078D88997173F1D5E491A8EB9A7657503B4E4E29FF",
+                "PreviousTxnLgrSeq": 90156042
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "8C165A484298A7B9696971C77522401F0BD094377E178D9D29A5F63A1F3A64C9",
+                  "Balance": "1467511509",
+                  "Flags": 0,
+                  "OwnerCount": 50,
+                  "Sequence": 12994735
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "38222CEA3F9F228A4AE5EC982059DB6B04953A3AA7826F3C78129F58ECA114A3",
+                  "Balance": "1467511519",
+                  "Sequence": 12994734
+                },
+                "PreviousTxnID": "38222CEA3F9F228A4AE5EC982059DB6B04953A3AA7826F3C78129F58ECA114A3",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F7649E56EB86403211BE414801DA87DD2B143701E72EE2553D87DD748E698848",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0045416945804255"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "ea1"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 22,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rwjyDXa3YsdZUJcJSDkyRRvt1qwPfxVNKY",
+        "Amount": "1",
+        "Destination": "rJn2zAPdFA193sixJwuFixRkYDUtx3apQh",
+        "DestinationTag": 500311910,
+        "Fee": "25",
+        "Flags": 2147483648,
+        "LastLedgerSequence": 90156072,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "5768656E20796F75207365652074686973206D6573736167652C207765206861766520616C7265616479206265656E206172726573746564206F72207475726E6564206F757273656C76657320696E2E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "546F20616C6C20476174654875622075736572732C"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "476174654875622069732061207368616D656C6573732063686561742E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "496E20323031372C2047617465487562206C6F7374207E354D2055534420637573746F6D6572206173736574732062656361757365207468657920646964206E6F7420756E6465727374616E64205061727469616C205061796D656E742066656174757265"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "496E20323032322C2077652073656E74207E31334D205553442061737365747320746F204761746548756220776974682074686569722070726F6D697365733A"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "312E206E6F206C6F6E6765722074616B65206C6567616C20616374696F6E20616761696E7374207573"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "322E206E6F206675727468657220636C61696D7320666F7220636F6D70656E736174696F6E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "332E206B65657020354D2055534420616E64206169722064726F7020746865206C6566742061737365747320746F20616C6C2047617465487562207573657273"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "342E20646F206E6F74207368617265206F757220696E666F726D6174696F6E20776974682074686972642070617274696573"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "352E206D616B6520616E20616E6E6F756E63656D656E7420726567617264696E67207468652061626F76652061677265656D656E7473"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "77652073656E742074686520636F696E732C20627574204761746548756220646964206E6F74206B6565702074686569722070726F6D69736573"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "6E6F20616E6E6F756E63656D656E742C206E6F206169722064726F702C20636F6E74696E756520746F20746872656174656E2075732077697468206C6567616C20616374696F6E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "476174654875622061736B20666F72206D6F726520616E64206D6F726520636F696E732E20416E20696E7361746961626C6520626C61636B6D61696C657221"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "57652068617665206E6F206D6F726520636F696E732C2074686520747275746820697320746865206F6E6C79207468696E672077652063616E207368617265"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "54686520747275746820697320746865206F6E6C79207468696E672077652063616E2073686172652E"
+            }
+          },
+          {
+            "Memo": {
+              "MemoData": "54686520747275746820697320746865206F6E6C79207468696E672077652063616E2073686172652E"
+            }
+          }
+        ],
+        "Sequence": 90846091,
+        "SigningPubKey": "03924D5111DD356B7B68E7E68A16848968B8492D812728627A3582572B14C798BF",
+        "TransactionType": "Payment",
+        "TxnSignature": "3044022056568AB4489AA12B70CBE804C0A27EF97509C7AF521F9FD0FB69391EEB93180002206E247E78A11D226C4C08C570F4D2030B7836722D5CE7CE6C2C0679BB96237DC8",
+        "hash": "8F21BBE8C33C0BEDA655B526B00CC610929C2AE68BD9182522AC943C3D396F23",
+        "DeliverMax": "1",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rwjyDXa3YsdZUJcJSDkyRRvt1qwPfxVNKY",
+                  "Balance": "4918228262",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 90846092
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1E70E44C3D201A11890678AC660EAD84642373F8D9B261ADEFA324306792F2B",
+                "PreviousFields": {
+                  "Balance": "4918228288",
+                  "Sequence": 90846091
+                },
+                "PreviousTxnID": "B9662ACCDCE0C2356C04474AB95170E69224841A13F2B94A45EDB349D86C36D2",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rJn2zAPdFA193sixJwuFixRkYDUtx3apQh",
+                  "Balance": "4369095772823",
+                  "Flags": 131072,
+                  "OwnerCount": 1,
+                  "Sequence": 117149
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C19B36F6B6F2EEC9F4E2AF875E533596503F4541DBA570F06B26904FDBBE9C52",
+                "PreviousFields": {
+                  "Balance": "4369095772822"
+                },
+                "PreviousTxnID": "B9662ACCDCE0C2356C04474AB95170E69224841A13F2B94A45EDB349D86C36D2",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            }
+          ],
+          "TransactionIndex": 42,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "1"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 7423369,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "5852646F67650000000000000000000000000000",
+          "issuer": "rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA",
+          "value": "0.00005980159239652893"
+        },
+        "TakerPays": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "1088068231418661e-28"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "57DD8511C4AF41587CE299BEE371B597F8D0F30C4A5B02D9B3D8FE31EA3612CC6B74FF449666A537273FB9F4ADE24CAEDB22BF1536570ED1639EEC117F4E3D00",
+        "hash": "90BE0BEFDCEC5C821E61D2710A3A3266407D90129B6C23D0123AAAD5DF638D26",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1184347.380904705"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA",
+                    "value": "0"
+                  },
+                  "HighNode": "9e2",
+                  "LowLimit": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rfY5yj9Sn2qvUmKaQKNr6ohtsgcQeznUzY",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "431036568798177561F250EFF71228616207FCA59D0281B378CFE09961A63B1E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1184347.380844903"
+                  }
+                },
+                "PreviousTxnID": "81A435E00151AD03C4E8C935EF8407E84E4BD17FABE05A4441CF0D29DF8AEB6B",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.376267977891884"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "9"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "68062CBD2811E4D5FB502D7C86E4BB04DA46A2AAE9BE2B400045A57E3B5DBA8B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.376267977783104"
+                  }
+                },
+                "PreviousTxnID": "FEEA3504938B34D4A28F8BBA69DE3C7B68E11264B18FB9658B1BBFAFC1DE63CA",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "353292.1535878733"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rLqUC2eCPohYvJCEBJ77eCCqVL2uEiczjA",
+                    "value": "0"
+                  },
+                  "HighNode": "9f0",
+                  "LowLimit": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "0"
+                  },
+                  "LowNode": "c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "9213259D89AA378C0C89F4BA32CD40186B517B11960B2FDB9B654422562ED630",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5852646F67650000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "353292.1536476749"
+                  }
+                },
+                "PreviousTxnID": "0B96B87375B27786DDD774523057F6E1401B7B9B1D47C67DA09937D466A51FD1",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "2.15490273912807"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "dc",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rfY5yj9Sn2qvUmKaQKNr6ohtsgcQeznUzY",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B51D2DFA43B87FEBC31C0CCA0746EAA7A63EB4DC5A52D33615B528C14F98F51D",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "2.15490273923685"
+                  }
+                },
+                "PreviousTxnID": "81A435E00151AD03C4E8C935EF8407E84E4BD17FABE05A4441CF0D29DF8AEB6B",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "90BE0BEFDCEC5C821E61D2710A3A3266407D90129B6C23D0123AAAD5DF638D26",
+                  "Balance": "420152578",
+                  "Flags": 0,
+                  "OwnerCount": 143,
+                  "Sequence": 7423370
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "0B96B87375B27786DDD774523057F6E1401B7B9B1D47C67DA09937D466A51FD1",
+                  "Balance": "420152588",
+                  "Sequence": 7423369
+                },
+                "PreviousTxnID": "0B96B87375B27786DDD774523057F6E1401B7B9B1D47C67DA09937D466A51FD1",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 11,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rN9jYGtDeXmQcuxxGvEtrUpdA9K4KCSAtR",
+        "Amount": "44",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1000004,
+        "Fee": "10",
+        "Sequence": 89526549,
+        "SigningPubKey": "ED64F78480510998FCB04C133423C6F90672CE5A3FDE386E3F1407317D789516F9",
+        "TransactionType": "Payment",
+        "TxnSignature": "D7604F9F4C0E9F67DB614199F149B92857D51B2FD14AD3DE2D4DE52051803E8318D76DC4361E629FE8C9C729C0A37B6C3833B4846E70A5E6C861797803966B06",
+        "hash": "95B6CFB7DB2272337AD4221A8B96ECB56CFCCF26FA520A23918CCEE8362BB64D",
+        "DeliverMax": "44",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rN9jYGtDeXmQcuxxGvEtrUpdA9K4KCSAtR",
+                  "Balance": "54240698",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89526550
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "4113D2E6FE6D898B6D19410067C6BECEA9BCB4F0AF7540FBC81D16226D7CF0CD",
+                "PreviousFields": {
+                  "Balance": "54240752",
+                  "Sequence": 89526549
+                },
+                "PreviousTxnID": "DF9309970CA2256557F02AD5AB0EBFBE69D8961FCF06D644445CD7D93F452CD8",
+                "PreviousTxnLgrSeq": 90156054
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "188398958",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "188398914"
+                },
+                "PreviousTxnID": "E4F5062B7A0858886F0B702CFBBA5FD46179E3D474CA3DACE9AD14FFD977139E",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 52,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "44"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994741,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "5341564500000000000000000000000000000000",
+          "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+          "value": "0.00000009057687267308036"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.0000000007104045872543673"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "4F4AAA7964E235F1ACD3761CC22868CFFCA503583D48954C26CC3F15E650621AD67B1962AFC06AAEF534460F8C4A429A13C7E66EC77A8FB35AAD94BA363ED00B",
+        "hash": "98E0F956171CEEBA795DC91E59163B77952A65DE16956F926A68C83C5569C4DF",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1048576,
+                  "HighLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+                    "value": "0"
+                  },
+                  "HighNode": "255",
+                  "LowLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c",
+                  "PreviousTxnID": "F2DA37ADB80192A93F683CA24EBFB1F1B6438939E2A33F84054232922BE20FD2",
+                  "PreviousTxnLgrSeq": 90156059
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "9DDD00FD772E18D0AFEF796BB21D2A5D37E3D1505DBDE727A28E700D220E1893",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.00000006286958084779931"
+                  },
+                  "Flags": 1114112
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-7.208444407228675"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "r3o25dZscweKkkh1WxjXLZ1yUW4itQ5E6r",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+                    "value": "0"
+                  },
+                  "LowNode": "254"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "BD923737FA1FA0BCC2C07C6A72681C675E1A5054BA22875105619B5EEAE82295",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-7.208444344359094"
+                  }
+                },
+                "PreviousTxnID": "211A97EFC1E1E92211FC8C0AED6AF83C40DD2D3D34465FA30E42856510F41896",
+                "PreviousTxnLgrSeq": 90156036
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BEFFFC911BD864EE253422C851B3DCD187CF2BF5DAD31DC7F3405B7BFDA84F61",
+                "PreviousTxnID": "F2DA37ADB80192A93F683CA24EBFB1F1B6438939E2A33F84054232922BE20FD2",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "254",
+                  "Owner": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+                  "RootIndex": "CDA3339900126079FDB4065323F527566FE5ED265D38D016563D51C1233AC382"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "BF8B60D0093FAF9AB84684FD4E6920F7F32910E19593CCE03FA291A0F734B93E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "98E0F956171CEEBA795DC91E59163B77952A65DE16956F926A68C83C5569C4DF",
+                  "Balance": "1467511932",
+                  "Flags": 0,
+                  "OwnerCount": 50,
+                  "Sequence": 12994742
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "F2DA37ADB80192A93F683CA24EBFB1F1B6438939E2A33F84054232922BE20FD2",
+                  "Balance": "1467511942",
+                  "OwnerCount": 51,
+                  "Sequence": 12994741
+                },
+                "PreviousTxnID": "F2DA37ADB80192A93F683CA24EBFB1F1B6438939E2A33F84054232922BE20FD2",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0000006640573587981671"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "c00"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "C6172C3C124263E8824878551FF6376348439DDB4492A13DB6B5BF7E30CCC208",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0000001710860908762917"
+                  }
+                },
+                "PreviousTxnID": "211A97EFC1E1E92211FC8C0AED6AF83C40DD2D3D34465FA30E42856510F41896",
+                "PreviousTxnLgrSeq": 90156036
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-56.70686847566747"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "r3o25dZscweKkkh1WxjXLZ1yUW4itQ5E6r",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "be6"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D76538A732D9E3D87753D16FF280F7836AF5B796D263A9D038705BA95E6A8BF8",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-56.70686896863874"
+                  }
+                },
+                "PreviousTxnID": "211A97EFC1E1E92211FC8C0AED6AF83C40DD2D3D34465FA30E42856510F41896",
+                "PreviousTxnLgrSeq": 90156036
+              }
+            }
+          ],
+          "TransactionIndex": 29,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rHqm6iTCWA8BDqEcAEp6QDgp9wvJ6WNjsc",
+        "Amount": "45",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 40000134,
+        "Fee": "10",
+        "Sequence": 89587987,
+        "SigningPubKey": "ED10ECEA690F7932813DB12BC6DA4C219EB57EEB225A360D9809AFCAA3767F93FD",
+        "TransactionType": "Payment",
+        "TxnSignature": "7BFC85A9BB67960285E3CCF79F2F349F2E6728BA9F9BE7A90538B2A1A25E82E8FA04EE01CAF5CF4135B866261BB7B7DEBBB6AC7CE629A105FB26C6CA4FC8330D",
+        "hash": "99EEBAF1E2F4A106B72719294DAE12FE19B8EB76EA5C8A137E60BE4254F2FDE6",
+        "DeliverMax": "45",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "188399137",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "188399092"
+                },
+                "PreviousTxnID": "74024CA8712093B48EE1F96529BECA9875D1095006F159A414AEF6B7536D0150",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rHqm6iTCWA8BDqEcAEp6QDgp9wvJ6WNjsc",
+                  "Balance": "54323087",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89587988
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "FDB311E993E0A2685F0A896873E69404FB5075D835411A245141240331761912",
+                "PreviousFields": {
+                  "Balance": "54323142",
+                  "Sequence": 89587987
+                },
+                "PreviousTxnID": "C613D4D4990563C03E3C82CC410E5487CD59DB9FEBADA25CE106EF651665185D",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 57,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "45"
+        }
+      },
+      {
+        "Account": "rHvysQt7ho5XSxXfumPYFeHVQSAYj6mFSg",
+        "Amount": "45",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 3000135,
+        "Fee": "10",
+        "Sequence": 89530398,
+        "SigningPubKey": "ED8ED516D81FA775E69B8459B0DB9A4A3E4B56859BF12FA2F42F1CEB75F8528F79",
+        "TransactionType": "Payment",
+        "TxnSignature": "6B6C80DA21F6A8CEA3E9C4CB6D0BEDDCC63F459B4690F8354E30CB95A5DB344CB52D219CAB0CA772B0883AB1A18AD6CFBDE3C0026A8C4696903796F9F80B9D07",
+        "hash": "9F7AA41AEA1211ACB727052486491AFFCA594685E1151DCEA43F56B6A133F0F3",
+        "DeliverMax": "45",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rHvysQt7ho5XSxXfumPYFeHVQSAYj6mFSg",
+                  "Balance": "54339520",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89530399
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2B99B4D2A7CE5464A6071CCB038F8FAA5F352543D2DFBB86B731271404862BDC",
+                "PreviousFields": {
+                  "Balance": "54339575",
+                  "Sequence": 89530398
+                },
+                "PreviousTxnID": "498A8BF5E822716903F2FBAF83F15761D3237363016CA089EE32D5D92991D5ED",
+                "PreviousTxnLgrSeq": 90156053
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "188399003",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "188398958"
+                },
+                "PreviousTxnID": "95B6CFB7DB2272337AD4221A8B96ECB56CFCCF26FA520A23918CCEE8362BB64D",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 54,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "45"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994736,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": "1",
+        "TakerPays": {
+          "currency": "OVO",
+          "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+          "value": "0.00004546877250602696"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "EEA7F9527F5E7482DF4E8DDEB9C7B09FA23359615DF2247498BF4F4B27452B9809A62961B9C3968ECE61DA9E021DC1C431F520695F7E0F1154C435E950F6430A",
+        "hash": "A398CE8F995BFC2D5FE33E76CBA8D66BB0E0EBF87FFF3C29493F05E507DBC3F7",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2749708BCBEA384C6EAABA392D5EBB9377BD32C1854FCF77C2E509806024126E",
+                "PreviousTxnID": "F637FC74490DEEF78FA68D14B6147CC26B619000C27159DCF0E5D59B8528D3AB",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "8EB8D4D2D6968FF99D8DD3993C7E77BE09D0F25951E7FA67077494C366602650",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.09050067"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "OVO",
+                    "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+                    "value": "0"
+                  },
+                  "HighNode": "33f",
+                  "LowLimit": {
+                    "currency": "OVO",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "33e",
+                  "Owner": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+                  "RootIndex": "A31C69C35689AA4FB1A2F162BD16EA77902F1421D91BBC3F6217457577DA121D"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "A9E494A4BA97F4BBD9D38393740E0E7723DF1DCCEE4DD463FCA25214D61EC616"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-31548814.70171337"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "OVO",
+                    "issuer": "rGkd4qqTnKpQhCP1GuvUzgVv3sxXznAFi3",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "OVO",
+                    "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+                    "value": "0"
+                  },
+                  "LowNode": "335"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B9A678AD1F297DC53CD4FF27225CD34EEA15F07A5FEBC6317D3DB00B50DECDF8",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-31548814.79221404"
+                  }
+                },
+                "PreviousTxnID": "3EC28B8455408984ABC377BDDF11CE8EDBB152ECD98B587613C7544CC5E5CA1A",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "A398CE8F995BFC2D5FE33E76CBA8D66BB0E0EBF87FFF3C29493F05E507DBC3F7",
+                  "Balance": "1467511982",
+                  "Flags": 0,
+                  "OwnerCount": 50,
+                  "Sequence": 12994737
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "021EA6C5BE9AE7209B23BF4F39BB738FFA45EB4B1CD6EAFFCFFB471FEF11AC10",
+                  "Balance": "1467511993",
+                  "OwnerCount": 49,
+                  "Sequence": 12994736
+                },
+                "PreviousTxnID": "021EA6C5BE9AE7209B23BF4F39BB738FFA45EB4B1CD6EAFFCFFB471FEF11AC10",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "9E0D139A1F5A8B0BCC039787A9FEAFB6DDD4DDE085E1F01E2D28781FB25B939E",
+                  "Account": "rGkd4qqTnKpQhCP1GuvUzgVv3sxXznAFi3",
+                  "Balance": "348603126",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 87418969
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "FA099132586A5FE1429E3ED9DDCF72BADC388696080110748B76F340B05D21D8",
+                "PreviousFields": {
+                  "Balance": "348603125"
+                },
+                "PreviousTxnID": "3EC28B8455408984ABC377BDDF11CE8EDBB152ECD98B587613C7544CC5E5CA1A",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            }
+          ],
+          "TransactionIndex": 24,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994744,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "XRL",
+          "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+          "value": "0.000001171106924971643"
+        },
+        "TakerPays": {
+          "currency": "NET",
+          "issuer": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+          "value": "0.000000004670783693034965"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "DAF2C0AA2760DC089CD51842E6C33ED83B0000B4F0C50FF56102AF84CB962994AE27B0920D9F4D8829F563902F231F932116A29128FB4C77D0D02B08B4636C01",
+        "hash": "AE58AE3792E53657BF5AE7C7B1A7ED32E520E6B70043211203B4F748D76789F1",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "368163F2B47E0164381E9A12A6ACA1A020B269224FC4A81F0385FCD03DEDB8D4",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000004669625369596813"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+                    "value": "0"
+                  },
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A78BDBB60A871C387C2698A23483A6F44105D6994E613389A513A6BD2C81869B",
+                "PreviousTxnID": "369064C9A5A37E7B470F8B10F63B1C067C01291BEEF4BE0D9C8ED2C8A490AB8B",
+                "PreviousTxnLgrSeq": 90156039
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+                  "RootIndex": "B8262C6AD2FDF8D4F8CE480B0E9E06A37FB20F516C178A1D98FC0212A5E2EEDD"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B8262C6AD2FDF8D4F8CE480B0E9E06A37FB20F516C178A1D98FC0212A5E2EEDD"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "AE58AE3792E53657BF5AE7C7B1A7ED32E520E6B70043211203B4F748D76789F1",
+                  "Balance": "1467511902",
+                  "Flags": 0,
+                  "OwnerCount": 50,
+                  "Sequence": 12994745
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "F0374F4F971FCBF13CC4AF5E53ADF5948C4A8EF34A55D0378FC3BFE1EF9D5A2C",
+                  "Balance": "1467511912",
+                  "OwnerCount": 49,
+                  "Sequence": 12994744
+                },
+                "PreviousTxnID": "F0374F4F971FCBF13CC4AF5E53ADF5948C4A8EF34A55D0378FC3BFE1EF9D5A2C",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.501848790207961"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "XRL",
+                    "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "XRL",
+                    "issuer": "rDFNguSG5Z1KDz6GymYrym2GcQADYt1ius",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D696689500FB5E2B25F6FC91A0D5605DBDA2D4E65FF5B130B16B9E999817ABE3",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.501847619101036"
+                  }
+                },
+                "PreviousTxnID": "600A1A439B631D0487BCC68F970A57FDF4B6A4CF4A6EBAD953EA5139E2954565",
+                "PreviousTxnLgrSeq": 90156039
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5811.945287621842"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "XRL",
+                    "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "XRL",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "c4"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "FCF9919AFEE1083CEC8CE802290093F96AECA1B415F9F64C6405E3F960FE56C4",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5811.945288792949"
+                  }
+                },
+                "PreviousTxnID": "F0374F4F971FCBF13CC4AF5E53ADF5948C4A8EF34A55D0378FC3BFE1EF9D5A2C",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-2.001542912352081"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "NET",
+                    "issuer": "rDFNguSG5Z1KDz6GymYrym2GcQADYt1ius",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "NET",
+                    "issuer": "rw9JPiWyakfNhabfgiZypDcLqdwfH2n7W1",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "FE3BCD820D92FF96E3458D3BCD2C5E7E566C641C11B4CF00453CDE13C970E09C",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "NET",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-2.001547581977451"
+                  }
+                },
+                "PreviousTxnID": "600A1A439B631D0487BCC68F970A57FDF4B6A4CF4A6EBAD953EA5139E2954565",
+                "PreviousTxnLgrSeq": 90156039
+              }
+            }
+          ],
+          "TransactionIndex": 32,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rwJYi2kzHj34cbqTie94jWdcc1FTfD4XBL",
+        "Amount": "165690000",
+        "Destination": "rNxp4h8apvRis6mJf9Sh8C6iRxfrDWN7AV",
+        "DestinationTag": 387224129,
+        "Fee": "12",
+        "LastLedgerSequence": 90156067,
+        "Sequence": 80685555,
+        "SigningPubKey": "021172C846E5533766AEB55ADCCFDD6FB720E9B03805478B9326A270FA16808DB0",
+        "TransactionType": "Payment",
+        "TxnSignature": "304402206F319E179D6D62B6A206B9E7FC53E276FEE599F37D956034072C7F0B637FC61F02206A51BF27D8F1CA044F4E020A2A7EF4EB3825B7BB1AC4DABCD1558854E31C73AE",
+        "hash": "B25217BB91258F540B0264525CC744FB49A55B3D9C0FC5DEB417E82A431F876C",
+        "DeliverMax": "165690000",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rNxp4h8apvRis6mJf9Sh8C6iRxfrDWN7AV",
+                  "Balance": "14162935661",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 77292712
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "59EDFBD7E3AA8EF84600C7AABD24DBC8229C19A1FF956C83D6B04390CF7C7E34",
+                "PreviousFields": {
+                  "Balance": "13997245661"
+                },
+                "PreviousTxnID": "100AF7E7D2A05BBF06B04632EDE96E7D572BCCCEB2F9D6805D6E38765C47C4B1",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rwJYi2kzHj34cbqTie94jWdcc1FTfD4XBL",
+                  "Balance": "14000933",
+                  "Flags": 0,
+                  "OwnerCount": 2,
+                  "Sequence": 80685556
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B0D6EBE7380571718205E9ECAB7BBCA35E7F1C4E87862F00FCBAA41754647535",
+                "PreviousFields": {
+                  "Balance": "179690945",
+                  "Sequence": 80685555
+                },
+                "PreviousTxnID": "D7E87898B68D462D6DC92F3251738D14B3E7EC0E5010E9284B1DD1DAC775B363",
+                "PreviousTxnLgrSeq": 90155988
+              }
+            }
+          ],
+          "TransactionIndex": 44,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "165690000"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Amount": "1",
+        "Destination": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 90156060,
+        "SendMax": {
+          "currency": "POZ",
+          "issuer": "rpvbUsHkJ91rGTa9gShUQU6jzLrFBgsVe3",
+          "value": "0.000000000360181825139119"
+        },
+        "Sequence": 12994751,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TransactionType": "Payment",
+        "TxnSignature": "DA8C831CD14F333B9A5EEE0DA9D1CDC4644E397E9EADAD631126B7EC10622BA5535D638F8E97E2083E6E061D321BF05430E8E21C9FD5C5D08326F86B61F18B05",
+        "hash": "B360BE15852950BFC704D83FEF30DA314EA18BA63B6EB31623FCDA4A9F9FCD4A",
+        "DeliverMax": "1",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "POZ",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.00004760885525286186"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "POZ",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "POZ",
+                    "issuer": "rpvbUsHkJ91rGTa9gShUQU6jzLrFBgsVe3",
+                    "value": "0"
+                  },
+                  "LowNode": "10"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "832EF40972BFCC2EF109FDBF2F59A41C7C841248A0BFEA907008B63C4D6EC21E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "POZ",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.000047609215434687"
+                  }
+                },
+                "PreviousTxnID": "39721CE7F5366F98B4870EAB58279D6592871DC533349D9779FD18E295FEA268",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "B360BE15852950BFC704D83FEF30DA314EA18BA63B6EB31623FCDA4A9F9FCD4A",
+                  "Balance": "1467511831",
+                  "Flags": 0,
+                  "OwnerCount": 49,
+                  "Sequence": 12994752
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "39721CE7F5366F98B4870EAB58279D6592871DC533349D9779FD18E295FEA268",
+                  "Balance": "1467511842",
+                  "Sequence": 12994751
+                },
+                "PreviousTxnID": "39721CE7F5366F98B4870EAB58279D6592871DC533349D9779FD18E295FEA268",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "69B8B3133D0760B5B7253924BEDF7FA50EF7E9B3E6DAAAE06D225BF938CB889C",
+                  "Account": "rkXhTduDBANLFXHqEg4obsoCepHVXj3qa",
+                  "Balance": "47516234152",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 89169440
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C91416F2B9A16F71C17FA5EA5CBB426AB046E382FF1D5F67A5CD08DFFB09A442",
+                "PreviousFields": {
+                  "Balance": "47516234151"
+                },
+                "PreviousTxnID": "80695A43309C3FFD4105E487FB295E37FF06A57A9E2B45E08EE221E8DDD147A9",
+                "PreviousTxnLgrSeq": 90155982
+              }
+            }
+          ],
+          "DeliveredAmount": "-1",
+          "TransactionIndex": 39,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "-1"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 7423367,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "5452535259000000000000000000000000000000",
+          "issuer": "rLBnhMjV6ifEHYeV4gaS6jPKerZhQddFxW",
+          "value": "0.0000004186265522595381"
+        },
+        "TakerPays": {
+          "currency": "58464C4F4B490000000000000000000000000000",
+          "issuer": "rUtXeAXonpFpgKubAa7LxcLd7NFep92T1t",
+          "value": "0.02744657183246495"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "C3A246DB08D7ECDC6EFE9EC9205D02C7E6A0B82703D4ABB35597D6A11F08F9B36B0785A21EE11E7419866278CBE729EC6B5C1FF106608C69E4D0C9551806F30E",
+        "hash": "BFB3F0E4D55727984A8ADFE3CCC2A334790094F6AA43643B19BB90F7A10CFEAB",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "17393881.91303726"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rUtXeAXonpFpgKubAa7LxcLd7NFep92T1t",
+                    "value": "0"
+                  },
+                  "HighNode": "983",
+                  "LowLimit": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "0"
+                  },
+                  "LowNode": "a"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "065135AE781A0ADA10F03EFC0CC720C9256FF3C3165FC3892365F5281770D40D",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "17393854.47326859"
+                  }
+                },
+                "PreviousTxnID": "922D9C29442A4BDB5ADB59A3A8A6622326CB02695963A8C2C50D1853DC9E7BED",
+                "PreviousTxnLgrSeq": 90156047
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.2577356350792622"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rLBnhMjV6ifEHYeV4gaS6jPKerZhQddFxW",
+                    "value": "0"
+                  },
+                  "HighNode": "156d",
+                  "LowLimit": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "r95a7Hqi5fJNDMMK68GXh3wewY2zcviyZ5",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "1CA7B4C76098473BCCC5353653D7A489B1C058021679CC315A35EF89E7847386",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.2577352164527099"
+                  }
+                },
+                "PreviousTxnID": "9406A44CB36B6F1EA866E587E4D3FAC97F2CB568C623384903596E9971C1E501",
+                "PreviousTxnLgrSeq": 90156047
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "16906450.64548828"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rUtXeAXonpFpgKubAa7LxcLd7NFep92T1t",
+                    "value": "0"
+                  },
+                  "HighNode": "981",
+                  "LowLimit": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "r95a7Hqi5fJNDMMK68GXh3wewY2zcviyZ5",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "7AF187427FC47AECAEC20A845A0A6921407D098FEAE0065666BDD2BFAA867195",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58464C4F4B490000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "16906478.08525695"
+                  }
+                },
+                "PreviousTxnID": "9406A44CB36B6F1EA866E587E4D3FAC97F2CB568C623384903596E9971C1E501",
+                "PreviousTxnLgrSeq": 90156047
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "BFB3F0E4D55727984A8ADFE3CCC2A334790094F6AA43643B19BB90F7A10CFEAB",
+                  "Balance": "420152598",
+                  "Flags": 0,
+                  "OwnerCount": 143,
+                  "Sequence": 7423368
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "001D94CAD812C393206DA188B6785055BB060E1D976A100F5B8890FAF3794F28",
+                  "Balance": "420152608",
+                  "Sequence": 7423367
+                },
+                "PreviousTxnID": "001D94CAD812C393206DA188B6785055BB060E1D976A100F5B8890FAF3794F28",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.007207070813217963"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rLBnhMjV6ifEHYeV4gaS6jPKerZhQddFxW",
+                    "value": "0"
+                  },
+                  "HighNode": "1572",
+                  "LowLimit": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "0"
+                  },
+                  "LowNode": "10"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F2394E748205610732195F7C7E3193D6A249F303DD2A92D67DE66A6F2E707125",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5452535259000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.007207489439770223"
+                  }
+                },
+                "PreviousTxnID": "001D94CAD812C393206DA188B6785055BB060E1D976A100F5B8890FAF3794F28",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 9,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rHji8oDyR7fB85jPAG2d25GC2bUSHPCpaH",
+        "Amount": "13000600000",
+        "Destination": "rNxp4h8apvRis6mJf9Sh8C6iRxfrDWN7AV",
+        "DestinationTag": 352660523,
+        "Fee": "10000",
+        "Flags": 2147483648,
+        "Sequence": 88405298,
+        "SigningPubKey": "ED6F9F91B201CFDCC6E74ADF2169E072D0A093F933068EBF6EDF1629959F3678FE",
+        "TransactionType": "Payment",
+        "TxnSignature": "FF954FDDD6F9E4EFDCAB0B2602961F4EFA76012410708FA7B1242AB067601994B2AE41C35CD43125A49DFAF647F394FAD27D9B832F41E2112861A220EC9B880B",
+        "hash": "C2B8DF4694253E8F17B3199F4A186EB7CB7F30E71ED2BA8F5866859566CFD0B7",
+        "DeliverMax": "13000600000",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rNxp4h8apvRis6mJf9Sh8C6iRxfrDWN7AV",
+                  "Balance": "27163535661",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 77292712
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "59EDFBD7E3AA8EF84600C7AABD24DBC8229C19A1FF956C83D6B04390CF7C7E34",
+                "PreviousFields": {
+                  "Balance": "14162935661"
+                },
+                "PreviousTxnID": "B25217BB91258F540B0264525CC744FB49A55B3D9C0FC5DEB417E82A431F876C",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rHji8oDyR7fB85jPAG2d25GC2bUSHPCpaH",
+                  "Balance": "1909824862857",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 88405299
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C31F8406109172DECE2CCC04738A9EFEBE9F20DE68CBFED780A75E0D76106EE6",
+                "PreviousFields": {
+                  "Balance": "1922825472857",
+                  "Sequence": 88405298
+                },
+                "PreviousTxnID": "EB8E66B9593E1CD1D7BAB6A89F613242F39D89D073C0CE400056DB7103D724AE",
+                "PreviousTxnLgrSeq": 90156056
+              }
+            }
+          ],
+          "TransactionIndex": 58,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "13000600000"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994738,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "CSC",
+          "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+          "value": "0.003280188261500091"
+        },
+        "TakerPays": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "5697933638543786e-26"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "BBC7C82795641BD7C843A2923F22A353ECA888EFD9622DFE011E23EA44868E52041C2E89D0D30028D0FE92BCE7F05F2E9D06E09B9787DC374CFF685E65183104",
+        "hash": "C3A090E476C1F22998D0A0CB0352BAE75C3792FF4432C814A23D1D9E3A1D483C",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 2097152,
+                  "HighLimit": {
+                    "currency": "CSC",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "CSC",
+                    "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                    "value": "0"
+                  },
+                  "LowNode": "cdc",
+                  "PreviousTxnID": "E206AB11F690BDE4871C6AD14559242D03D4EB2CF0AB5892D6D4699FB732A59D",
+                  "PreviousTxnLgrSeq": 90156059
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "535000E2717B9D512E29501AB7EC715309786C304D41050D8F4BC696AE13E08A",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.002732817645147587"
+                  },
+                  "Flags": 2228224
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "cdb",
+                  "Owner": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                  "RootIndex": "DFAF312DD953BA48DDC8A4A39525612D592329EA689E2DCBDEE99F97FCA7B087"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B00C1F8067D4005FD8D157A14BF3E02ECC016D138F39E29EA6D2D7B35CDA91FA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "C3A090E476C1F22998D0A0CB0352BAE75C3792FF4432C814A23D1D9E3A1D483C",
+                  "Balance": "1467511962",
+                  "Flags": 0,
+                  "OwnerCount": 50,
+                  "Sequence": 12994739
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "E206AB11F690BDE4871C6AD14559242D03D4EB2CF0AB5892D6D4699FB732A59D",
+                  "Balance": "1467511972",
+                  "OwnerCount": 51,
+                  "Sequence": 12994738
+                },
+                "PreviousTxnID": "E206AB11F690BDE4871C6AD14559242D03D4EB2CF0AB5892D6D4699FB732A59D",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-25818.34453410135"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "CSC",
+                    "issuer": "rBbya3c9Pb7oiLi3SDbewyBTWH3iyA2r3t",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "CSC",
+                    "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                    "value": "0"
+                  },
+                  "LowNode": "c82"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D3D3946A7278AE47D184AF5887CD05C970AE1C023B3C3E114886DA796AB66A38",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-25818.3418012837"
+                  }
+                },
+                "PreviousTxnID": "FEEA3504938B34D4A28F8BBA69DE3C7B68E11264B18FB9658B1BBFAFC1DE63CA",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000001864975768096969"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D63A73BFE673289DA86434524C38EBA61561FC4C7614601A6173E85C92A0AC07",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000001390382519567137"
+                  }
+                },
+                "PreviousTxnID": "7B81F50CB814A1C17874C43BD13356D52E08CFAA116A8A0F8553D4612F473631",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "D666EA6CD2EAA558E508921A18E54E41005CD742CBB09CB478E8CF1123D0E93C",
+                "PreviousTxnID": "E206AB11F690BDE4871C6AD14559242D03D4EB2CF0AB5892D6D4699FB732A59D",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.4484893189971124"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "dd",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBbya3c9Pb7oiLi3SDbewyBTWH3iyA2r3t",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F6544D69B85890231ACB54262A16EE5C5BB545D3E3A897FE20C98CE9CB168387",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.4484893664564373"
+                  }
+                },
+                "PreviousTxnID": "FEEA3504938B34D4A28F8BBA69DE3C7B68E11264B18FB9658B1BBFAFC1DE63CA",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 26,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 7423360,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "0.0000002114225309744176"
+        },
+        "TakerPays": {
+          "currency": "MAG",
+          "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+          "value": "7639887809100125e-28"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "FDBD912311964842C582375EACC04C392F7A25652C5059CF7368B710675E46A6CDC5DEBCD7CADB22F16648FCAB5B486A938BB29A24B372CA9FC71B1921616F01",
+        "hash": "C4C48398BD837B9BC1AA0EC4E080D6BC340C1FE4761B84A85208544F463B95A8",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.37626797789191"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "9"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "68062CBD2811E4D5FB502D7C86E4BB04DA46A2AAE9BE2B400045A57E3B5DBA8B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.376268189314441"
+                  }
+                },
+                "PreviousTxnID": "09A3924FA3F679EB55914AFC2BDD944BE8B3C443DB1D2C38EF8C798A9FBE5863",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.002024025521783921"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "MAG",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "HighNode": "8",
+                  "LowLimit": {
+                    "currency": "MAG",
+                    "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+                    "value": "0"
+                  },
+                  "LowNode": "214"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "6AEDB0D2B26C22AC4401CBDCEB4181C26081FE867AC3A8C233488A6D66724DE8",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.002024024757984602"
+                  }
+                },
+                "PreviousTxnID": "7B35B95950B1DDD3270F7EDE107F7D1E37B60F4AC97F5A08C3C722ED422A2DF3",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.001180724822495674"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "MAG",
+                    "issuer": "rM7vEvcmqKnydfrSS65nHEURsce2ap1RFF",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "MAG",
+                    "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+                    "value": "0"
+                  },
+                  "LowNode": "1bf"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "AB4DCD585958A8E0276E6AAB9D44D3770EE4870F3B104A44D91BD703B3BC1EFD",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.001180725586294993"
+                  }
+                },
+                "PreviousTxnID": "B43381F9DDEE96E721CCC397D9FF370E2A427BA3C8758CD6C9F30F041D5FC01C",
+                "PreviousTxnLgrSeq": 90156056
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.3267445515362966"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rM7vEvcmqKnydfrSS65nHEURsce2ap1RFF",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "LowNode": "df"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D2751670133C827CEB2F8D7AFD0EFCC642B9AA0D7CE68A5E0E5E4ED040FFD1F5",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.3267443401137656"
+                  }
+                },
+                "PreviousTxnID": "B43381F9DDEE96E721CCC397D9FF370E2A427BA3C8758CD6C9F30F041D5FC01C",
+                "PreviousTxnLgrSeq": 90156056
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "C4C48398BD837B9BC1AA0EC4E080D6BC340C1FE4761B84A85208544F463B95A8",
+                  "Balance": "420152668",
+                  "Flags": 0,
+                  "OwnerCount": 143,
+                  "Sequence": 7423361
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "09A3924FA3F679EB55914AFC2BDD944BE8B3C443DB1D2C38EF8C798A9FBE5863",
+                  "Balance": "420152678",
+                  "Sequence": 7423360
+                },
+                "PreviousTxnID": "09A3924FA3F679EB55914AFC2BDD944BE8B3C443DB1D2C38EF8C798A9FBE5863",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 2,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rHqm6iTCWA8BDqEcAEp6QDgp9wvJ6WNjsc",
+        "Amount": "88",
+        "Destination": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+        "DestinationTag": 1111172,
+        "Fee": "10",
+        "Sequence": 89587986,
+        "SigningPubKey": "ED10ECEA690F7932813DB12BC6DA4C219EB57EEB225A360D9809AFCAA3767F93FD",
+        "TransactionType": "Payment",
+        "TxnSignature": "1184DB11D2D2C0C88EA8A089D8EF5AFF7EA901BBBA5A95092D87039268DC5605AFA89BCB3AFA902768032EEB8C041E173F748AD24FCDD1E78ED89882EA7EA208",
+        "hash": "C613D4D4990563C03E3C82CC410E5487CD59DB9FEBADA25CE106EF651665185D",
+        "DeliverMax": "88",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+                  "Balance": "43091412",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89531841
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2A9DF02FF78FCCE946B77372B25D9C6F875895CEE6AAC1D37A7158BAA3E9BBDC",
+                "PreviousFields": {
+                  "Balance": "43091324"
+                },
+                "PreviousTxnID": "1FBD2B85E5B282D2D6D7EBA356F213E62A22EBFB17A5B5A30F5BB7F8D9004A44",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rHqm6iTCWA8BDqEcAEp6QDgp9wvJ6WNjsc",
+                  "Balance": "54323142",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89587987
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "FDB311E993E0A2685F0A896873E69404FB5075D835411A245141240331761912",
+                "PreviousFields": {
+                  "Balance": "54323240",
+                  "Sequence": 89587986
+                },
+                "PreviousTxnID": "2F3467CC7A2A7EE3DBD2F6683B15444629BCA85A54E239F758E3EB14BAD7A133",
+                "PreviousTxnLgrSeq": 90156051
+              }
+            }
+          ],
+          "TransactionIndex": 56,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "88"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994749,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "2298448146314074e-28"
+        },
+        "TakerPays": {
+          "currency": "5A52505900000000000000000000000000000000",
+          "issuer": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+          "value": "4169022965977860e-28"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "6864C5396C379F2C69152342CDDBEB2EB888C9D1A7447A7C51491760FF6AC2345FEAAF0BEDC123F12BC80A6CB031772821BA719795816C46055277D60E059A09",
+        "hash": "C66A8737DAE8857289034C1A36E6CE4ECB273C90269035626E76C6E2DE06B954",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.3388189178512045"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rLtURbYhZP4b984Vue45v79DCThWQxLmD3",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "LowNode": "df"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "1E42AF87018C6F9E76306573AAF7B5A085E3DC11725DDC8901AD4071A4094781",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.3388189178509747"
+                  }
+                },
+                "PreviousTxnID": "B78CCF7474DC45ACB422808FDBA3C1B4152BF903E784F33F2945F86CB615ADF7",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-614.5714988798197"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rLtURbYhZP4b984Vue45v79DCThWQxLmD3",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+                    "value": "0"
+                  },
+                  "LowNode": "89"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "2A16BBBAD0056C8A9180C46E05DFE6301D67DCBD2B1B67BFE7039B7DF63145C2",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-614.5714988802365"
+                  }
+                },
+                "PreviousTxnID": "B78CCF7474DC45ACB422808FDBA3C1B4152BF903E784F33F2945F86CB615ADF7",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "90848E9A1185CCEF2B55329945A8D6075A88A10A854FF6DB890994AAD4CED060",
+                "PreviousTxnID": "4C032E0D756913DE48BD2C8DADA162C078730B2C0C5F6218826DB47E09C78DC1",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "C66A8737DAE8857289034C1A36E6CE4ECB273C90269035626E76C6E2DE06B954",
+                  "Balance": "1467511852",
+                  "Flags": 0,
+                  "OwnerCount": 50,
+                  "Sequence": 12994750
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "C7BC8434A20D4DD3C6B98C20BEFDABB199C2D4A6C45AA923ABD24E206261C097",
+                  "Balance": "1467511862",
+                  "OwnerCount": 49,
+                  "Sequence": 12994749
+                },
+                "PreviousTxnID": "C7BC8434A20D4DD3C6B98C20BEFDABB199C2D4A6C45AA923ABD24E206261C097",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "8f",
+                  "Owner": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+                  "RootIndex": "4492BEF2FF8CE6639BB5E6AA330E8163DC45BED13660B310A2C5503C03534CA6"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "C3F0C59D3E02E306BD82ABA89093BEB615F70ADA0ECDE4E08A9470FB277D2744"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000001968531333975598"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D63A73BFE673289DA86434524C38EBA61561FC4C7614601A6173E85C92A0AC07",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000001968533632423744"
+                  }
+                },
+                "PreviousTxnID": "C7BC8434A20D4DD3C6B98C20BEFDABB199C2D4A6C45AA923ABD24E206261C097",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "E5D9EA1D087FA02C08D319E9DBD3167D791173D848A08EC9EB6F4F77F4CFA48C",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0000000004167989086535497"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "5A52505900000000000000000000000000000000",
+                    "issuer": "rsxkrpsYaeTUdciSFJwvto7MKSrgGnvYvA",
+                    "value": "0"
+                  },
+                  "LowNode": "90"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 37,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994748,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "434F524500000000000000000000000000000000",
+          "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+          "value": "2237124523235235e-26"
+        },
+        "TakerPays": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "1915373455261728e-31"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "26FD72CADBE0E31DA62005ADDBC49B82315963E9E6D8F1D659012C62AACF053DDF8D5AE52E33BA09E6C4A0533800C8C99930245049D281EE14EF15D15155410D",
+        "hash": "C7BC8434A20D4DD3C6B98C20BEFDABB199C2D4A6C45AA923ABD24E206261C097",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMffDj93JAQvogvJ2k8196DeAt5HcpdDQC",
+                  "Balance": "283506159",
+                  "Flags": 0,
+                  "OwnerCount": 24,
+                  "Sequence": 76158366
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "075E8FCFD124B5C1BFDCD999226F7D3D190ED74A71474A28F4D704022AC83FBC",
+                "PreviousFields": {
+                  "Balance": "283506160"
+                },
+                "PreviousTxnID": "021EA6C5BE9AE7209B23BF4F39BB738FFA45EB4B1CD6EAFFCFFB471FEF11AC10",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1E1ADBD847116F2C0DF91CCB7165719E2285397499705C85414A745A3AC80F43",
+                "PreviousTxnID": "FA5F34CD69302D540E466246C0C86223FE5824F2720DFEE53E8BC11AC858896A",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "14.46082572447929"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "dc",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rnv4kx1H76k43HYKZa3wrKhVnWNvA4kQpm",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "318E00F1D5FCAAD58867D5AA41CF32A319597C463F8DB9CBB4D0851A3258AD50",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "14.46082580321028"
+                  }
+                },
+                "PreviousTxnID": "09A3924FA3F679EB55914AFC2BDD944BE8B3C443DB1D2C38EF8C798A9FBE5863",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-53.03798729613259"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rMffDj93JAQvogvJ2k8196DeAt5HcpdDQC",
+                    "value": "1000000"
+                  },
+                  "HighNode": "a45",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "ad0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "431A90E2C48B0F2F2B7A95E55E41F54CEBBA1A1C3BDFE48CE45091350568127E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-53.03798729611395"
+                  }
+                },
+                "PreviousTxnID": "021EA6C5BE9AE7209B23BF4F39BB738FFA45EB4B1CD6EAFFCFFB471FEF11AC10",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMffDj93JAQvogvJ2k8196DeAt5HcpdDQC",
+                  "BookDirectory": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F4F20ACEA4283CE40",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "a45",
+                  "Sequence": 76158365,
+                  "TakerGets": "9996238",
+                  "TakerPays": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "91.93866507071383"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "4EEB87528A6B72703D4DB70BF0FFC79E6AC4DA40DB047DAD8DDF12BD8E95460F",
+                "PreviousFields": {
+                  "TakerGets": "9996239",
+                  "TakerPays": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "91.93866507073247"
+                  }
+                },
+                "PreviousTxnID": "021EA6C5BE9AE7209B23BF4F39BB738FFA45EB4B1CD6EAFFCFFB471FEF11AC10",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "B416780D1A45F7BA8665AA6967CD1F346087B495EAC1B0D4FD8AC421444D04A5",
+                  "Account": "rnv4kx1H76k43HYKZa3wrKhVnWNvA4kQpm",
+                  "Balance": "183607772",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 86806716
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A64DC21AF513694977C5F654D42828F1D178E9DBBA85B270DCB95378669834F7",
+                "PreviousFields": {
+                  "Balance": "183607771"
+                },
+                "PreviousTxnID": "09A3924FA3F679EB55914AFC2BDD944BE8B3C443DB1D2C38EF8C798A9FBE5863",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "ea0",
+                  "Owner": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                  "RootIndex": "5DD87298A566F5805C113F1E887578A4AF0123F117D08E74F3A0698F1AD100ED"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B2FBE6A2AD61B0BBC3C6EECCAD32590841ADA8E5AE4811728B29F85AA95A747F"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "C7BC8434A20D4DD3C6B98C20BEFDABB199C2D4A6C45AA923ABD24E206261C097",
+                  "Balance": "1467511862",
+                  "Flags": 0,
+                  "OwnerCount": 49,
+                  "Sequence": 12994749
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "FA5F34CD69302D540E466246C0C86223FE5824F2720DFEE53E8BC11AC858896A",
+                  "Balance": "1467511872",
+                  "OwnerCount": 50,
+                  "Sequence": 12994748
+                },
+                "PreviousTxnID": "FA5F34CD69302D540E466246C0C86223FE5824F2720DFEE53E8BC11AC858896A",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000001968533632423744"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D63A73BFE673289DA86434524C38EBA61561FC4C7614601A6173E85C92A0AC07",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000001181223731471715"
+                  }
+                },
+                "PreviousTxnID": "272EA89713D998812DF34E0A30F9E1F53AD24B7977661EF7DEE8681F5DB4A92D",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 2097152,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "ea1",
+                  "PreviousTxnID": "FA5F34CD69302D540E466246C0C86223FE5824F2720DFEE53E8BC11AC858896A",
+                  "PreviousTxnLgrSeq": 90156059
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F7649E56EB86403211BE414801DA87DD2B143701E72EE2553D87DD748E698848",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1863810660369185e-26"
+                  },
+                  "Flags": 2228224
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 36,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rPJ2kXNTseFAD1qotRXBtv7cd3x8ZN4BkP",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 90156072,
+        "OfferSequence": 87567340,
+        "Sequence": 0,
+        "SigningPubKey": "ED430693FC7ECA8BF90BDF979181B1D6E8E698041144A82900828DB965794FF857",
+        "TakerGets": "8651431",
+        "TakerPays": {
+          "currency": "4450415900000000000000000000000000000000",
+          "issuer": "rBvXRy3AkW7En4rByqymXW7bBLET3y2P9f",
+          "value": "8639.2191971"
+        },
+        "TicketSequence": 87567338,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "D9D61EA32989BE51A12F741996367447AB46CDC26739F84C2063C116CA6EFC505A765D58973B9BC0257ADF53CC3954A414EA7F74617FA949B4D627889FE55807",
+        "hash": "CBF65094F40D8A5491E7E51B7F187B2EDBD4EFB5DA8E0E5592AD9A7193243292",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rPJ2kXNTseFAD1qotRXBtv7cd3x8ZN4BkP",
+                  "Flags": 0,
+                  "OwnerNode": "47aa",
+                  "PreviousTxnID": "A8A8A329827B691DC0FC1E48C1A9224529E56EAC2AB43B6E16F1C18A58E1756A",
+                  "PreviousTxnLgrSeq": 90155997,
+                  "TicketSequence": 87567338
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "054B4C5086F1733F5F8F3B2D6C796895F3805A0CCD80915BACD1CF907F382D29"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rPJ2kXNTseFAD1qotRXBtv7cd3x8ZN4BkP",
+                  "Balance": "1912403778",
+                  "Flags": 0,
+                  "OwnerCount": 49,
+                  "Sequence": 87567348,
+                  "TicketCount": 16
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2D0D7A8511A7CF5930081E38DB4EB8585AECB3A6646EC7CDC93B40880C28C993",
+                "PreviousFields": {
+                  "Balance": "1912403790",
+                  "OwnerCount": 50,
+                  "TicketCount": 17
+                },
+                "PreviousTxnID": "30D5587662E47A1683DA3EC84D634BAA6F373051FE9FCA3655543EF7BB2769A5",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rPJ2kXNTseFAD1qotRXBtv7cd3x8ZN4BkP",
+                  "BookDirectory": "EA2A80818E0A7ED9C7436E94F31A22A7A019B9F6FBC3D7A051237A1F7159EFEB",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "47aa",
+                  "PreviousTxnID": "53CEBF8020E0FDEFE318C8E437C23D0C50DE3D30A2DE6B02890B095C86AA8044",
+                  "PreviousTxnLgrSeq": 90156055,
+                  "Sequence": 87567340,
+                  "TakerGets": "8651418",
+                  "TakerPays": {
+                    "currency": "4450415900000000000000000000000000000000",
+                    "issuer": "rBvXRy3AkW7En4rByqymXW7bBLET3y2P9f",
+                    "value": "8639.2191971"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "659EAE7E997E578582F7F3891DF7BB190EFE0277A6DF38CADA7F398152FEECC1"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "80E4FB5115339AD474611823722C1683B298B194EAE9D3880478A1B83F7EBCD8",
+                "NewFields": {
+                  "Account": "rPJ2kXNTseFAD1qotRXBtv7cd3x8ZN4BkP",
+                  "BookDirectory": "EA2A80818E0A7ED9C7436E94F31A22A7A019B9F6FBC3D7A051237A1F7159EFEB",
+                  "OwnerNode": "47aa",
+                  "Sequence": 87567338,
+                  "TakerGets": "8651418",
+                  "TakerPays": {
+                    "currency": "4450415900000000000000000000000000000000",
+                    "issuer": "rBvXRy3AkW7En4rByqymXW7bBLET3y2P9f",
+                    "value": "8639.2191971"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "47a2",
+                  "Owner": "rPJ2kXNTseFAD1qotRXBtv7cd3x8ZN4BkP",
+                  "RootIndex": "E5891B3D122CC93DF66E0A32B2085B7420895C43D04491928CB94EDD442816FC"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9A0C78B3B975E780B9AE66FEACC74079064F07EAA60EC58A0F52F446E3A5343D"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "51237a1f7159efeb",
+                  "Flags": 0,
+                  "RootIndex": "EA2A80818E0A7ED9C7436E94F31A22A7A019B9F6FBC3D7A051237A1F7159EFEB",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "4450415900000000000000000000000000000000",
+                  "TakerPaysIssuer": "77D0B4B5C5C3A55A28BB4C9C2F4A93D4A256B7C3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "EA2A80818E0A7ED9C7436E94F31A22A7A019B9F6FBC3D7A051237A1F7159EFEB"
+              }
+            }
+          ],
+          "TransactionIndex": 65,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rL96PCEgD5ZPQUDGzTxo2se3cbLfU9di2w",
+        "Amount": "44",
+        "Destination": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+        "DestinationTag": 1234,
+        "Fee": "10",
+        "Sequence": 89520284,
+        "SigningPubKey": "EDD1CAD085615B4389259DF7C13F6A3426794F1D5198E59AEA900D0BA38BA0409F",
+        "TransactionType": "Payment",
+        "TxnSignature": "FCA0BABB2806EA6224CA25106EE46FE736E08A2FB51E30148A4342434C9A9389306FF62F531F4666D18DDCF0F381AE5F2521EFF7EA4DE977F99D4E0798C6F40C",
+        "hash": "CDAF37BFA782D4A2FE0AA3521CCFC9CE3A4485F08E25C268972D01026C758DEC",
+        "DeliverMax": "44",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rL96PCEgD5ZPQUDGzTxo2se3cbLfU9di2w",
+                  "Balance": "54361675",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89520285
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "0E10F86AF2120FD769826D53FE0F1D6903349611D63B231A6A1D7807DF90ED90",
+                "PreviousFields": {
+                  "Balance": "54361729",
+                  "Sequence": 89520284
+                },
+                "PreviousTxnID": "700B94ACD6845A11C19A7E932EC6DA1198A84BD7F4CA534986AE203F6AE4F26E",
+                "PreviousTxnLgrSeq": 90156045
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMo8bT3qWkvyNvp4UQUfFEAKYv921aGdhk",
+                  "Balance": "43091456",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89531841
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2A9DF02FF78FCCE946B77372B25D9C6F875895CEE6AAC1D37A7158BAA3E9BBDC",
+                "PreviousFields": {
+                  "Balance": "43091412"
+                },
+                "PreviousTxnID": "C613D4D4990563C03E3C82CC410E5487CD59DB9FEBADA25CE106EF651665185D",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 61,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "44"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 90156061,
+        "OfferSequence": 148592487,
+        "Sequence": 148592497,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": "33794000000",
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "19529.89054"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "30450221008A83B4E5C3209522B587F5A6C3C85B897CA5F2DB219DFDFEAD3B7ABD86E6D24002204C0719E6507D5F01B234400E2B10F1AB10C062FF28BBE8A101AD3005740E2DC9",
+        "hash": "DC6E1BADB49C694C1C3D8E1D25E611A44D26F67B38FF9BD76AE84467B15CC74F",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "33894335361",
+                  "Flags": 0,
+                  "OwnerCount": 15,
+                  "Sequence": 148592498
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "33894335381",
+                  "Sequence": 148592497
+                },
+                "PreviousTxnID": "D64F1065E2B04D3F13AAEE27F57930BD0AB39405E186C30B6F51D2589B0B2B78",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "36939E5FF8C8B8D9C3097EA437CAD6FFE8A19F7CE58909201432D744C3052DEB",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4E14880F929F1800",
+                  "Sequence": 148592497,
+                  "TakerGets": "33794000000",
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "19529.89054"
+                  }
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4E148783DFD5A800",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "18994A7792E1ACFBAE1DF1F20696D1E6780B651AE6EE0727D34C0793480830AC",
+                  "PreviousTxnLgrSeq": 90156057,
+                  "Sequence": 148592487,
+                  "TakerGets": "33794000000",
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "19527.8629"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "7A73AF95BB80633BF2C8D188053647BDA99689C8B19CFA0D380016C8F3EE7276"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4e148783dfd5a800",
+                  "Flags": 0,
+                  "RootIndex": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4E148783DFD5A800",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4E148783DFD5A800"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4E14880F929F1800",
+                "NewFields": {
+                  "ExchangeRate": "4e14880f929f1800",
+                  "RootIndex": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4E14880F929F1800",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 45,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 7423363,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "262",
+          "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+          "value": "0.00000156707451794543"
+        },
+        "TakerPays": {
+          "currency": "434F524500000000000000000000000000000000",
+          "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+          "value": "0.00000002469381596239431"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "6D57D53E8F450BD15CE31BBF4A239FE26E3BAF0EC16E099AA7C992EE0CA5EB454A779882C1E070A8412BCF5FB1A7F130EC1ACED162506780978F343745EC7E08",
+        "hash": "DE110956D7EF61FF1BFB955428AAB4E24665466DB0593CB57C27F2FB836E877E",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "9.363238492004759"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "52DB81328A8EFF7305F672D5E8D9C6129B933D4CBC78C440D6EC6862C1B01883",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "9.363240059079277"
+                  }
+                },
+                "PreviousTxnID": "017F4531E83EE1B66AE7B85818B54E5767097B632521C0BE13C918531FDD2C3E",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-197.2967329529106"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "HighNode": "8",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "e9a"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B5AE9624630077C320F4F84D35562B165941C6E7D64BA7722A9CCDF0595F2F7E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-197.2967082652185"
+                  }
+                },
+                "PreviousTxnID": "09A3924FA3F679EB55914AFC2BDD944BE8B3C443DB1D2C38EF8C798A9FBE5863",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-85.74329213907244"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rNgEMUDzYaSFGCyBVEbdjWHe4aqRdBJFsN",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "e99"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B96747D67A5D752D833FFBC9A44A4686BF72A4F6FDF2B3DE42009C31A9E532ED",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-85.7433168267645"
+                  }
+                },
+                "PreviousTxnID": "7089A1EA10B8EAD60785967EFB1F13E57268BE5E1BF51DAF71ACD3B8D774F05F",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "DE110956D7EF61FF1BFB955428AAB4E24665466DB0593CB57C27F2FB836E877E",
+                  "Balance": "420152638",
+                  "Flags": 0,
+                  "OwnerCount": 143,
+                  "Sequence": 7423364
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "017F4531E83EE1B66AE7B85818B54E5767097B632521C0BE13C918531FDD2C3E",
+                  "Balance": "420152648",
+                  "Sequence": 7423363
+                },
+                "PreviousTxnID": "017F4531E83EE1B66AE7B85818B54E5767097B632521C0BE13C918531FDD2C3E",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5.441279083268731"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rNgEMUDzYaSFGCyBVEbdjWHe4aqRdBJFsN",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F6B3EA89AA7CA0CFA93C462078472417FE72D18D460E006FFC28933EE4BC7145",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5.441277516194213"
+                  }
+                },
+                "PreviousTxnID": "7089A1EA10B8EAD60785967EFB1F13E57268BE5E1BF51DAF71ACD3B8D774F05F",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            }
+          ],
+          "TransactionIndex": 5,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 7423365,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "CSC",
+          "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+          "value": "0.000006263602897384274"
+        },
+        "TakerPays": {
+          "currency": "OVO",
+          "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+          "value": "0.0000001250255099493724"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "8F04BF2D8F75771B634A5B687F4D39A606BFAE6D2181592D564787A2B17E648CE974B9491BFE9486A794D63A61F2D5425B54420922B1C2BB806AFCF1883E9406",
+        "hash": "E173F5C1EFBAA334615006D4CF8D03B461DC7EA9866D33F9592F075996A28AD5",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-4425565.460450544"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "OVO",
+                    "issuer": "rJeo3HgNHNtw93VaJNdKNNCfuGgipz5yQh",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "OVO",
+                    "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+                    "value": "0"
+                  },
+                  "LowNode": "335"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "431C46C3FAC02845E47D7D0C3E68CE30FA458F92307B5D5DF86ED45CF365EE35",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-4425565.460575539"
+                  }
+                },
+                "PreviousTxnID": "8FA3AD9FA208BABBE1875959F2874E1787BE0B39D9A626CDE1A72DBF74A58F9C",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-221714.1985435858"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "CSC",
+                    "issuer": "rJeo3HgNHNtw93VaJNdKNNCfuGgipz5yQh",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "CSC",
+                    "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                    "value": "0"
+                  },
+                  "LowNode": "ca0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "8897157A2774218ECDDC86A1CFF9298C29A2AD4C25C26E3AFD71E69CDD657968",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-221714.1985373222"
+                  }
+                },
+                "PreviousTxnID": "8FA3AD9FA208BABBE1875959F2874E1787BE0B39D9A626CDE1A72DBF74A58F9C",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-83706.18816470907"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "CSC",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "HighNode": "8",
+                  "LowLimit": {
+                    "currency": "CSC",
+                    "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                    "value": "0"
+                  },
+                  "LowNode": "cd5"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "943790BC0B024485EE6ABEFB29FC21D2AA6940D7ECA08E1CEC8BEA2849B00985",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-83706.18817097267"
+                  }
+                },
+                "PreviousTxnID": "FEEA3504938B34D4A28F8BBA69DE3C7B68E11264B18FB9658B1BBFAFC1DE63CA",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "565808.9582533747"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "OVO",
+                    "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+                    "value": "0"
+                  },
+                  "HighNode": "33e",
+                  "LowLimit": {
+                    "currency": "OVO",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "CF7D03A277BB38033EE1039387650B3720EB33056781C1BE75B19A4FC6B999AD",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "565808.9581283802"
+                  }
+                },
+                "PreviousTxnID": "5002771C69EF3DDEEFD39F17CED6A813450390EBC8EB4C1FA2AF024BADFA5001",
+                "PreviousTxnLgrSeq": 90156055
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "E173F5C1EFBAA334615006D4CF8D03B461DC7EA9866D33F9592F075996A28AD5",
+                  "Balance": "420152618",
+                  "Flags": 0,
+                  "OwnerCount": 143,
+                  "Sequence": 7423366
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "FEEA3504938B34D4A28F8BBA69DE3C7B68E11264B18FB9658B1BBFAFC1DE63CA",
+                  "Balance": "420152628",
+                  "Sequence": 7423365
+                },
+                "PreviousTxnID": "FEEA3504938B34D4A28F8BBA69DE3C7B68E11264B18FB9658B1BBFAFC1DE63CA",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 7,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994737,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "OVO",
+          "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+          "value": "0.05456252700723236"
+        },
+        "TakerPays": {
+          "currency": "CSC",
+          "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+          "value": "0.000002733490217916743"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "C2522A471C774E6DFEBE59289D41F1519D1188A8380028DD1B16D457922B618ABB042092CE4507A57B009793EAA321C5C26F18C62AA7A25C63C068E54AE0E801",
+        "hash": "E206AB11F690BDE4871C6AD14559242D03D4EB2CF0AB5892D6D4699FB732A59D",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-4425565.515013071"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "OVO",
+                    "issuer": "rJeo3HgNHNtw93VaJNdKNNCfuGgipz5yQh",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "OVO",
+                    "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+                    "value": "0"
+                  },
+                  "LowNode": "335"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "431C46C3FAC02845E47D7D0C3E68CE30FA458F92307B5D5DF86ED45CF365EE35",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-4425565.460450544"
+                  }
+                },
+                "PreviousTxnID": "E173F5C1EFBAA334615006D4CF8D03B461DC7EA9866D33F9592F075996A28AD5",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "535000E2717B9D512E29501AB7EC715309786C304D41050D8F4BC696AE13E08A",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.002732817645147587"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "CSC",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "CSC",
+                    "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                    "value": "0"
+                  },
+                  "LowNode": "cdc"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-221714.1958107682"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "CSC",
+                    "issuer": "rJeo3HgNHNtw93VaJNdKNNCfuGgipz5yQh",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "CSC",
+                    "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                    "value": "0"
+                  },
+                  "LowNode": "ca0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "8897157A2774218ECDDC86A1CFF9298C29A2AD4C25C26E3AFD71E69CDD657968",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-221714.1985435858"
+                  }
+                },
+                "PreviousTxnID": "E173F5C1EFBAA334615006D4CF8D03B461DC7EA9866D33F9592F075996A28AD5",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.03593814299276764"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "OVO",
+                    "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+                    "value": "0"
+                  },
+                  "HighNode": "33f",
+                  "LowLimit": {
+                    "currency": "OVO",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "8EB8D4D2D6968FF99D8DD3993C7E77BE09D0F25951E7FA67077494C366602650",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.09050067"
+                  }
+                },
+                "PreviousTxnID": "A398CE8F995BFC2D5FE33E76CBA8D66BB0E0EBF87FFF3C29493F05E507DBC3F7",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "cdb",
+                  "Owner": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                  "RootIndex": "DFAF312DD953BA48DDC8A4A39525612D592329EA689E2DCBDEE99F97FCA7B087"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B00C1F8067D4005FD8D157A14BF3E02ECC016D138F39E29EA6D2D7B35CDA91FA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "E206AB11F690BDE4871C6AD14559242D03D4EB2CF0AB5892D6D4699FB732A59D",
+                  "Balance": "1467511972",
+                  "Flags": 0,
+                  "OwnerCount": 51,
+                  "Sequence": 12994738
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "A398CE8F995BFC2D5FE33E76CBA8D66BB0E0EBF87FFF3C29493F05E507DBC3F7",
+                  "Balance": "1467511982",
+                  "OwnerCount": 50,
+                  "Sequence": 12994737
+                },
+                "PreviousTxnID": "A398CE8F995BFC2D5FE33E76CBA8D66BB0E0EBF87FFF3C29493F05E507DBC3F7",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "D666EA6CD2EAA558E508921A18E54E41005CD742CBB09CB478E8CF1123D0E93C",
+                "PreviousTxnID": "50D6C47BB22319297FB277236B1D99E7B1D06020B531CAD1338A6168676FDF88",
+                "PreviousTxnLgrSeq": 90156057
+              }
+            }
+          ],
+          "TransactionIndex": 25,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "raFvV8JRi79gcVx6m3wnnmv4wPFycRkuze",
+        "Amount": "44",
+        "Destination": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+        "DestinationTag": 1000012,
+        "Fee": "10",
+        "Sequence": 89536141,
+        "SigningPubKey": "EDF674DE02954F654A60BB47371F8D28E516689DD90D770635CD77835F27389781",
+        "TransactionType": "Payment",
+        "TxnSignature": "460AC1F46820EC42377CADDE177EBF308F8543C686D5D1DB3E3F7180EDA7096205E114C1E378C7FBEE8B5051AD28BF0A3144BA34D0C770343B4F7131D133510D",
+        "hash": "E4F5062B7A0858886F0B702CFBBA5FD46179E3D474CA3DACE9AD14FFD977139E",
+        "DeliverMax": "44",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "raFvV8JRi79gcVx6m3wnnmv4wPFycRkuze",
+                  "Balance": "54391613",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89536142
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "06B664DF9C0907C5D6E298852D76D104143A852D52DFACEC7136F271FBF24AC4",
+                "PreviousFields": {
+                  "Balance": "54391667",
+                  "Sequence": 89536141
+                },
+                "PreviousTxnID": "3C5C3196A8470AE4276EB77796F4E4D893CF05D4C9E089C7983BAC5E763749AB",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEzdn46Gjxh8YJNAZrmMUsFh1QDfT8uuTs",
+                  "Balance": "188398914",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 89221294
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "51C728407B1A8B3037D6B40ADB49013ABD9F62FB12ED8981D6575C722A176EB1",
+                "PreviousFields": {
+                  "Balance": "188398870"
+                },
+                "PreviousTxnID": "67D1B49182EF7412BC4A81080815B687010A0ED17F742D4076F4B6704E8507A8",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 19,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "44"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 90156061,
+        "OfferSequence": 148592489,
+        "Sequence": 148592499,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": "33794000000",
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "19264.112321342"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100976348645BCE57143F18DECBB092280AB70284447ACA0FB67F24CF107C3FD5ED02206CF77D3D120D970B49DCA1042081528B911EF46ADF9A7B2FB57B7511F531BF2D",
+        "hash": "EEED2DC6BA004D54D1811C4D270C6809C71A66BEED7EEFD619B8AE19C3E9A9FA",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E144093CA24E980",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "4E1891E849163AD8B9C587E68479ADE6D0AE207F518AC9D4A2436440C68300C8",
+                  "PreviousTxnLgrSeq": 90156057,
+                  "Sequence": 148592489,
+                  "TakerGets": "33794000000",
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "19264.279939582"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "0109D62306D96021FB85D9191351E20E535A1E0357F6FF3837F99EE4E453B79A"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "33894335321",
+                  "Flags": 0,
+                  "OwnerCount": 15,
+                  "Sequence": 148592500
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "33894335341",
+                  "Sequence": 148592499
+                },
+                "PreviousTxnID": "73788695B77933702ED53977A1A5016B93D71C0E42E675C190DC38F95478E5AE",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E1440883DC0F980",
+                "NewFields": {
+                  "ExchangeRate": "4e1440883dc0f980",
+                  "RootIndex": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E1440883DC0F980",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4e144093ca24e980",
+                  "Flags": 0,
+                  "RootIndex": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E144093CA24E980",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E144093CA24E980"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "A61F633925005EFC782A1F1AD3C84C182A49C6D9B5657E83048ED9980F520E2D",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784E1440883DC0F980",
+                  "Sequence": 148592499,
+                  "TakerGets": "33794000000",
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "19264.112321342"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 47,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994743,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": "1",
+        "TakerPays": {
+          "currency": "XRL",
+          "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+          "value": "0.0000000009759224374763695"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "5251CF597FEA02CE9C5DC2196EB3AE097D5E074BCAD74802058361FB18DD06AEE083990FBE07584B217F62C27928923ED79051D2169F2BE6D22D309DDB9AD50D",
+        "hash": "F0374F4F971FCBF13CC4AF5E53ADF5948C4A8EF34A55D0378FC3BFE1EF9D5A2C",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rP8oBvFndK8PaNmy3hzR3yUZEEPw54441d",
+                  "Balance": "105777428",
+                  "Flags": 8388608,
+                  "OwnerCount": 36,
+                  "Sequence": 83482356
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "42DCE2DD8CDA516C665E097A383050A2EBF97CC217EB18638EEAC377D46B806D",
+                "PreviousFields": {
+                  "Balance": "105777427"
+                },
+                "PreviousTxnID": "9AB39507E77FB585D7A783A68431F53DD4F917D1EDDB6AAFE6FD716B36C61B77",
+                "PreviousTxnLgrSeq": 90156039
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-13862594322.48161"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "XRL",
+                    "issuer": "rP8oBvFndK8PaNmy3hzR3yUZEEPw54441d",
+                    "value": "26000000000"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "XRL",
+                    "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "7A85483151BB3ED9F08601CAD00C37950E93A04659C7AD2DB45AECAEBD92B13F",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-13862594323.48161"
+                  }
+                },
+                "PreviousTxnID": "9AB39507E77FB585D7A783A68431F53DD4F917D1EDDB6AAFE6FD716B36C61B77",
+                "PreviousTxnLgrSeq": 90156039
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rP8oBvFndK8PaNmy3hzR3yUZEEPw54441d",
+                  "BookDirectory": "DFBD7714A3D903789CB517FCE64B9E23C650CEEA56C51CC355038D7EA4C68000",
+                  "BookNode": "0",
+                  "Flags": 131072,
+                  "OwnerNode": "0",
+                  "Sequence": 83482245,
+                  "TakerGets": {
+                    "currency": "XRL",
+                    "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+                    "value": "9867594319.481657"
+                  },
+                  "TakerPays": "9867593707"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "AD4A2866FC092883010A61255500FAD3E2E24C34EA95254211C2D62FA1BFD736",
+                "PreviousFields": {
+                  "TakerGets": {
+                    "currency": "XRL",
+                    "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+                    "value": "9867594320.481657"
+                  },
+                  "TakerPays": "9867593708"
+                },
+                "PreviousTxnID": "9AB39507E77FB585D7A783A68431F53DD4F917D1EDDB6AAFE6FD716B36C61B77",
+                "PreviousTxnLgrSeq": 90156039
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "F0374F4F971FCBF13CC4AF5E53ADF5948C4A8EF34A55D0378FC3BFE1EF9D5A2C",
+                  "Balance": "1467511912",
+                  "Flags": 0,
+                  "OwnerCount": 49,
+                  "Sequence": 12994744
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "0FD1E5BD2ED0C3B468549102C2B80D98B7503FF2C70F4FF9ABD89189BE58716D",
+                  "Balance": "1467511923",
+                  "Sequence": 12994743
+                },
+                "PreviousTxnID": "0FD1E5BD2ED0C3B468549102C2B80D98B7503FF2C70F4FF9ABD89189BE58716D",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5811.945288792949"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "XRL",
+                    "issuer": "rEeKbkGG2cgEG3yBXzvcdZ2oQ88nYiDZMQ",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "XRL",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "c4"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "FCF9919AFEE1083CEC8CE802290093F96AECA1B415F9F64C6405E3F960FE56C4",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "XRL",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5810.945288792949"
+                  }
+                },
+                "PreviousTxnID": "600A1A439B631D0487BCC68F970A57FDF4B6A4CF4A6EBAD953EA5139E2954565",
+                "PreviousTxnLgrSeq": 90156039
+              }
+            }
+          ],
+          "TransactionIndex": 31,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994740,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "58434F5245000000000000000000000000000000",
+          "issuer": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+          "value": "0.00001171507233554251"
+        },
+        "TakerPays": {
+          "currency": "5341564500000000000000000000000000000000",
+          "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+          "value": "7548072722756697e-26"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "AA47F89C8192FA6973F31E22C8A5390BEB57D6A1D4E7A8CF4757B37975199077E49F5EB97C9FF205866CCFCA7ACDBE8EF7A14092E03E40FCA10CEA83E210700D",
+        "hash": "F2DA37ADB80192A93F683CA24EBFB1F1B6438939E2A33F84054232922BE20FD2",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.452611499152008"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+                    "value": "0"
+                  },
+                  "HighNode": "996",
+                  "LowLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rfnuDi8Eos8Bi6U7ux7HZHjuzkx143Eosf",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "7BE7E23F06637C9A81C6EF770289DE78987BF5172BE75E91CB489BE5799E3B08",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.452601739012754"
+                  }
+                },
+                "PreviousTxnID": "C2E018D6BE2E0B72BA4B97707F44D9AEBCB8F2BEDE35A883CC85F731AA30B38F",
+                "PreviousTxnLgrSeq": 90156036
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.009387312554632011"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+                    "value": "0"
+                  },
+                  "HighNode": "255",
+                  "LowLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rfnuDi8Eos8Bi6U7ux7HZHjuzkx143Eosf",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "831E2CD2BABCBF26986555CCB09578BC73844C0118E77F6F683B5F516DDF077F",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.009387375424212859"
+                  }
+                },
+                "PreviousTxnID": "C2E018D6BE2E0B72BA4B97707F44D9AEBCB8F2BEDE35A883CC85F731AA30B38F",
+                "PreviousTxnLgrSeq": 90156036
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "99f",
+                  "Owner": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+                  "RootIndex": "C0DA491E53EA9440740C19AAF40FD7AB7132224EFFEF4B224280BF80C03C7BF8"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "979C3C6EC438DABC913A71490D84B69C2A8EEB02ED871BB22BE79FD7C81A047A"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "9DDD00FD772E18D0AFEF796BB21D2A5D37E3D1505DBDE727A28E700D220E1893",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.00000006286958084779931"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+                    "value": "0"
+                  },
+                  "HighNode": "255",
+                  "LowLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1048576,
+                  "HighLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+                    "value": "0"
+                  },
+                  "HighNode": "9a0",
+                  "LowLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c",
+                  "PreviousTxnID": "272EA89713D998812DF34E0A30F9E1F53AD24B7977661EF7DEE8681F5DB4A92D",
+                  "PreviousTxnLgrSeq": 90156059
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "AC0346AB66951F5FC37BC58EE00CEC66E878B2CFA770BFD503CD7730022B17BA",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000009760139253683009"
+                  },
+                  "Flags": 1114112
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BEFFFC911BD864EE253422C851B3DCD187CF2BF5DAD31DC7F3405B7BFDA84F61",
+                "PreviousTxnID": "211A97EFC1E1E92211FC8C0AED6AF83C40DD2D3D34465FA30E42856510F41896",
+                "PreviousTxnLgrSeq": 90156036
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "254",
+                  "Owner": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+                  "RootIndex": "CDA3339900126079FDB4065323F527566FE5ED265D38D016563D51C1233AC382"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "BF8B60D0093FAF9AB84684FD4E6920F7F32910E19593CCE03FA291A0F734B93E"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "F2DA37ADB80192A93F683CA24EBFB1F1B6438939E2A33F84054232922BE20FD2",
+                  "Balance": "1467511942",
+                  "Flags": 0,
+                  "OwnerCount": 51,
+                  "Sequence": 12994741
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "272EA89713D998812DF34E0A30F9E1F53AD24B7977661EF7DEE8681F5DB4A92D",
+                  "Balance": "1467511952",
+                  "Sequence": 12994740
+                },
+                "PreviousTxnID": "272EA89713D998812DF34E0A30F9E1F53AD24B7977661EF7DEE8681F5DB4A92D",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E0093B8AB888B3827399F6A36072CB9EB55AC8B9A0C326EB8113732B7A88394F",
+                "PreviousTxnID": "272EA89713D998812DF34E0A30F9E1F53AD24B7977661EF7DEE8681F5DB4A92D",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            }
+          ],
+          "TransactionIndex": 28,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rMvCasZ9cohYrSZRNYPTZfoaaSUQMfgQ8G",
+        "Amount": "1195000000",
+        "Destination": "rBA7oBScBPccjDcmGhkmCY82v2ZeLa2K2f",
+        "DestinationTag": 26489892,
+        "Fee": "10000",
+        "Sequence": 67931184,
+        "SigningPubKey": "034BEF11C25323DF3EE1AE1B3AB360BB4F7CA7B8B4CDC2744969AE48F1A0282DC4",
+        "TransactionType": "Payment",
+        "TxnSignature": "3045022100E8DA287C278AAF39E4321E3806DF98942A9E3E855CD55D2A5EE6633F7A97F15E02204BD5FBC013E8C4302064FD3711344A33B7D02EB016C9A391FE2EC18AB4576435",
+        "hash": "F94B2EDCF9ADF89E124EAE159A25869393CBBAD7100F0A830D4C4FB2A9E56C0E",
+        "DeliverMax": "1195000000",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMvCasZ9cohYrSZRNYPTZfoaaSUQMfgQ8G",
+                  "Balance": "76864127155631",
+                  "Flags": 0,
+                  "OwnerCount": 1,
+                  "Sequence": 67931185
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "3BFAEEAD933C62413BD9A92BBC11993F2B0FCA28E2CD8FEE69EB8C22EE848E36",
+                "PreviousFields": {
+                  "Balance": "76865322165631",
+                  "Sequence": 67931184
+                },
+                "PreviousTxnID": "81AB3D1DD4502D2ED0AC283FF66DC150B0DFC05D8DC8F0B77616FE7E19328FE2",
+                "PreviousTxnLgrSeq": 90156054
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBA7oBScBPccjDcmGhkmCY82v2ZeLa2K2f",
+                  "Balance": "1801466839461",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 73986564
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E46AD04FC6268AFC5E4B22519F0242F93A2C62D0349C6FE51ECA0E76527FAE2D",
+                "PreviousFields": {
+                  "Balance": "1800271839461"
+                },
+                "PreviousTxnID": "26D95C2A28EBE302F89AE469714E82E837D1BA493EE65EF8B9EF4120AC6CF029",
+                "PreviousTxnLgrSeq": 90156045
+              }
+            }
+          ],
+          "TransactionIndex": 63,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "1195000000"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994747,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": {
+          "currency": "262",
+          "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+          "value": "1183072061599743e-27"
+        },
+        "TakerPays": {
+          "currency": "434F524500000000000000000000000000000000",
+          "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+          "value": "1864270436029362e-29"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "2C9F7B8E73435C4A2910C84FE869EE3838639D96ED9085709DC0C8A23DE114297B89CE99B539C5F80BA9091C9D27EDF510A0595617B90454052ECE25E296E208",
+        "hash": "FA5F34CD69302D540E466246C0C86223FE5824F2720DFEE53E8BC11AC858896A",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1E1ADBD847116F2C0DF91CCB7165719E2285397499705C85414A745A3AC80F43",
+                "PreviousTxnID": "021EA6C5BE9AE7209B23BF4F39BB738FFA45EB4B1CD6EAFFCFFB471FEF11AC10",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000005835736533681642"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "968094565752D3F13D0F072C005830CC4C81B87EBF471026B2B583BE4F008F9E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000005835748364402258"
+                  }
+                },
+                "PreviousTxnID": "06897F546B9394C4EC95A010FCACC50B03CA2D85A06BAD86D19F5B19D5BDB3B4",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "ea0",
+                  "Owner": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                  "RootIndex": "5DD87298A566F5805C113F1E887578A4AF0123F117D08E74F3A0698F1AD100ED"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B2FBE6A2AD61B0BBC3C6EECCAD32590841ADA8E5AE4811728B29F85AA95A747F"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-85.7432921390538"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rNgEMUDzYaSFGCyBVEbdjWHe4aqRdBJFsN",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "e99"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B96747D67A5D752D833FFBC9A44A4686BF72A4F6FDF2B3DE42009C31A9E532ED",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-85.74329213907244"
+                  }
+                },
+                "PreviousTxnID": "DE110956D7EF61FF1BFB955428AAB4E24665466DB0593CB57C27F2FB836E877E",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "FA5F34CD69302D540E466246C0C86223FE5824F2720DFEE53E8BC11AC858896A",
+                  "Balance": "1467511872",
+                  "Flags": 0,
+                  "OwnerCount": 50,
+                  "Sequence": 12994748
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "06897F546B9394C4EC95A010FCACC50B03CA2D85A06BAD86D19F5B19D5BDB3B4",
+                  "Balance": "1467511882",
+                  "OwnerCount": 49,
+                  "Sequence": 12994747
+                },
+                "PreviousTxnID": "06897F546B9394C4EC95A010FCACC50B03CA2D85A06BAD86D19F5B19D5BDB3B4",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5.441279083269914"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "262",
+                    "issuer": "rPTVSsQTeZGfLTEociHb2sqaGbBHxX4co4",
+                    "value": "0"
+                  },
+                  "HighNode": "1",
+                  "LowLimit": {
+                    "currency": "262",
+                    "issuer": "rNgEMUDzYaSFGCyBVEbdjWHe4aqRdBJFsN",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F6B3EA89AA7CA0CFA93C462078472417FE72D18D460E006FFC28933EE4BC7145",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "262",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "5.441279083268731"
+                  }
+                },
+                "PreviousTxnID": "DE110956D7EF61FF1BFB955428AAB4E24665466DB0593CB57C27F2FB836E877E",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F7649E56EB86403211BE414801DA87DD2B143701E72EE2553D87DD748E698848",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1863810660369185e-26"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "HighNode": "19c",
+                  "LowLimit": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "0"
+                  },
+                  "LowNode": "ea1"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 35,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 12994732,
+        "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+        "TakerGets": "494",
+        "TakerPays": {
+          "currency": "58434F5245000000000000000000000000000000",
+          "issuer": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+          "value": "0.000005556041197418687"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "B806F7A404C134C586D584AD9A34B9A66D7489A9C8C89B8168DD71E2888EFB6D13B15ABE08D53FDAE4AC43CC44ACD3629D9B24AEAB5E85E133DB9D3BA348C10A",
+        "hash": "FE15DA0666AC16B54CCB9819A1D6AAD37E2AC479D1EAF39879CE4E853B336B9B",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b",
+                  "Owner": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "RootIndex": "41B79640AFB84EF0D56C2166E932625EB79957A445541CEA47A5D58D0D3E18D0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "324B48B22DD551D2CFA495367EA407612FCE2FAC6E3213793C359F588B9C0DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "CC7564FBE32710D4B022B8B33B41E28C8C2BE4096EAE7B57CD96822C7C81E439",
+                  "Account": "rwmP5KpxyXazdGuUxWy94Vf35FTiwKFdTA",
+                  "Balance": "13431952330",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 86795387
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "8862F75381FF1FDF13C8F727131A0CB257EB7AD816998F9A5463CE820A00EF0A",
+                "PreviousFields": {
+                  "Balance": "13431951836"
+                },
+                "PreviousTxnID": "5B7CFADCDB24DF496AFAA59E171859F2A047D7DDE98842588CB6056AB5E2004C",
+                "PreviousTxnLgrSeq": 90156042
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "99f",
+                  "Owner": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+                  "RootIndex": "C0DA491E53EA9440740C19AAF40FD7AB7132224EFFEF4B224280BF80C03C7BF8"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "979C3C6EC438DABC913A71490D84B69C2A8EEB02ED871BB22BE79FD7C81A047A"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-151391.6454636956"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rwmP5KpxyXazdGuUxWy94Vf35FTiwKFdTA",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+                    "value": "0"
+                  },
+                  "LowNode": "988"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "9BE256CCF7FEA1C0D4054BA2E6A9BED6200173A8EB8D591DE90D5F52A67C1D7D",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-151391.6510185451"
+                  }
+                },
+                "PreviousTxnID": "5B7CFADCDB24DF496AFAA59E171859F2A047D7DDE98842588CB6056AB5E2004C",
+                "PreviousTxnLgrSeq": 90156042
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "AC0346AB66951F5FC37BC58EE00CEC66E878B2CFA770BFD503CD7730022B17BA",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0055548495"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "r3dVizzUAS3U29WKaaSALqkieytA2LCoRe",
+                    "value": "0"
+                  },
+                  "HighNode": "9a0",
+                  "LowLimit": {
+                    "currency": "58434F5245000000000000000000000000000000",
+                    "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                    "value": "0"
+                  },
+                  "LowNode": "19c"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+                  "AccountTxnID": "FE15DA0666AC16B54CCB9819A1D6AAD37E2AC479D1EAF39879CE4E853B336B9B",
+                  "Balance": "1467511529",
+                  "Flags": 0,
+                  "OwnerCount": 50,
+                  "Sequence": 12994733
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+                "PreviousFields": {
+                  "AccountTxnID": "71B257414F2BE28C71CCD387F18DE2F4E33F66432932C37950A1BA723905BAE5",
+                  "Balance": "1467512033",
+                  "OwnerCount": 49,
+                  "Sequence": 12994732
+                },
+                "PreviousTxnID": "71B257414F2BE28C71CCD387F18DE2F4E33F66432932C37950A1BA723905BAE5",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E0093B8AB888B3827399F6A36072CB9EB55AC8B9A0C326EB8113732B7A88394F",
+                "PreviousTxnID": "D12F48245842EDE3CCFAEBBB7D39E1C03F91A272ABFD753DAACD51DA22232B99",
+                "PreviousTxnLgrSeq": 90156042
+              }
+            }
+          ],
+          "TransactionIndex": 20,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 655360,
+        "LastLedgerSequence": 90156060,
+        "Sequence": 7423364,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TakerGets": {
+          "currency": "4249547800000000000000000000000000000000",
+          "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+          "value": "0.0000000001088060910386818"
+        },
+        "TakerPays": {
+          "currency": "CSC",
+          "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+          "value": "0.000000006263602897384274"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "81DFC75B518D1AE5F626A1F8A49C4866EEE4ACBB0AF568F758C052D505527E17D0C9C73F320B93D8B5C68A1276C67B05A6395FCE6B943F53CC897229CEA47E0A",
+        "hash": "FEEA3504938B34D4A28F8BBA69DE3C7B68E11264B18FB9658B1BBFAFC1DE63CA",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.376267977783104"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "e1",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "LowNode": "9"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "68062CBD2811E4D5FB502D7C86E4BB04DA46A2AAE9BE2B400045A57E3B5DBA8B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1.37626797789191"
+                  }
+                },
+                "PreviousTxnID": "C4C48398BD837B9BC1AA0EC4E080D6BC340C1FE4761B84A85208544F463B95A8",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-83706.18817097267"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "CSC",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "1000000000000000e-1"
+                  },
+                  "HighNode": "8",
+                  "LowLimit": {
+                    "currency": "CSC",
+                    "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                    "value": "0"
+                  },
+                  "LowNode": "cd5"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "943790BC0B024485EE6ABEFB29FC21D2AA6940D7ECA08E1CEC8BEA2849B00985",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-83706.18816471062"
+                  }
+                },
+                "PreviousTxnID": "BA0F3697C5EBCFC0319F3068742D2C2CA1EAFAB9022FFD130AF65FC96996167F",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-25818.3418012837"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "CSC",
+                    "issuer": "rBbya3c9Pb7oiLi3SDbewyBTWH3iyA2r3t",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "CSC",
+                    "issuer": "rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr",
+                    "value": "0"
+                  },
+                  "LowNode": "c82"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D3D3946A7278AE47D184AF5887CD05C970AE1C023B3C3E114886DA796AB66A38",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "CSC",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-25818.34180754575"
+                  }
+                },
+                "PreviousTxnID": "FE3A88F7CBA677272155CBF36D83255A8794B21481C998819D0C3B7C3D576A50",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "FEEA3504938B34D4A28F8BBA69DE3C7B68E11264B18FB9658B1BBFAFC1DE63CA",
+                  "Balance": "420152628",
+                  "Flags": 0,
+                  "OwnerCount": 143,
+                  "Sequence": 7423365
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "DE110956D7EF61FF1BFB955428AAB4E24665466DB0593CB57C27F2FB836E877E",
+                  "Balance": "420152638",
+                  "Sequence": 7423364
+                },
+                "PreviousTxnID": "DE110956D7EF61FF1BFB955428AAB4E24665466DB0593CB57C27F2FB836E877E",
+                "PreviousTxnLgrSeq": 90156059
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.4484893664564373"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBitcoiNXev8VoVxV7pwoQx1sSfonVP9i3",
+                    "value": "0"
+                  },
+                  "HighNode": "dd",
+                  "LowLimit": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rBbya3c9Pb7oiLi3SDbewyBTWH3iyA2r3t",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F6544D69B85890231ACB54262A16EE5C5BB545D3E3A897FE20C98CE9CB168387",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4249547800000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.4484893663476312"
+                  }
+                },
+                "PreviousTxnID": "FE3A88F7CBA677272155CBF36D83255A8794B21481C998819D0C3B7C3D576A50",
+                "PreviousTxnLgrSeq": 90156058
+              }
+            }
+          ],
+          "TransactionIndex": 6,
+          "TransactionResult": "tesSUCCESS"
+        }
+      }
+    ]
+  }
+}

--- a/xrpl4j-core/src/test/resources/negative-balance-ledgers/txresult-offercreate-withnegatives.json
+++ b/xrpl4j-core/src/test/resources/negative-balance-ledgers/txresult-offercreate-withnegatives.json
@@ -1,0 +1,169 @@
+{
+  "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+  "Fee": "10",
+  "Flags": 655360,
+  "LastLedgerSequence": 87704324,
+  "Memos": [
+    {
+      "Memo": {
+        "MemoData": "4209DCD25EF91F20D6C0FC12F175B6CD0AD6BAF604A22498404A3ED505E3E037401BE767D34DF04E4076E2CE7646AE053FF0000000000000"
+      }
+    }
+  ],
+  "Sequence": 1051567,
+  "SigningPubKey": "EDE30BA017ED458B9B372295863B042C2BA8F11AD53B4BDFB398E778CB7679146B",
+  "TakerGets": "9939",
+  "TakerPays": {
+    "currency": "SGB",
+    "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+    "value": "-0.0005216884852049924"
+  },
+  "TransactionType": "OfferCreate",
+  "TxnSignature": "7AE0BEC498F6224AB90EB6A6792A39C9EBB01F960BCC1C7963408ECB4CEB58134A0DF586E92A3AA02FFF0CE3BC0B24AF491300B728059D51B258DC43C6FCDC0F",
+  "hash": "C4D4986FE857F144B8F21B8D603430931EE65F382E1FB8547EF23E9FB0664DA5",
+  "metaData": {
+    "AffectedNodes": [
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+            "Balance": "-252580537",
+            "Flags": 0,
+            "OwnerCount": 31,
+            "Sequence": 77735066
+          },
+          "LedgerEntryType": "AccountRoot",
+          "LedgerIndex": "0943A7CA0445F090EFA54DF215581407714AE7E396207B491C049F9EB75BB6A5",
+          "PreviousFields": {
+            "Balance": "-252570598"
+          },
+          "PreviousTxnID": "4809E032BE36F28C90A3824DF5F28250BFCCF3985C35E04235CD29411AE227C2",
+          "PreviousTxnLgrSeq": 87704321
+        }
+      },
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+            "BookDirectory": "CF4E10710F68879A15534813B9047ED60B2A0E90988B9F965906C4AC0727C256",
+            "BookNode": "0",
+            "Flags": 0,
+            "OwnerNode": "1",
+            "Sequence": 77735064,
+            "TakerGets": {
+              "currency": "SGB",
+              "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+              "value": "-365.6536989495917"
+            },
+            "TakerPays": "-6966043"
+          },
+          "LedgerEntryType": "Offer",
+          "LedgerIndex": "141FC5FC5B32AD1CF25E80F2DF6B1D4B0E8EF0936967253160D412ACEA3EFC9C",
+          "PreviousFields": {
+            "TakerGets": {
+              "currency": "SGB",
+              "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+              "value": "-366.175405765622"
+            },
+            "TakerPays": "-6975982"
+          },
+          "PreviousTxnID": "4809E032BE36F28C90A3824DF5F28250BFCCF3985C35E04235CD29411AE227C2",
+          "PreviousTxnLgrSeq": 87704321
+        }
+      },
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Balance": {
+              "currency": "SGB",
+              "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+              "value": "-39.20990285771919"
+            },
+            "Flags": 2228224,
+            "HighLimit": {
+              "currency": "SGB",
+              "issuer": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+              "value": "-20"
+            },
+            "HighNode": "7",
+            "LowLimit": {
+              "currency": "SGB",
+              "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+              "value": "-10"
+            },
+            "LowNode": "5f4"
+          },
+          "LedgerEntryType": "RippleState",
+          "LedgerIndex": "8D426D0D58528156D32A4D77C4B176C9552DFD85B2E953F8B4FE971CE52CA294",
+          "PreviousFields": {
+            "Balance": {
+              "currency": "SGB",
+              "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+              "value": "-38.68819604168891"
+            }
+          },
+          "PreviousTxnID": "D76EBAC94363B98275523C0B54EABA77057940B6671BA93AD9ED7E4981FE58F8",
+          "PreviousTxnLgrSeq": 87704321
+        }
+      },
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Balance": {
+              "currency": "SGB",
+              "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+              "value": "-1336.091568733186"
+            },
+            "Flags": 2228224,
+            "HighLimit": {
+              "currency": "SGB",
+              "issuer": "rfpBQvCTyCsExf47gvDbY647b9pz67BjsM",
+              "value": "-23523463"
+            },
+            "HighNode": "0",
+            "LowLimit": {
+              "currency": "SGB",
+              "issuer": "rctArjqVvTHihekzDeecKo6mkTYTUSBNc",
+              "value": "-1"
+            },
+            "LowNode": "571"
+          },
+          "LedgerEntryType": "RippleState",
+          "LedgerIndex": "9A0EB00C56F3A466A7973F355AFF8937FE3F601A379254740E231B9286AE26B2",
+          "PreviousFields": {
+            "Balance": {
+              "currency": "SGB",
+              "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+              "value": "-1336.614840669664"
+            }
+          },
+          "PreviousTxnID": "4809E032BE36F28C90A3824DF5F28250BFCCF3985C35E04235CD29411AE227C2",
+          "PreviousTxnLgrSeq": 87704321
+        }
+      },
+      {
+        "ModifiedNode": {
+          "FinalFields": {
+            "Account": "rapido5rxPmP4YkMZZEeXSHqWefxHEkqv6",
+            "AccountTxnID": "C4D4986FE857F144B8F21B8D603430931EE65F382E1FB8547EF23E9FB0664DA5",
+            "Balance": "-2308705199",
+            "Flags": 0,
+            "OwnerCount": 117,
+            "Sequence": 1051568
+          },
+          "LedgerEntryType": "AccountRoot",
+          "LedgerIndex": "BFF40FB02870A44349BB5E482CD2A4AA3415C7E72F4D2E9E98129972F26DA9AA",
+          "PreviousFields": {
+            "AccountTxnID": "DAD2D087DDD04A9BB8ECA61B729DB8CA2030C8F6BDA1541C84C5155C247AD9A7",
+            "Balance": "-2308715148",
+            "Sequence": 1051567
+          },
+          "PreviousTxnID": "DAD2D087DDD04A9BB8ECA61B729DB8CA2030C8F6BDA1541C84C5155C247AD9A7",
+          "PreviousTxnLgrSeq": 87704321
+        }
+      }
+    ],
+    "TransactionIndex": 9,
+    "TransactionResult": "tesSUCCESS"
+  }
+}


### PR DESCRIPTION
Fixes #474 by adding the `isNegative` function `CurrencyAmount`, and then properly supporting negative value detection in XRP and IssuedCurrency amounts.

This fix should also fix issue #527.