### PR TITLE
Upgrade bcprov-jdk18on version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
-        <version>1.75</version>
+        <version>1.78.1</version>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>


### PR DESCRIPTION
Fixes a bunch of vulnerabilities - https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on

Also https://github.com/XRPLF/xrpl4j/pull/438 never reopened with a newer version