### PR TITLE
Update deploy plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -498,18 +498,17 @@
           </configuration>
         </plugin>
 
-        <!-- org.sonatype.plugins:nexus-staging-maven-plugin -->
+        <!-- org.sonatype.central:central-publishing-maven-plugin -->
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.13</version>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>0.5.0</version>
           <extensions>true</extensions>
           <configuration>
-            <serverId>ossrh-snapshots</serverId>
-            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            <publishingServerId>central</publishingServerId>
           </configuration>
         </plugin>
+
 
         <!-- org.codehaus.mojo:license-maven-plugin -->
         <plugin>
@@ -608,10 +607,10 @@
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
 
-      <!-- org.sonatype.plugins:nexus-staging-maven-plugin -->
+      <!-- org.sonatype.central:central-publishing-maven-plugin -->
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
       </plugin>
 
       <plugin>
@@ -677,16 +676,5 @@
 
     </plugins>
   </reporting>
-
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-    </repository>
-  </distributionManagement>
 
 </project>


### PR DESCRIPTION
Sonatype has a new mechanism to deploy to maven central. This change enables the new system. See https://central.sonatype.org/publish-ea/publish-ea-guide/