### PR TITLE
Fixes #590

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/TransactionDeserializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/TransactionDeserializer.java
@@ -52,12 +52,13 @@ public class TransactionDeserializer extends StdDeserializer<Transaction> {
     TransactionType transactionType = TransactionType.forValue(objectNode.get("TransactionType").asText());
     final Class<? extends Transaction> transactionTypeClass = Transaction.typeMap.inverse().get(transactionType);
 
-    // Remove the `Account` property from any incoming `UnlModify` JSON about to be deserialized. This is because the 
-    // JSON returned by the rippled/clio API v1 has a bug where the account value in `UnlModify` transactions is an 
-    // empty string. In this case, the Java value for the `Account` property is always set to ACCOUNT_ZERO via a default
-    // method, so this property is removed from incoming JSON before deserialization because it's not needed (the 
-    // default method handles population in Java) and if not removed, this field will end up in the `unknownFields`
-    // map of the ultimate Java object, which is incorrect.
+    // Fixes #590 by removing the `Account` property from any incoming `UnlModify` JSON about to be deserialized. 
+    // This fixes #590 because the JSON returned by the rippled/clio API v1 has a bug where the account value in 
+    // `UnlModify` transactions is an empty string. When this value is deserialized, an exception is thrown because 
+    // the empty string value is not a valid `Address`. By removing the property from incoming JSON, the Java value 
+    // for the `Account` property is always set to ACCOUNT_ZERO via a default method. One other side effect of this 
+    // fix is that `Account` property will not be errantly added to `unknownFields map of the ultimate Java object,
+    // which is incorrect.
     if (UnlModify.class.isAssignableFrom(transactionTypeClass)) {
       objectNode.remove("Account");
     }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/TransactionDeserializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/TransactionDeserializer.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.jackson.modules;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,6 @@ package org.xrpl.xrpl4j.model.jackson.modules;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -50,8 +49,7 @@ public class TransactionDeserializer extends StdDeserializer<Transaction> {
     final ObjectMapper objectMapper = (ObjectMapper) jsonParser.getCodec();
     final ObjectNode objectNode = objectMapper.readTree(jsonParser);
 
-    final JsonNode transactionTypeJsonNode = objectNode.get("TransactionType");
-    final TransactionType transactionType = TransactionType.forValue(transactionTypeJsonNode.asText());
+    TransactionType transactionType = TransactionType.forValue(objectNode.get("TransactionType").asText());
     final Class<? extends Transaction> transactionTypeClass = Transaction.typeMap.inverse().get(transactionType);
 
     // Remove the `Account` property from any incoming `UnlModify` JSON about to be deserialized. This is because the 

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/UnlModify.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/UnlModify.java
@@ -9,9 +9,9 @@ package org.xrpl.xrpl4j.model.transactions;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,8 +28,8 @@ import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 
 /**
- * A {@link UnlModify} pseudo-transaction marks a change to the Negative UNL,
- * indicating that a trusted validator has gone offline or come back online.
+ * A {@link UnlModify} pseudo-transaction marks a change to the Negative UNL, indicating that a trusted validator has
+ * gone offline or come back online.
  *
  * @see "https://xrpl.org/unlmodify.html"
  */
@@ -49,27 +49,26 @@ public interface UnlModify extends Transaction {
     return ImmutableUnlModify.builder();
   }
 
-
   /**
-   * This field is overridden in this class because of a bug in rippled that causes this field to be missing
-   * in API responses. In other pseudo-transactions such as {@link SetFee} and {@link EnableAmendment}, the rippled
-   * API sets the {@code account} field to a special XRPL address called ACCOUNT_ZERO, which is the base58
-   * encoding of the number zero. Because rippled does not set the {@code account} field of the {@link UnlModify}
-   * pseudo-transaction, this override will always set the field to ACCOUNT_ZERO to avoid deserialization issues
-   * and to be consistent with other pseudo-transactions.
+   * This field is overridden in this class because of a bug in rippled that causes this field to be missing in API
+   * responses. In other pseudo-transactions such as {@link SetFee} and {@link EnableAmendment}, the rippled API sets
+   * the {@code account} field to a special XRPL address called ACCOUNT_ZERO, which is the base58 encoding of the number
+   * zero. Because rippled does not set the {@code account} field of the {@link UnlModify} pseudo-transaction, this
+   * override will always set the field to ACCOUNT_ZERO to avoid deserialization issues and to be consistent with other
+   * pseudo-transactions.
    *
    * @return Always returns ACCOUNT_ZERO, which is the base58 encoding of the number zero.
    */
   @Override
   @JsonProperty("Account")
-  @Value.Default
+  @Value.Default // Must be `Default` not `Derived`, else this field will be serialized into `unknownFields`.
   default Address account() {
     return ACCOUNT_ZERO;
   }
 
   /**
-   * The {@link LedgerIndex} where this pseudo-transaction appears.
-   * This distinguishes the pseudo-transaction from other occurrences of the same change.
+   * The {@link LedgerIndex} where this pseudo-transaction appears. This distinguishes the pseudo-transaction from other
+   * occurrences of the same change.
    *
    * @return A {@link LedgerIndex} to indicates where the tx appears.
    */
@@ -77,8 +76,8 @@ public interface UnlModify extends Transaction {
   LedgerIndex ledgerSequence();
 
   /**
-   * If 1, this change represents adding a validator to the Negative UNL. If 0, this change represents
-   * removing a validator from the Negative UNL.
+   * If 1, this change represents adding a validator to the Negative UNL. If 0, this change represents removing a
+   * validator from the Negative UNL.
    *
    * @return An {@link UnsignedInteger} denoting either 0 or 1.
    */

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/NegativeTransactionMetadataTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/NegativeTransactionMetadataTest.java
@@ -1,7 +1,6 @@
 package org.xrpl.xrpl4j.model.transactions;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -113,6 +112,29 @@ class NegativeTransactionMetadataTest {
   }
 
   /**
+   * This test validates that the ledger 94084608 and all of its transactions and metadata are handled correctly, even
+   * in the presence of a `UnlModify` transaction that has an empty `Account`.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "ledger-result-94084608.json" // <-- See https://github.com/XRPLF/xrpl4j/issues/590
+  })
+  void deserializeLedgerResultWithSpecialObjects(String ledgerResultFileName) throws IOException {
+    Objects.requireNonNull(ledgerResultFileName);
+
+    File jsonFile = new File(
+      "src/test/resources/special-object-ledgers/" + ledgerResultFileName
+    );
+
+    LedgerResult ledgerResult = objectMapper.readValue(jsonFile, LedgerResult.class);
+
+    ledgerResult.ledger().transactions().forEach(transactionResult -> {
+      assertThat(transactionResult.metadata().isPresent()).isTrue();
+      transactionResult.metadata().ifPresent(this::handleTransactionMetadata);
+    });
+  }
+
+  /**
    * This test validates that the ledger 87704323 and all of its transactions and metadata are handled correctly, even
    * in the presence of negative XRP or IOU amounts.
    */
@@ -144,9 +166,13 @@ class NegativeTransactionMetadataTest {
           } else if (ledgerEntryType.equals(MetaLedgerEntryType.RIPPLE_STATE)) {
             handleMetaLedgerObject((MetaRippleStateObject) createdNode.newFields());
           } else if (ledgerEntryType.equals(MetaLedgerEntryType.DIRECTORY_NODE)) {
-            logger.warn("Ignoring ledger entry type {}", ledgerEntryType);
+            logger.warn("Ignoring CreatedNode ledger entry type {}", ledgerEntryType);
+          } else if (ledgerEntryType.equals(MetaLedgerEntryType.NEGATIVE_UNL)) {
+            logger.warn(
+              "Ignoring DeletedNode ledger entry type {}. See https://github.com/XRPLF/xrpl4j/issues/16",
+              ledgerEntryType);
           } else {
-            throw new RuntimeException("Unhandled ledger entry type: " + ledgerEntryType);
+            throw new RuntimeException("Unhandled CreatedNode ledger entry type: " + ledgerEntryType);
           }
         },
         (modifiedNode) -> {
@@ -159,8 +185,19 @@ class NegativeTransactionMetadataTest {
                 handleMetaLedgerObject((MetaAccountRootObject) metaLedgerObject);
               } else if (ledgerEntryType.equals(MetaLedgerEntryType.RIPPLE_STATE)) {
                 handleMetaLedgerObject((MetaRippleStateObject) metaLedgerObject);
+              } else if (ledgerEntryType.equals(MetaLedgerEntryType.DIRECTORY_NODE)) {
+                logger.warn("Ignoring ModifiedNode ledger entry type {}", ledgerEntryType);
+              } else if (ledgerEntryType.equals(MetaLedgerEntryType.NEGATIVE_UNL)) {
+                logger.warn(
+                  "Ignoring DeletedNode ledger entry type {}. See https://github.com/XRPLF/xrpl4j/issues/16",
+                  ledgerEntryType);
+              } else if (ledgerEntryType.equals(MetaLedgerEntryType.AMM)) {
+                logger.warn(
+                  "Ignoring DeletedNode ledger entry type {}. See https://github.com/XRPLF/xrpl4j/issues/591",
+                  ledgerEntryType);
               } else {
-                throw new RuntimeException("Unhandled ledger entry type: " + ledgerEntryType);
+                throw new RuntimeException(
+                  "Unhandled ModifiedNode PreviousFields ledger entry type: " + ledgerEntryType);
               }
             });
 
@@ -173,10 +210,15 @@ class NegativeTransactionMetadataTest {
                 handleMetaLedgerObject((MetaAccountRootObject) metaLedgerObject);
               } else if (ledgerEntryType.equals(MetaLedgerEntryType.RIPPLE_STATE)) {
                 handleMetaLedgerObject((MetaRippleStateObject) metaLedgerObject);
-              } else if (ledgerEntryType.equals(MetaLedgerEntryType.DIRECTORY_NODE)) {
-                logger.warn("Ignoring ledger entry type {}", ledgerEntryType);
+              } else if (
+                ledgerEntryType.equals(MetaLedgerEntryType.DIRECTORY_NODE)) {
+                logger.warn("Ignoring ModifiedNode ledger entry type {}", ledgerEntryType);
+              } else if (ledgerEntryType.equals(MetaLedgerEntryType.AMM)) {
+                logger.warn(
+                  "Ignoring ModifiedNode ledger entry type {}. See See https://github.com/XRPLF/xrpl4j/issues/591",
+                  ledgerEntryType);
               } else {
-                throw new RuntimeException("Unhandled ledger entry type: " + ledgerEntryType);
+                throw new RuntimeException("Unhandled ModifiedNode FinalFields ledger entry type: " + ledgerEntryType);
               }
             });
         },
@@ -191,7 +233,8 @@ class NegativeTransactionMetadataTest {
               } else if (ledgerEntryType.equals(MetaLedgerEntryType.RIPPLE_STATE)) {
                 handleMetaLedgerObject((MetaRippleStateObject) metaLedgerObject);
               } else {
-                throw new RuntimeException("Unhandled ledger entry type: " + ledgerEntryType);
+                throw new RuntimeException(
+                  "Unhandled DeletedNode PreviousFields ledger entry type: " + ledgerEntryType);
               }
             });
 
@@ -204,14 +247,15 @@ class NegativeTransactionMetadataTest {
           } else if (ledgerEntryType.equals(MetaLedgerEntryType.RIPPLE_STATE)) {
             handleMetaLedgerObject((MetaRippleStateObject) finalFields);
           } else if (ledgerEntryType.equals(MetaLedgerEntryType.TICKET)) {
-            logger.info("Ignoring ledger entry type {} because it has no currency values for negative checking",
-              ledgerEntryType);
+            logger.info(
+              "Ignoring ledger entry type {} because it has no currency values for negative checking", ledgerEntryType
+            );
           } else if (ledgerEntryType.equals(MetaLedgerEntryType.DIRECTORY_NODE)) {
-            logger.warn("Ignoring ledger entry type {}", ledgerEntryType);
+            logger.warn("Ignoring DeletedNode ledger entry type {}", ledgerEntryType);
           } else if (ledgerEntryType.equals(MetaLedgerEntryType.NFTOKEN_OFFER)) {
             handleMetaLedgerObject((MetaNfTokenOfferObject) finalFields);
           } else {
-            throw new RuntimeException("Unhandled ledger entry type: " + ledgerEntryType);
+            throw new RuntimeException("Unhandled DeletedNode FinalFields ledger entry type: " + ledgerEntryType);
           }
         }
       );

--- a/xrpl4j-core/src/test/resources/special-object-ledgers/ledger-result-94084608.json
+++ b/xrpl4j-core/src/test/resources/special-object-ledgers/ledger-result-94084608.json
@@ -1,0 +1,10160 @@
+{
+  "ledger": {
+    "account_hash": "182FEA6AF29CC929EE899B51613193285F938B67E6059033139CCCBE78C2811A",
+    "close_flags": 0,
+    "close_time": 792634570,
+    "close_time_human": "2025-Feb-12 00:16:10.000000000 UTC",
+    "close_time_iso": "2025-02-12T00:16:10Z",
+    "close_time_resolution": 10,
+    "closed": true,
+    "ledger_hash": "576A59C1EA928637915556DBF2BF9F6CC7ADAC942EAA6706BA91BB35751140A5",
+    "ledger_index": "94084608",
+    "parent_close_time": 792634561,
+    "parent_hash": "A2B1008137A86238A72942B7C7C711EED4F29D8812044806EF72CCA65B5DB65E",
+    "total_coins": "99986441776131104",
+    "transaction_hash": "03F812C03CA173CC5B1546E468D9E927783F517ACF6650FF56B9DDB8AC439602",
+    "transactions": [
+      {
+        "Account": "rNVouA3wbxt4JBSSDP851azsfJhC5cVuqT",
+        "Fee": "12",
+        "Flags": 2228224,
+        "LastLedgerSequence": 94084626,
+        "LimitAmount": {
+          "currency": "4954444D53000000000000000000000000000000",
+          "issuer": "r37SFJAmTrxxGT8XQAaA8eUj5Rq7RrakoW",
+          "value": "0"
+        },
+        "Sequence": 92771114,
+        "SigningPubKey": "EDADB1A807C32C6AA8D412BBFC71AC421617AE467D7F9732FF133E8EDC9362E352",
+        "TransactionType": "TrustSet",
+        "TxnSignature": "325FA50E06440C643D18710099360FC5F28DCF63FBCF46CAC0C8A535B90A17C0DFB75300FDC7441522D59B3BC20FA1F9837259A44B7F65BE9D76452F954CCA0F",
+        "hash": "00D9B6D401EC13BDBAD2EE5D14CF8968293C73EC95324E67D987605648A1CB14",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rNVouA3wbxt4JBSSDP851azsfJhC5cVuqT",
+                  "Balance": "29989868",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 92771115,
+                  "TicketCount": 5
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "5BBB016C1A2D909E4085468D97F8EC05E650B691F2F51F09A6B3EE25C8372892",
+                "PreviousFields": {
+                  "Balance": "29989880",
+                  "Sequence": 92771114
+                },
+                "PreviousTxnID": "72F3F833E76FEFAE8B9F8A7A05C2D64F9B626EB29E25C4EB419EF451FAF20B6C",
+                "PreviousTxnLgrSeq": 94080355
+              }
+            }
+          ],
+          "TransactionIndex": 66,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 94084611,
+        "OfferSequence": 167782389,
+        "Sequence": 167782400,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": "14935000000",
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "36853.0799893"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3044022033FF75BE82533D83C59ECBA5AF1109BC3E7FA5DE3292F4B162C66B08BA92F524022062CE07E8782408D2B2AB0AFEC107F9A9D739E019FD1ED3556CA5704D04CECC25",
+        "hash": "024D5B79089F6A4D39A89AB84A99D65A1F09B56BBFC39FBC6D28C9D859C7F999",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3",
+                "PreviousTxnID": "43293CB7CA7BD8540D3783FF0060B4E812CFBD15E6ADC069EA19077CD4B7E507",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "15035590590",
+                  "Flags": 0,
+                  "OwnerCount": 17,
+                  "Sequence": 167782401
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "15035590610",
+                  "Sequence": 167782400
+                },
+                "PreviousTxnID": "43293CB7CA7BD8540D3783FF0060B4E812CFBD15E6ADC069EA19077CD4B7E507",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784F08C43CB22C1300",
+                "NewFields": {
+                  "ExchangeRate": "4f08c43cb22c1300",
+                  "RootIndex": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784F08C43CB22C1300",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f08c43cd5ef5900",
+                  "Flags": 0,
+                  "PreviousTxnID": "DC2A71F9BF5481883265496C97E59BC78A53533E45B47CACDF852930B797FB6F",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "RootIndex": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784F08C43CD5EF5900",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784F08C43CD5EF5900"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "BA054A5279E7ED5C7123414B745ABA1866974C3E302E355E3C4555A073F8DB83",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784F08C43CB22C1300",
+                  "Sequence": 167782400,
+                  "TakerGets": "14935000000",
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "36853.0799893"
+                  }
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "79C54A4EBD69AB2EADCE313042F36092BE432423CC6A4F784F08C43CD5EF5900",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "DC2A71F9BF5481883265496C97E59BC78A53533E45B47CACDF852930B797FB6F",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "Sequence": 167782389,
+                  "TakerGets": "14935000000",
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "36853.0889503"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "F057EE7E93ABE57B9B9AF86E96F315AABD7474CBF9892D891CC7A0D759929566"
+              }
+            }
+          ],
+          "TransactionIndex": 38,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+        "Expiration": 792720015,
+        "Fee": "10",
+        "Flags": 65536,
+        "LastLedgerSequence": 94084626,
+        "OfferSequence": 90961371,
+        "Sequence": 0,
+        "SigningPubKey": "ED4A8371720A1D404927F0B32DD49BDE4F8E2A8177D027482492AEE4F3C5045834",
+        "TakerGets": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "1905.27178"
+        },
+        "TakerPays": "789076180",
+        "TicketSequence": 90961386,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "66A9FB24FF7A5A710FB4F33BCFF1E4953E510C6585BED9705872784FCF167B36FA8AD6E56D59B7DBF6CED6AE205306E71846137479109E972C69A517E1E94E0F",
+        "hash": "0BAF66DD43047CDB74FDE23A20A2A185F1D7BE1E1BA429A11509208365F565D7",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Flags": 0,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "A6F924B090289827515733829A2C4CAF2DABEA5920F6F1B845515F9E243D1D9D",
+                  "PreviousTxnLgrSeq": 94084581,
+                  "TicketSequence": 90961386
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "00B73B6B22FD56B6A52E765989BB9E222CAAB5AA413035FB13D159F38F1C20B7"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "412",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "32D3BEA733A3C7B90A32A6A57DF912F7BE843090DD460A54255F8083E925C2ED",
+                "PreviousTxnID": "9AF16F22553695556DC8E4A57F0CD49ECB2A5DDA274791454BDB273192586A4B",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EC4F5E14E8400",
+                  "BookNode": "0",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "A70CA86B91814034282707115A138861867EE6D06EC3EDCDDF59B572E9274292",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "Sequence": 90961371,
+                  "TakerGets": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "9488.198695759897"
+                  },
+                  "TakerPays": "3944443450"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "8DC82CBEA1948BD424CBA18A574CF4AE15A5B064568451A0E5ABF3B09A470ADE"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Balance": "48203421409",
+                  "Flags": 0,
+                  "OwnerCount": 31,
+                  "Sequence": 90961404,
+                  "TicketCount": 17
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AB4F967F07A17B276A162D2BE831BB2B4BB7D28C58A71E2B47040114CE4599AE",
+                "PreviousFields": {
+                  "Balance": "48203421419",
+                  "OwnerCount": 32,
+                  "TicketCount": 18
+                },
+                "PreviousTxnID": "9AF16F22553695556DC8E4A57F0CD49ECB2A5DDA274791454BDB273192586A4B",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB6B5E3BB7C00",
+                "NewFields": {
+                  "ExchangeRate": "5a0eb6b5e3bb7c00",
+                  "RootIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB6B5E3BB7C00",
+                  "TakerGetsCurrency": "524C555344000000000000000000000000000000",
+                  "TakerGetsIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5a0ec4f5e14e8400",
+                  "Flags": 0,
+                  "PreviousTxnID": "A70CA86B91814034282707115A138861867EE6D06EC3EDCDDF59B572E9274292",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "RootIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EC4F5E14E8400",
+                  "TakerGetsCurrency": "524C555344000000000000000000000000000000",
+                  "TakerGetsIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EC4F5E14E8400"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "E29BAB08BB4A2F5DE8B839DD52EF6F708A0B235AE41DBE6F416BC3B71C10E7BD",
+                "NewFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB6B5E3BB7C00",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "Sequence": 90961386,
+                  "TakerGets": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "1905.271466521407"
+                  },
+                  "TakerPays": "789076180"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 25,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 143700483,
+        "Sequence": 143700487,
+        "SigningPubKey": "039451ECAC6D4EB75E3C926E7DC7BA7721719A1521502F99EC7EB2FE87CEE9E824",
+        "TakerGets": "17091820630",
+        "TakerPays": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "499379.7565155069"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304402205BF45D735921BA7E9DB08D79B560FD66875DABC0CA07BFEE89FE4AC17616183A02205204E257D2FFD731028604AA3EED5D8EC11D4A2E961E6B505EBB94EFEBADC7EE",
+        "hash": "0BFAA9309E7118D22B3385A33AA1C3BAB5758DBAB4F0122AE8F671108A80E579",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "04FCA3878A3792B1F57FCE034BCBD8533B35EEE1CB30FDD3B76C7614FD7B281F",
+                "NewFields": {
+                  "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500A61503C10296A",
+                  "Sequence": 143700487,
+                  "TakerGets": "17091820630",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "499379.7565155069"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "RootIndex": "07CE63F6E62E095CAF97BC77572A203D75ECB68219F97505AC5DF2DB061C9D96"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "07CE63F6E62E095CAF97BC77572A203D75ECB68219F97505AC5DF2DB061C9D96",
+                "PreviousTxnID": "CD5F359A7BB3BA488F8742EC99D8918A60C2E1976954BBC6889F96F8B4CE8CBC",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "Balance": "1000571139",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 143700488
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "47FE64F9223D604034486F4DA7A175D5DA7F8A096952261CF8F3D77B74DC4AFA",
+                "PreviousFields": {
+                  "Balance": "1000571154",
+                  "Sequence": 143700487
+                },
+                "PreviousTxnID": "CD5F359A7BB3BA488F8742EC99D8918A60C2E1976954BBC6889F96F8B4CE8CBC",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500A62BD8BE19380",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "29C80692C5948BDB2B0BB15BC622F7F55E7B1D3C8BB9706514E4B0C93D94F80A",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "Sequence": 143700483,
+                  "TakerGets": "955071694",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "27919.76366379525"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "58D45B1380C74A82C925A6B90385724B6819CD60D840974E2041CE20ECD99650"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500A61503C10296A",
+                "NewFields": {
+                  "ExchangeRate": "500a61503c10296a",
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500A61503C10296A",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "500a62bd8be19380",
+                  "Flags": 0,
+                  "PreviousTxnID": "29C80692C5948BDB2B0BB15BC622F7F55E7B1D3C8BB9706514E4B0C93D94F80A",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500A62BD8BE19380",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500A62BD8BE19380"
+              }
+            }
+          ],
+          "TransactionIndex": 78,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+        "Expiration": 792720015,
+        "Fee": "10",
+        "Flags": 65536,
+        "LastLedgerSequence": 94084626,
+        "OfferSequence": 90961382,
+        "Sequence": 0,
+        "SigningPubKey": "ED4A8371720A1D404927F0B32DD49BDE4F8E2A8177D027482492AEE4F3C5045834",
+        "TakerGets": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "9488.16762"
+        },
+        "TakerPays": "3945380900",
+        "TicketSequence": 90961400,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "64F1B3494B50CBC137FF21EEB1A028D68000CD39B2C35B9B386C02A863DB75064E49EB2870E8CC6A7C1982737C9F87A98AF75D4A540E79997C18DBFE56D43E0A",
+        "hash": "10936C69003027A4EFB32CE83FDC3BF9ED06239A2397AEE14168A371EA42A38C",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089B269F89EA53",
+                  "BookNode": "0",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "D19E12FE05E46721200731AE1139CD387856A40BA672C9E4A1B72816AC492CBC",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "Sequence": 90961382,
+                  "TakerGets": "788888688",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "1910.99607"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "0A57E957C44B71715C2762678A3EDA9043A68E11B7F80FCB1D13D6FCB4948001"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Flags": 0,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "A6F924B090289827515733829A2C4CAF2DABEA5920F6F1B845515F9E243D1D9D",
+                  "PreviousTxnLgrSeq": 94084581,
+                  "TicketSequence": 90961400
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "1194D2455A13F3DBA789BB91543BC4B447FD08107FC268B8ACD137B2B17A74A6"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "412",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "32D3BEA733A3C7B90A32A6A57DF912F7BE843090DD460A54255F8083E925C2ED",
+                "PreviousTxnID": "24D7F6BEFFA561831D754DA6559EAE3509EA107EB6678E96BC4EB4D944A7FE03",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f089b269f89ea53",
+                  "Flags": 0,
+                  "PreviousTxnID": "D19E12FE05E46721200731AE1139CD387856A40BA672C9E4A1B72816AC492CBC",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089B269F89EA53",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089B269F89EA53"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Balance": "48203421389",
+                  "Flags": 0,
+                  "OwnerCount": 29,
+                  "Sequence": 90961404,
+                  "TicketCount": 15
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AB4F967F07A17B276A162D2BE831BB2B4BB7D28C58A71E2B47040114CE4599AE",
+                "PreviousFields": {
+                  "Balance": "48203421399",
+                  "OwnerCount": 30,
+                  "TicketCount": 16
+                },
+                "PreviousTxnID": "24D7F6BEFFA561831D754DA6559EAE3509EA107EB6678E96BC4EB4D944A7FE03",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EC5DF2D292800",
+                "NewFields": {
+                  "ExchangeRate": "5a0ec5df2d292800",
+                  "RootIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EC5DF2D292800",
+                  "TakerGetsCurrency": "524C555344000000000000000000000000000000",
+                  "TakerGetsIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "FE205BF6461BC8D17E9893C8B9CD19DC6AF2A8148C2E2D41D21838C1846AE758",
+                "NewFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EC5DF2D292800",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "Sequence": 90961400,
+                  "TakerGets": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "9488.166788994886"
+                  },
+                  "TakerPays": "3945380900"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 27,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rPKouuMgXmr7K2oa1z5D8A6Pw1ZAvVCiYB",
+        "Amount": {
+          "currency": "24464C4950505900000000000000000000000000",
+          "issuer": "rsENFmELvj92orrCKTkDTug53MzwsB7zBd",
+          "value": "30.74789292401313"
+        },
+        "DeliverMax": {
+          "currency": "24464C4950505900000000000000000000000000",
+          "issuer": "rsENFmELvj92orrCKTkDTug53MzwsB7zBd",
+          "value": "30.74789292401313"
+        },
+        "DeliverMin": {
+          "currency": "24464C4950505900000000000000000000000000",
+          "issuer": "rsENFmELvj92orrCKTkDTug53MzwsB7zBd",
+          "value": "30.13293506553287"
+        },
+        "Destination": "rPKouuMgXmr7K2oa1z5D8A6Pw1ZAvVCiYB",
+        "Fee": "12",
+        "Flags": 131072,
+        "LastLedgerSequence": 94084626,
+        "SendMax": "9338591",
+        "Sequence": 93970645,
+        "SigningPubKey": "ED9C49C3B26279D737BE972FBB292A131031DE2A04952E31D4F34EF53EF02609FA",
+        "TransactionType": "Payment",
+        "TxnSignature": "59A3735B32C56628B2965AC54D53BD157313E87FF6F48F72B5360F9EFFA8854626394C475D54F97274EB454B2548768924FE9F01DCA38FECBB3D4698100E6902",
+        "hash": "12147C84E730F0292B8758CD6571B3C860CAAE2B713E3C247028A6A52BA746C6",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "24464C4950505900000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-30.84269644028536"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "24464C4950505900000000000000000000000000",
+                    "issuer": "rPKouuMgXmr7K2oa1z5D8A6Pw1ZAvVCiYB",
+                    "value": "1000000000"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "24464C4950505900000000000000000000000000",
+                    "issuer": "rsENFmELvj92orrCKTkDTug53MzwsB7zBd",
+                    "value": "0"
+                  },
+                  "LowNode": "8e"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "1E27E8F9D076A1EF4FBD07F50303F498A4B7E7EFC41F6A77C7CE3C67D03D276A",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "24464C4950505900000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.09480351627223"
+                  }
+                },
+                "PreviousTxnID": "0D50E6FC4150D478965C2CA3BD56B7A0CAE5E0ED7A9737CFD97B7F70B343B0AD",
+                "PreviousTxnLgrSeq": 94084569
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "24464C4950505900000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-56327.18189794181"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "24464C4950505900000000000000000000000000",
+                    "issuer": "r93wkPVVrRJbtSbkkeYtEi9W4AERCi2J7a",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "24464C4950505900000000000000000000000000",
+                    "issuer": "rsENFmELvj92orrCKTkDTug53MzwsB7zBd",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "2B4836DBE4D4C55F3D8E2F9BAEE0BF0B90BCB0442CB6ECD0EB9108953A96D1EB",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "24464C4950505900000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-56357.92979086582"
+                  }
+                },
+                "PreviousTxnID": "A8EDB2501C8412287B42674101592CDCF0C53EEF87FF585C8F28479B8B352B28",
+                "PreviousTxnLgrSeq": 94084605
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rPKouuMgXmr7K2oa1z5D8A6Pw1ZAvVCiYB",
+                  "Balance": "3828361",
+                  "Flags": 0,
+                  "OwnerCount": 2,
+                  "Sequence": 93970646
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C6858E27A1F54E258F2A321E2F671E99CC1962EF2B1EF4E1179A909B189FD8C1",
+                "PreviousFields": {
+                  "Balance": "13136548",
+                  "Sequence": 93970645
+                },
+                "PreviousTxnID": "BCBA038521FBECACBF8FE225DD64B4ABFE0552FFA5DB4AA08CB10E7288EA0B48",
+                "PreviousTxnLgrSeq": 94084573
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "486C5217703D4B42CD4675C82E0C88E686D14C19FB8A31BBFB68FBD9EFFE836B",
+                  "Account": "r93wkPVVrRJbtSbkkeYtEi9W4AERCi2J7a",
+                  "Balance": "17060817918",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 91626141
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "FE8F56C76FD08DC0BF1637ABFB1A772627145E3C3B5C071861F319352A001054",
+                "PreviousFields": {
+                  "Balance": "17051509743"
+                },
+                "PreviousTxnID": "A8EDB2501C8412287B42674101592CDCF0C53EEF87FF585C8F28479B8B352B28",
+                "PreviousTxnLgrSeq": 94084605
+              }
+            }
+          ],
+          "TransactionIndex": 74,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "24464C4950505900000000000000000000000000",
+            "issuer": "rsENFmELvj92orrCKTkDTug53MzwsB7zBd",
+            "value": "30.74789292401313"
+          }
+        }
+      },
+      {
+        "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+        "Expiration": 792720015,
+        "Fee": "10",
+        "Flags": 65536,
+        "LastLedgerSequence": 94084626,
+        "OfferSequence": 90961367,
+        "Sequence": 0,
+        "SigningPubKey": "ED4A8371720A1D404927F0B32DD49BDE4F8E2A8177D027482492AEE4F3C5045834",
+        "TakerGets": "789076180",
+        "TakerPays": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "1911.00047"
+        },
+        "TicketSequence": 90961366,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "2879E5DFBB3E9C3E86464CDACC1EA4811E545A684351C2F41B78A3C74F0F9DB43B51A2A2FD9BF2275B011B2A8B60E0755F065F8CCDB3A8309B81249A7D573701",
+        "hash": "1782C1B4315FA0CBD0005C53A718A1B8ED005AEA008067A3269B048EC625CBDD",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "ae9",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "32D3BEA733A3C7B90A32A6A57DF912F7BE843090DD460A54255F8083E925C2ED",
+                "PreviousTxnID": "B6D1CDD6F4E841DCF81A641B66C3FAABE9A29831D5313461AE5BFD628757394E",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "aea",
+                  "IndexPrevious": "412",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "53E435E1C3E5EBBA12349B35AD36843988423C4C6E64C6D3E92F508C6CEC005D",
+                "PreviousTxnID": "B6D1CDD6F4E841DCF81A641B66C3FAABE9A29831D5313461AE5BFD628757394E",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089AA1E8DADEA5",
+                "NewFields": {
+                  "ExchangeRate": "4f089aa1e8dadea5",
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089AA1E8DADEA5",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f089d5a12bb5bc8",
+                  "Flags": 0,
+                  "PreviousTxnID": "1F6B701E674C582E59B4A52A216787673D3A0BF92D54F966699C4C890195734D",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089D5A12BB5BC8",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089D5A12BB5BC8"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "987E38307DD17EDA2F070CB4EA503D27449E4475FFF32785B6131C6CEA7BFB13",
+                "NewFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089AA1E8DADEA5",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "Sequence": 90961366,
+                  "TakerGets": "789076178",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "1911.00047"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Balance": "48203421449",
+                  "Flags": 0,
+                  "OwnerCount": 35,
+                  "Sequence": 90961404,
+                  "TicketCount": 21
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AB4F967F07A17B276A162D2BE831BB2B4BB7D28C58A71E2B47040114CE4599AE",
+                "PreviousFields": {
+                  "Balance": "48203421459",
+                  "OwnerCount": 36,
+                  "TicketCount": 22
+                },
+                "PreviousTxnID": "B6D1CDD6F4E841DCF81A641B66C3FAABE9A29831D5313461AE5BFD628757394E",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089D5A12BB5BC8",
+                  "BookNode": "0",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "1F6B701E674C582E59B4A52A216787673D3A0BF92D54F966699C4C890195734D",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "Sequence": 90961367,
+                  "TakerGets": "788888688",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "1912.90518"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "B51F8148E63E312D78011045314959CBCDF57C1A636F64B5A5102D3E05C5415A"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Flags": 0,
+                  "OwnerNode": "ae9",
+                  "PreviousTxnID": "A6F924B090289827515733829A2C4CAF2DABEA5920F6F1B845515F9E243D1D9D",
+                  "PreviousTxnLgrSeq": 94084581,
+                  "TicketSequence": 90961366
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "E8F00C75226EBAACA9AFA31A906D676E40567E2363748DA596BC9338F78FA350"
+              }
+            }
+          ],
+          "TransactionIndex": 21,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Amount": {
+          "currency": "MAG",
+          "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+          "value": "0.000002844979069698192"
+        },
+        "DeliverMax": {
+          "currency": "MAG",
+          "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+          "value": "0.000002844979069698192"
+        },
+        "Destination": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 94084609,
+        "SendMax": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "0.01021491577115065"
+        },
+        "Sequence": 29665816,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TransactionType": "Payment",
+        "TxnSignature": "63FFBF9724505E201E558E4C6E09BEC22607CE3CC0D84BCDDB8F2964F47E818BF0619FCB7B4AD4164B237E78E8C104926BDA1DBCEF9217428B94018FAD2F3008",
+        "hash": "1A08D366FC1A816E504CD9F819D35801A1F49429C031A917624B24E780D4631D",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0000028454807281036"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "MAG",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "HighNode": "8",
+                  "LowLimit": {
+                    "currency": "MAG",
+                    "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+                    "value": "0"
+                  },
+                  "LowNode": "214"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "6AEDB0D2B26C22AC4401CBDCEB4181C26081FE867AC3A8C233488A6D66724DE8",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.000000000501658405408"
+                  }
+                },
+                "PreviousTxnID": "842C902D24727B066525EC681B562AFEFF28B6645C479A41A7748FC865A40B8A",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000000674244795718"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "0"
+                  },
+                  "HighNode": "3a7",
+                  "LowLimit": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "2a"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "A92E75B22F28DBE5B8DA92B6365E02506C19727082EAF5E32E321F569131D24B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.009704832179073668"
+                  }
+                },
+                "PreviousTxnID": "A602880FA0F31697D7454A2FFAC5981F5451027C83DDDEC2D5879D9F8B56E98E",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "410.2418033950393"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "0"
+                  },
+                  "HighNode": "654",
+                  "LowLimit": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rpXQhNrxFbgMzoRDQPw8zuY463jvy2U6EL",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D55D762C4F276169D1C151C2F7EF23D920AEDFEBBD1F4E9E2B86B51D423EB2D2",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "410.232099237105"
+                  }
+                },
+                "PreviousTxnID": "869F22C54F957F9ED04C595DEEAA062B23A86D72F72C8B5C35341FB1C5529F9C",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "1A08D366FC1A816E504CD9F819D35801A1F49429C031A917624B24E780D4631D",
+                  "Balance": "97189464",
+                  "Flags": 0,
+                  "OwnerCount": 404,
+                  "Sequence": 29665817
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "A602880FA0F31697D7454A2FFAC5981F5451027C83DDDEC2D5879D9F8B56E98E",
+                  "Balance": "97189474",
+                  "Sequence": 29665816
+                },
+                "PreviousTxnID": "A602880FA0F31697D7454A2FFAC5981F5451027C83DDDEC2D5879D9F8B56E98E",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.1206022815906186"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "MAG",
+                    "issuer": "rpXQhNrxFbgMzoRDQPw8zuY463jvy2U6EL",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "MAG",
+                    "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+                    "value": "0"
+                  },
+                  "LowNode": "315"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "FC59F27111C6D1B4EAB680043B15B920AE33585E03A8CFE823809043A81AF863",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.1206051265696883"
+                  }
+                },
+                "PreviousTxnID": "869F22C54F957F9ED04C595DEEAA062B23A86D72F72C8B5C35341FB1C5529F9C",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            }
+          ],
+          "TransactionIndex": 14,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "MAG",
+            "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+            "value": "0.000002844979069698192"
+          }
+        }
+      },
+      {
+        "Account": "rQGeZdBAupy34KduV56qtkmjoaaEEgikwW",
+        "Fee": "12",
+        "Flags": 2228224,
+        "LastLedgerSequence": 94084626,
+        "LimitAmount": {
+          "currency": "5748590000000000000000000000000000000000",
+          "issuer": "rUikrq6kQdeuQAmowgRtazfi46qvQHzEBD",
+          "value": "0"
+        },
+        "Sequence": 92793090,
+        "SigningPubKey": "EDE6D7DB9A50F12112FD251E9B810E4338D55E0C639483156DE833CD6C1ECDCE53",
+        "TransactionType": "TrustSet",
+        "TxnSignature": "DF0C7078B140369E717F4AB9B088D703D1AC4CBEF0468572EC4C165EF89634D8E38DB35D498B3A19A176F9DD493F15DB3409C3006353C01835BA5562BC37F304",
+        "hash": "1D37AEF885D15B6F344AA910A1819A3A9A12DC6A85352FB145E1D88F40E5FDB0",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rQGeZdBAupy34KduV56qtkmjoaaEEgikwW",
+                  "Balance": "29692704",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 92793091,
+                  "TicketCount": 5
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "711E2A31A561EA857987AE1128C0F573297D271EF9E8EA925B83DE0D613A99C7",
+                "PreviousFields": {
+                  "Balance": "29692716",
+                  "Sequence": 92793090
+                },
+                "PreviousTxnID": "B20612F71BC78D7A92167FE8A191122AB0BF5EE9F1DD481A7EC5B0F7D3B1123A",
+                "PreviousTxnLgrSeq": 94080355
+              }
+            }
+          ],
+          "TransactionIndex": 80,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "6A72734E5341574D4237503430774F5A4F44456774",
+              "MemoType": "696E7465726E616C6F726465726964"
+            }
+          }
+        ],
+        "OfferSequence": 93305413,
+        "Sequence": 93305418,
+        "SigningPubKey": "025EBE8E351CAC5C641624238CD36A360631728177A5314566CC6BA0BAD4EF65FC",
+        "TakerGets": "43244903",
+        "TakerPays": {
+          "currency": "434F524500000000000000000000000000000000",
+          "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+          "value": "574.751832"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100FF7CAF0814CC6C293C201D5A615D508A467E14B53FE2DC17158947FBB4244FAB022029C40C5A2F53C93B41EF95258C5F81106C5AC28F6761F8EA6CCFEFAA9299484D",
+        "hash": "21532642DFDA93CDA88147D6AFA4C3DF647CF351D64180104CBF23DF68FC8857",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+                  "BookDirectory": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004BA205BECCB2D",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "B9ECFED87B40DA435699AB129F2282789225EF78B5902F523CCEB52B4F3E89C8",
+                  "PreviousTxnLgrSeq": 94084607,
+                  "Sequence": 93305413,
+                  "TakerGets": "43354776",
+                  "TakerPays": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "576.856127"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "3C03FF4E94BABF4C4C66A33AF549DF39CBF8580AE007783884C58E83110DA038"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+                  "RootIndex": "625124F968DCC1DEBB9EBE2C902DD6DE00945C218CC672DB067A8B30DC2F8542"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "625124F968DCC1DEBB9EBE2C902DD6DE00945C218CC672DB067A8B30DC2F8542",
+                "PreviousTxnID": "73B0BE40BE76D877702D8D3A362B697D16933C4D7C452F967ECB0298DD55D850",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+                  "Balance": "68142050862",
+                  "Flags": 0,
+                  "OwnerCount": 11,
+                  "Sequence": 93305419
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "9C1D8ABFBDC2F6A287CF320407BF8957B3CA5FE87C52C1EAD494E867A32ED9DB",
+                "PreviousFields": {
+                  "Balance": "68142050877",
+                  "Sequence": 93305418
+                },
+                "PreviousTxnID": "248DC12F1576791446DCBFD77F83C716AEEC14C9F20162FE7C895D4298AE8149",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "AC181DDE6545D1999D75DCDF437F687F979592B93C0214C58B927C8727730B6C",
+                "NewFields": {
+                  "Account": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+                  "BookDirectory": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004B8C68021EE9C",
+                  "Sequence": 93305418,
+                  "TakerGets": "43244903",
+                  "TakerPays": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "574.751832"
+                  }
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004B8C68021EE9C",
+                "NewFields": {
+                  "ExchangeRate": "5004b8c68021ee9c",
+                  "RootIndex": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004B8C68021EE9C",
+                  "TakerPaysCurrency": "434F524500000000000000000000000000000000",
+                  "TakerPaysIssuer": "06C4F77E3CBA482FB688F8AA92DCA0A10A8FD774"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5004ba205beccb2d",
+                  "Flags": 0,
+                  "PreviousTxnID": "B9ECFED87B40DA435699AB129F2282789225EF78B5902F523CCEB52B4F3E89C8",
+                  "PreviousTxnLgrSeq": 94084607,
+                  "RootIndex": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004BA205BECCB2D",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "434F524500000000000000000000000000000000",
+                  "TakerPaysIssuer": "06C4F77E3CBA482FB688F8AA92DCA0A10A8FD774"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004BA205BECCB2D"
+              }
+            }
+          ],
+          "TransactionIndex": 55,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rNv2NxNzZpyWcHSxNe6MPkLFgjEymmC9JR",
+        "Fee": "12",
+        "Flags": 2228224,
+        "LastLedgerSequence": 94084626,
+        "LimitAmount": {
+          "currency": "464D4C4652000000000000000000000000000000",
+          "issuer": "rUe41xMLKy1NVdLQD6cdZftKMhEwDaRJkf",
+          "value": "0"
+        },
+        "Sequence": 92790657,
+        "SigningPubKey": "ED2A6BDD5CBF23117DE66FCF2F1ECDD8B6BE75E67249F5142CC7D6EE1018390949",
+        "TransactionType": "TrustSet",
+        "TxnSignature": "E3B4DBAC301EC97E089AB1DC5817C7D1EDD008440683E43524549F69A9CA1B8BE1F93A7366BA2BCB8AE3EB6D45004D61F4CAD8E8920C378D6FA0684DF9929705",
+        "hash": "21F999F9CBEEDF9367D99D17EE1C0FEC3A756692E7167D211EAADD82E78D9F09",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rNv2NxNzZpyWcHSxNe6MPkLFgjEymmC9JR",
+                  "Balance": "29989867",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 92790658,
+                  "TicketCount": 5
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "38C2C6FC2CB6523ABE4501044F6636B836D25A9D5F5F392C4E4CB1B3FC092813",
+                "PreviousFields": {
+                  "Balance": "29989879",
+                  "Sequence": 92790657
+                },
+                "PreviousTxnID": "95F1D4DBF97B5D278B5F7533308F344BEACA74F46C6E99EE1DB168D6F6C68BFB",
+                "PreviousTxnLgrSeq": 94080355
+              }
+            }
+          ],
+          "TransactionIndex": 68,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 30301444,
+        "Sequence": 30301448,
+        "SigningPubKey": "021C987881039AD42AEC336FB8460F1B1F4DDF0839CAF3EAB1AF69DDF8012C30A3",
+        "TakerGets": "3943786926",
+        "TakerPays": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "122209.438269155"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100EC40BBE30AB258B1133E47140E2C2372E966F5445CE60C608458554AD16C85A1022026E1EB71BB8DC0E926D9D96F42A0BE7A34947FA9FC72D2A2413FF91E71E6C9AA",
+        "hash": "234E97E407508667F7480659B5AC360D8E0F3FCA83CD7532BC4BA54D898F4C4E",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500B0253DF92F5EE",
+                "NewFields": {
+                  "ExchangeRate": "500b0253df92f5ee",
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500B0253DF92F5EE",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "500b051f21156f85",
+                  "Flags": 0,
+                  "PreviousTxnID": "BD0872BB78B9F9A7A37B0510F53044F9137E9428E8CC90FAD4461AA644A642E4",
+                  "PreviousTxnLgrSeq": 94084599,
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500B051F21156F85",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500B051F21156F85"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "69323A63314DF36BF91CD23696F7BA4CE50F8BB56F821C4EB518848FCF4B3FD0",
+                "NewFields": {
+                  "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500B0253DF92F5EE",
+                  "Sequence": 30301448,
+                  "TakerGets": "3943786926",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "122209.438269155"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "Balance": "1000922607",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 30301449
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "7645DE0D353FF9ECB95EE6D8A5C51A666BBBA29860C30B45C529957871E586C1",
+                "PreviousFields": {
+                  "Balance": "1000922622",
+                  "Sequence": 30301448
+                },
+                "PreviousTxnID": "3ECAFC64F36606DF8A7B2830E980FB239BD1EEE51692FDA8D4771ABF4971B407",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "RootIndex": "C1806EB01C8FA2A0E78311B4D24FBFD21003E89934435DB975F40610FE0D1FAC"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "C1806EB01C8FA2A0E78311B4D24FBFD21003E89934435DB975F40610FE0D1FAC",
+                "PreviousTxnID": "3ECAFC64F36606DF8A7B2830E980FB239BD1EEE51692FDA8D4771ABF4971B407",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500B051F21156F85",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "BD0872BB78B9F9A7A37B0510F53044F9137E9428E8CC90FAD4461AA644A642E4",
+                  "PreviousTxnLgrSeq": 94084599,
+                  "Sequence": 30301444,
+                  "TakerGets": "735897767",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "22826.48904687921"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "E8FD5D2031EE0D2813D7A15712A3D663D539B04A8024675B9615E3ABB3C2C350"
+              }
+            }
+          ],
+          "TransactionIndex": 43,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+        "Expiration": 792720015,
+        "Fee": "10",
+        "Flags": 65536,
+        "LastLedgerSequence": 94084626,
+        "OfferSequence": 90961381,
+        "Sequence": 0,
+        "SigningPubKey": "ED4A8371720A1D404927F0B32DD49BDE4F8E2A8177D027482492AEE4F3C5045834",
+        "TakerGets": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "4753.63163"
+        },
+        "TakerPays": "1972690450",
+        "TicketSequence": 90961393,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "417974CD020CB9F6179324638F2EC2FF07017B620D91D00EDB251C4F13D2ECBE8779246FD199B41B287AD078B46D442C744ADCD2C4D8468EB3D043150AA7C20D",
+        "hash": "24D7F6BEFFA561831D754DA6559EAE3509EA107EB6678E96BC4EB4D944A7FE03",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Flags": 0,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "A6F924B090289827515733829A2C4CAF2DABEA5920F6F1B845515F9E243D1D9D",
+                  "PreviousTxnLgrSeq": 94084581,
+                  "TicketSequence": 90961393
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "108F3E8582935D60D0E494248909B50CD155C4C777CCEA5C8F86500A7EFEA24A"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "412",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "32D3BEA733A3C7B90A32A6A57DF912F7BE843090DD460A54255F8083E925C2ED",
+                "PreviousTxnID": "0BAF66DD43047CDB74FDE23A20A2A185F1D7BE1E1BA429A11509208365F565D7",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB9952B3357FF",
+                  "BookNode": "0",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "7EDC7EAD054BD8D90037EDD51606DFC4C46F50655E26448C503D783A3BD25289",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "Sequence": 90961381,
+                  "TakerGets": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "2855.051125533815"
+                  },
+                  "TakerPays": "1183333040"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "936BABF3339FB7F8733CBEAD107D9FE581DE39B2ADE6C7BE17F3A4B0C7C24BF1"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Balance": "48203421399",
+                  "Flags": 0,
+                  "OwnerCount": 30,
+                  "Sequence": 90961404,
+                  "TicketCount": 16
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AB4F967F07A17B276A162D2BE831BB2B4BB7D28C58A71E2B47040114CE4599AE",
+                "PreviousFields": {
+                  "Balance": "48203421409",
+                  "OwnerCount": 31,
+                  "TicketCount": 17
+                },
+                "PreviousTxnID": "0BAF66DD43047CDB74FDE23A20A2A185F1D7BE1E1BA429A11509208365F565D7",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5a0eb9952b3357ff",
+                  "Flags": 0,
+                  "PreviousTxnID": "7EDC7EAD054BD8D90037EDD51606DFC4C46F50655E26448C503D783A3BD25289",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "RootIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB9952B3357FF",
+                  "TakerGetsCurrency": "524C555344000000000000000000000000000000",
+                  "TakerGetsIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB9952B3357FF"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EBE46932AE800",
+                "NewFields": {
+                  "ExchangeRate": "5a0ebe46932ae800",
+                  "RootIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EBE46932AE800",
+                  "TakerGetsCurrency": "524C555344000000000000000000000000000000",
+                  "TakerGetsIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "F63BF50DC3D305DC44DD29D97E4D06FB4129B728A8F32791ECF45456345927BE",
+                "NewFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EBE46932AE800",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "Sequence": 90961393,
+                  "TakerGets": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "4753.631327321886"
+                  },
+                  "TakerPays": "1972690450"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 26,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r4ViXHhkdy5Dt9VoKucGbDWuXAb9ERUbx2",
+        "Amount": "8485699",
+        "DeliverMax": "8485699",
+        "DeliverMin": "8315985",
+        "Destination": "r4ViXHhkdy5Dt9VoKucGbDWuXAb9ERUbx2",
+        "Fee": "12",
+        "Flags": 131072,
+        "LastLedgerSequence": 94084626,
+        "SendMax": {
+          "currency": "416D657269636100000000000000000000000000",
+          "issuer": "rpVajoWTXFkKWY7gtWSwcpEcpLDUjtktCA",
+          "value": "3987805.034890162"
+        },
+        "Sequence": 93496570,
+        "SigningPubKey": "ED8236C4228E4855EC6D1B0476A954DF9B1A1FBBC3FBB87D76204102A6C3468415",
+        "TransactionType": "Payment",
+        "TxnSignature": "99876B8567A06BB8DDDF2A33C946443EE15A5328BBD25AD58FD75E012550351FEDCE85AE3607A4B9BE79787344D30F799F8E36B090C1C38E2D78964C90AB9C04",
+        "hash": "29B38C33CCF2D500600D746F109A7A985203A45EA78F5A6D677A916884BE9249",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1954422704.301244"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rDwJrWbmBd2eGMmpGhA1NJLXYXhUHhv8sh",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rpVajoWTXFkKWY7gtWSwcpEcpLDUjtktCA",
+                    "value": "0"
+                  },
+                  "LowNode": "1"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "7C3D48ED20980D68B8C3FDA328F5AE2A87F5137BD29EB402C8BF94A07A9399C2",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1950434899.266354"
+                  }
+                },
+                "PreviousTxnID": "7C78C64689154600D39326B9ABAB56D59CD90717AA2A2D5477725C7F285C567D",
+                "PreviousTxnLgrSeq": 94084606
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "ED4CBF1A89198D096EAB02EEE41B5E1D2B895D9CEE0F27E9EFE509EA3C23A1C7",
+                  "Account": "rDwJrWbmBd2eGMmpGhA1NJLXYXhUHhv8sh",
+                  "Balance": "4135718801",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 92443065
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "7D917B911BF3B3F3E052B85D540C4B26B33E4C9247FA7F03CEEF59F82877D30A",
+                "PreviousFields": {
+                  "Balance": "4144173900"
+                },
+                "PreviousTxnID": "7C78C64689154600D39326B9ABAB56D59CD90717AA2A2D5477725C7F285C567D",
+                "PreviousTxnLgrSeq": 94084606
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "r4ViXHhkdy5Dt9VoKucGbDWuXAb9ERUbx2",
+                    "value": "1000000000000000e-2"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rpVajoWTXFkKWY7gtWSwcpEcpLDUjtktCA",
+                    "value": "0"
+                  },
+                  "LowNode": "23"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D438ABD63455F25A8E94FF0223BE9B8B34A7EAF674847284217AE488DEA1B2FE",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-3987805.034890162"
+                  }
+                },
+                "PreviousTxnID": "006A2BE747B4792AF3D7DDC9A793C7D3B5C6F4FBEA64B6140B718A0A22F5AAA6",
+                "PreviousTxnLgrSeq": 94084585
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r4ViXHhkdy5Dt9VoKucGbDWuXAb9ERUbx2",
+                  "Balance": "13176546",
+                  "Flags": 0,
+                  "OwnerCount": 1,
+                  "Sequence": 93496571
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "DBD2ED410D5C0C5C0038ACA8FE55F17D9BB1E5E6EFDA2CA035AB4CC704984C28",
+                "PreviousFields": {
+                  "Balance": "4721459",
+                  "Sequence": 93496570
+                },
+                "PreviousTxnID": "A080A32F557270A8206E812D224F34631528560C639D63064D0B60095B45F25A",
+                "PreviousTxnLgrSeq": 94084587
+              }
+            }
+          ],
+          "DeliveredAmount": "8455099",
+          "TransactionIndex": 72,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "8455099"
+        }
+      },
+      {
+        "Account": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "454D54416E507668754F7667644242426D6F666363",
+              "MemoType": "696E7465726E616C6F726465726964"
+            }
+          }
+        ],
+        "OfferSequence": 93305414,
+        "Sequence": 93305420,
+        "SigningPubKey": "025EBE8E351CAC5C641624238CD36A360631728177A5314566CC6BA0BAD4EF65FC",
+        "TakerGets": "17345432",
+        "TakerPays": {
+          "currency": "434F524500000000000000000000000000000000",
+          "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+          "value": "230.64814"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100BC1D6798BB6531A2D9FFAA046ADCDD34E1F41CCD9CF88DBA8612B82A9A0C3DFC022018B776D7C6C591412EB4D50D0D82C6FAC1BCE7A6D99C9796334FA732A8034AB5",
+        "hash": "36593A69EF519C76D03348334F3CC780009EE99D67B1BDE48CF3DF1B429FF4E5",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+                  "RootIndex": "625124F968DCC1DEBB9EBE2C902DD6DE00945C218CC672DB067A8B30DC2F8542"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "625124F968DCC1DEBB9EBE2C902DD6DE00945C218CC672DB067A8B30DC2F8542",
+                "PreviousTxnID": "8DE11442A8DB0B97E7F6B4718E062B7C232FE7734A32E606D883577421EAC61C",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "8A1F8426E9916F7E8054B4EC1B5466218AEA034F7A07B4F9C424F44912114F2A",
+                "NewFields": {
+                  "Account": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+                  "BookDirectory": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004B962DE242970",
+                  "Sequence": 93305420,
+                  "TakerGets": "17345432",
+                  "TakerPays": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "230.64814"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+                  "Balance": "68142050832",
+                  "Flags": 0,
+                  "OwnerCount": 11,
+                  "Sequence": 93305421
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "9C1D8ABFBDC2F6A287CF320407BF8957B3CA5FE87C52C1EAD494E867A32ED9DB",
+                "PreviousFields": {
+                  "Balance": "68142050847",
+                  "Sequence": 93305420
+                },
+                "PreviousTxnID": "8DE11442A8DB0B97E7F6B4718E062B7C232FE7734A32E606D883577421EAC61C",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004B962DE242970",
+                "NewFields": {
+                  "ExchangeRate": "5004b962de242970",
+                  "RootIndex": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004B962DE242970",
+                  "TakerPaysCurrency": "434F524500000000000000000000000000000000",
+                  "TakerPaysIssuer": "06C4F77E3CBA482FB688F8AA92DCA0A10A8FD774"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5004ba9c10a55fe8",
+                  "Flags": 0,
+                  "PreviousTxnID": "5A501CD20F4C521CAA350AD6AAE3349C567E3159194FBF10B27824D15DB2709B",
+                  "PreviousTxnLgrSeq": 94084607,
+                  "RootIndex": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004BA9C10A55FE8",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "434F524500000000000000000000000000000000",
+                  "TakerPaysIssuer": "06C4F77E3CBA482FB688F8AA92DCA0A10A8FD774"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004BA9C10A55FE8"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+                  "BookDirectory": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004BA9C10A55FE8",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "5A501CD20F4C521CAA350AD6AAE3349C567E3159194FBF10B27824D15DB2709B",
+                  "PreviousTxnLgrSeq": 94084607,
+                  "Sequence": 93305414,
+                  "TakerGets": "17305602",
+                  "TakerPays": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "230.351297"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "EE7452762016DAE917EC11AF07281B2DF1B0F943DC90F84634DCD956A7670DDE"
+              }
+            }
+          ],
+          "TransactionIndex": 57,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rHoKM6uJUoHGRwPoc4Xs1DebNrF8e7x1SW",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 94084626,
+        "LimitAmount": {
+          "currency": "RXO",
+          "issuer": "rUSm6rb8gPZ9ZZRaWu6KaMYDSyqRPNAe9r",
+          "value": "1000000"
+        },
+        "Sequence": 94083084,
+        "SigningPubKey": "EDCAC152341CE55B82E6CBD97A5819713FF3AB2B1D1DC0A787E55A93A8921A59A8",
+        "TransactionType": "TrustSet",
+        "TxnSignature": "EF384ACB5A2B9BE185213B0695FF1A12E16C7D611211B1627F2870920DAEA10BD8C89408DEC0031E3710742E1A88E3A19B3A6279056D86DD9BD0F2400A1C2809",
+        "hash": "383C86A32E4875666A1380D9CD95D4814F568D69E3A82FE50B910B213E097457",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "2",
+                  "Owner": "rHoKM6uJUoHGRwPoc4Xs1DebNrF8e7x1SW",
+                  "RootIndex": "A5F7ABB0ACDE76AA1854F31B85E6E53BCE974EB8EBE2BFDE8E8633101B874CF6"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "16A38EC273B8BCD3047FA36781A1A7FA5181A3555961138F0BCB8FD1BE8A10FE",
+                "PreviousTxnID": "9C7976B46950C88C51159E22C19E5055B1AECD08DBC4F5F9A0FA8B38CB5F8E79",
+                "PreviousTxnLgrSeq": 94084600
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "967031B112B62AFEF0035353CA636FEBE606A3D572E88C10C82BDDABDABE8A98",
+                "PreviousTxnID": "7C83AE5ACEA1FF81934BB266939304EB7ACCEC794CB56B315607BED2A1072294",
+                "PreviousTxnLgrSeq": 94084604
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rHoKM6uJUoHGRwPoc4Xs1DebNrF8e7x1SW",
+                  "Balance": "119991332",
+                  "Flags": 0,
+                  "OwnerCount": 110,
+                  "Sequence": 94083085
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "A8C2B3FA143FA5F13064C3AE6E5FCFB9082CADB52604A1AB312D279B7C8D097F",
+                "PreviousFields": {
+                  "Balance": "119991342",
+                  "OwnerCount": 109,
+                  "Sequence": 94083084
+                },
+                "PreviousTxnID": "9C7976B46950C88C51159E22C19E5055B1AECD08DBC4F5F9A0FA8B38CB5F8E79",
+                "PreviousTxnLgrSeq": 94084600
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B06246E2FB08B390ADDE36393BB7DEA50F6A591CAAE2608CB76CC47D34B26098",
+                "NewFields": {
+                  "Balance": {
+                    "currency": "RXO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "RXO",
+                    "issuer": "rHoKM6uJUoHGRwPoc4Xs1DebNrF8e7x1SW",
+                    "value": "1000000"
+                  },
+                  "HighNode": "3",
+                  "LowLimit": {
+                    "currency": "RXO",
+                    "issuer": "rUSm6rb8gPZ9ZZRaWu6KaMYDSyqRPNAe9r",
+                    "value": "0"
+                  },
+                  "LowNode": "4e"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "4d",
+                  "Owner": "rUSm6rb8gPZ9ZZRaWu6KaMYDSyqRPNAe9r",
+                  "RootIndex": "B08C5994613FB529FD83BA5747535418047908DA6EAF3BEF588061EE49C75373"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DEFBCD4A4CF56952BE0C750F40D78C80C2A9051BE38B32C25E1FB9D9AD116AC1",
+                "PreviousTxnID": "9C7976B46950C88C51159E22C19E5055B1AECD08DBC4F5F9A0FA8B38CB5F8E79",
+                "PreviousTxnLgrSeq": 94084600
+              }
+            }
+          ],
+          "TransactionIndex": 62,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+        "Fee": "15",
+        "Flags": 524288,
+        "LastLedgerSequence": 94084610,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "346D6532573234424473374878376474646C434E44",
+              "MemoType": "696E7465726E616C6F726465726964"
+            }
+          }
+        ],
+        "OfferSequence": 97505272,
+        "Sequence": 97505282,
+        "SigningPubKey": "034D6788B751D18BBE92CAF1255431512D6D187446D47FAEE20FDB0BFA8144DB1E",
+        "TakerGets": "16960807100",
+        "TakerPays": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "41039.047291444"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100B9C20BDE557895706EB5581A0F89F462AF8953F54F965DD6D935FCBC136BFD620220759D2C23608C6EE783B62C84655C867936D211E050F77960BF5DD95F1353649C",
+        "hash": "3AA4DD7E65BFBF8FFA606E7370438D2F9CC5035EB3A8781FD0D957D7F2F41052",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F0899F7F16B5400",
+                  "BookNode": "0",
+                  "Flags": 131072,
+                  "OwnerNode": "1",
+                  "PreviousTxnID": "7FD0F08B2A4CC2C179926E9339B834EF34C191C97E16ED794B83DF72D9CE01C1",
+                  "PreviousTxnLgrSeq": 94084607,
+                  "Sequence": 97505272,
+                  "TakerGets": "16950645300",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "41039.037829377"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "4725E604942BBBDC99990F8D08078BA12C239BB200B885384B0A270BF9482812"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "4C81E24CD900A4AC6FAED0B6BCC0F24ED9B6DF0D95FF612A94D3DE0C458E55AE",
+                "NewFields": {
+                  "Account": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F0898A656AF3000",
+                  "Flags": 131072,
+                  "OwnerNode": "1",
+                  "Sequence": 97505282,
+                  "TakerGets": "16960807100",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "41039.047291444"
+                  }
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F0898A656AF3000",
+                "NewFields": {
+                  "ExchangeRate": "4f0898a656af3000",
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F0898A656AF3000",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f0899f7f16b5400",
+                  "Flags": 0,
+                  "PreviousTxnID": "7FD0F08B2A4CC2C179926E9339B834EF34C191C97E16ED794B83DF72D9CE01C1",
+                  "PreviousTxnLgrSeq": 94084607,
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F0899F7F16B5400",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F0899F7F16B5400"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+                  "Balance": "60817108098",
+                  "Flags": 0,
+                  "OwnerCount": 34,
+                  "Sequence": 97505283
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "6BC9286C5146B76D0D140873B509D72581AABEB79037BF1D9849830FBF5A9FE6",
+                "PreviousFields": {
+                  "Balance": "60817108113",
+                  "Sequence": 97505282
+                },
+                "PreviousTxnID": "BBEFC10A4F627378921E0AB5D8F2205D1C74FDE4B8714EDABCF175B5C99DC127",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+                  "RootIndex": "49B537464A9659478275132402EB6D5E8723F42ED20DB3CF4A4527A9A3F1589A"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "E06052755A83D52A63C3392B87634326BE0E4E68ECB59B7DF3A2B1851229208D",
+                "PreviousTxnID": "BBEFC10A4F627378921E0AB5D8F2205D1C74FDE4B8714EDABCF175B5C99DC127",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            }
+          ],
+          "TransactionIndex": 46,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rMdpzP6SSRcNDSgHQGGx4hV3qeRiuRoqQM",
+        "Fee": "15",
+        "Flags": 524288,
+        "LastLedgerSequence": 94084609,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "72615F69463647446649705645756D6D346F306A69",
+              "MemoType": "696E7465726E616C6F726465726964"
+            }
+          }
+        ],
+        "OfferSequence": 93427580,
+        "Sequence": 93427586,
+        "SigningPubKey": "02F9157DFDE7BE71E317AE313431F615F689CA3D35B6526576DCCB06A300BB0B00",
+        "TakerGets": {
+          "currency": "534F4C4F00000000000000000000000000000000",
+          "issuer": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz",
+          "value": "1242.164958"
+        },
+        "TakerPays": "207798049",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "30440220730C11FABBFB3A2FCE986739BD266A72703EEA9FBE5AE1E340FEF5BC3F6C9ACB022053084B2D03E75865251CAA7E6844FA0534B177554C37DF3DA1CCB5610C59CAD9",
+        "hash": "3B611A7DC282C699F892C3AA7A8E341F7C19F4808A3C81022100F4845807C927",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rMdpzP6SSRcNDSgHQGGx4hV3qeRiuRoqQM",
+                  "RootIndex": "1261DEF9887726607C6C931B6CB1FC7718B674821432D3E138A29F442DF00E45"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1261DEF9887726607C6C931B6CB1FC7718B674821432D3E138A29F442DF00E45",
+                "PreviousTxnID": "E73146697FC3AF801D269926CBAB42C213C247C9F75C3ED3ED877A5F2AFAB48D",
+                "PreviousTxnLgrSeq": 94084599
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rMdpzP6SSRcNDSgHQGGx4hV3qeRiuRoqQM",
+                  "BookDirectory": "5C8970D155D65DB8FF49B291D7EFFA4A09F9E8A68D9974B25A05EFF03E6DD571",
+                  "BookNode": "0",
+                  "Flags": 131072,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "21E15803D485279D93FA9E81FADA45AFC85FEEC77CEDA7BE16FCDBE872D8F342",
+                  "PreviousTxnLgrSeq": 94084552,
+                  "Sequence": 93427580,
+                  "TakerGets": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz",
+                    "value": "1240.808554"
+                  },
+                  "TakerPays": "207362685"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "1D4CFB829C206E5EBBE8623D00AF36E343FE7E5984440BF32988390C1570C7D2"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMdpzP6SSRcNDSgHQGGx4hV3qeRiuRoqQM",
+                  "Balance": "52900295135",
+                  "Flags": 0,
+                  "OwnerCount": 8,
+                  "Sequence": 93427587
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "2400FD7BAEE16FC502375E649183943F0987A083A221E3F964C1F29420326ACC",
+                "PreviousFields": {
+                  "Balance": "52900295150",
+                  "Sequence": 93427586
+                },
+                "PreviousTxnID": "E73146697FC3AF801D269926CBAB42C213C247C9F75C3ED3ED877A5F2AFAB48D",
+                "PreviousTxnLgrSeq": 94084599
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5a05eff03e6dd571",
+                  "Flags": 0,
+                  "PreviousTxnID": "21E15803D485279D93FA9E81FADA45AFC85FEEC77CEDA7BE16FCDBE872D8F342",
+                  "PreviousTxnLgrSeq": 94084552,
+                  "RootIndex": "5C8970D155D65DB8FF49B291D7EFFA4A09F9E8A68D9974B25A05EFF03E6DD571",
+                  "TakerGetsCurrency": "534F4C4F00000000000000000000000000000000",
+                  "TakerGetsIssuer": "1EB3EAA3AD86242E1D51DC502DD6566BD39E06A6",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "5C8970D155D65DB8FF49B291D7EFFA4A09F9E8A68D9974B25A05EFF03E6DD571"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "5C8970D155D65DB8FF49B291D7EFFA4A09F9E8A68D9974B25A05F17765F29399",
+                "NewFields": {
+                  "ExchangeRate": "5a05f17765f29399",
+                  "RootIndex": "5C8970D155D65DB8FF49B291D7EFFA4A09F9E8A68D9974B25A05F17765F29399",
+                  "TakerGetsCurrency": "534F4C4F00000000000000000000000000000000",
+                  "TakerGetsIssuer": "1EB3EAA3AD86242E1D51DC502DD6566BD39E06A6"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "FC710194EE4E9513B6457ACA6519B5D78A65F368CC52C2D38937DA55B3FD3D84",
+                "NewFields": {
+                  "Account": "rMdpzP6SSRcNDSgHQGGx4hV3qeRiuRoqQM",
+                  "BookDirectory": "5C8970D155D65DB8FF49B291D7EFFA4A09F9E8A68D9974B25A05F17765F29399",
+                  "Flags": 131072,
+                  "Sequence": 93427586,
+                  "TakerGets": {
+                    "currency": "534F4C4F00000000000000000000000000000000",
+                    "issuer": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz",
+                    "value": "1242.164958"
+                  },
+                  "TakerPays": "207798049"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 71,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 30424032,
+        "Sequence": 30424037,
+        "SigningPubKey": "037E9B02A63FFC298C82B66D250932A5DCF89361122925CB42339E3C769245084C",
+        "TakerGets": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "176755.7717946494"
+        },
+        "TakerPays": "17515433570",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100A62F3632095B9B4C3618C8FE0F5FAC5C43F631ED48C8C3BC774BED7463BC35C102203BCA35EF482BDA4598BDF2F698F0E6FE435AED38251AD656C03D284C30913998",
+        "hash": "3B779F0C2BC5600A1D518E6C3579BCE0B06A96FD8D387A5EF61FDC9F80BB3872",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "03C6830B0A461DB11BD19348C50120B4DF23967669A79E53D3CDD49DE5BC62A6",
+                "NewFields": {
+                  "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975923348B99CFE1AE",
+                  "Sequence": 30424037,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "176755.7717946494"
+                  },
+                  "TakerPays": "17515433570"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "591e54adce4d0d8a",
+                  "Flags": 0,
+                  "PreviousTxnID": "FF224E6F03687C941491CB28CDEB8755D7153418AB6A710509C2E07370B20A69",
+                  "PreviousTxnLgrSeq": 94084600,
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591E54ADCE4D0D8A",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591E54ADCE4D0D8A"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975923348B99CFE1AE",
+                "NewFields": {
+                  "ExchangeRate": "5923348b99cfe1ae",
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975923348B99CFE1AE",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "Balance": "100882719",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 30424038
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C84DB7EC299936754ADF7B0342A2E3B441F5076DAD476769D5021BA104BF9A7E",
+                "PreviousFields": {
+                  "Balance": "100882734",
+                  "Sequence": 30424037
+                },
+                "PreviousTxnID": "45BD6733BEAFCBC7801318C3A50E1703C2677E3556E36A188C804EA4D8104A02",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "RootIndex": "D2932301FC455041F84607F18EEFB3E24C9B4B9269DAB4B79DEEBA3A96FED70E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "D2932301FC455041F84607F18EEFB3E24C9B4B9269DAB4B79DEEBA3A96FED70E",
+                "PreviousTxnID": "45BD6733BEAFCBC7801318C3A50E1703C2677E3556E36A188C804EA4D8104A02",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591E54ADCE4D0D8A",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "FF224E6F03687C941491CB28CDEB8755D7153418AB6A710509C2E07370B20A69",
+                  "PreviousTxnLgrSeq": 94084600,
+                  "Sequence": 30424032,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "94039.96246676243"
+                  },
+                  "TakerPays": "8028525220"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "EEFF56B06376FD6630CF9B1096A636AA17BD3011975B60B37EFF0C82AD3F1D31"
+              }
+            }
+          ],
+          "TransactionIndex": 32,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 30301443,
+        "Sequence": 30301447,
+        "SigningPubKey": "021C987881039AD42AEC336FB8460F1B1F4DDF0839CAF3EAB1AF69DDF8012C30A3",
+        "TakerGets": "13271946625",
+        "TakerPays": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "354764.1766493199"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100FC0BD74A683547E8D7A49480E7C527A8E0D5E77FB189066F4F1CA82EB5A02BF802204B933300AC700CF28FFA96CE3C9251974715C961C3DFC55CF2EA9DF27AA07304",
+        "hash": "3ECAFC64F36606DF8A7B2830E980FB239BD1EEE51692FDA8D4771ABF4971B407",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE1007994750097F1D2878BB51",
+                "NewFields": {
+                  "ExchangeRate": "50097f1d2878bb51",
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE1007994750097F1D2878BB51",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5009818628c803f2",
+                  "Flags": 0,
+                  "PreviousTxnID": "EED656A002B5FC4764F057E58438C5D82A4208102CE865EC3296C99C78B4F77B",
+                  "PreviousTxnLgrSeq": 94084599,
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475009818628C803F2",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475009818628C803F2"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "Balance": "1000922622",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 30301448
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "7645DE0D353FF9ECB95EE6D8A5C51A666BBBA29860C30B45C529957871E586C1",
+                "PreviousFields": {
+                  "Balance": "1000922637",
+                  "Sequence": 30301447
+                },
+                "PreviousTxnID": "406CED51BD822DF4090D8C52EBF8A61A4969A77EA2F25C847BA4AC8662A8C16F",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475009818628C803F2",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "EED656A002B5FC4764F057E58438C5D82A4208102CE865EC3296C99C78B4F77B",
+                  "PreviousTxnLgrSeq": 94084599,
+                  "Sequence": 30301443,
+                  "TakerGets": "5795580526",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "155071.6526757346"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "BF1399F9A44410F1FBAD7C9ACFC147C8539619C1A24B19FF6168E1AFFDF0D541"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "RootIndex": "C1806EB01C8FA2A0E78311B4D24FBFD21003E89934435DB975F40610FE0D1FAC"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "C1806EB01C8FA2A0E78311B4D24FBFD21003E89934435DB975F40610FE0D1FAC",
+                "PreviousTxnID": "406CED51BD822DF4090D8C52EBF8A61A4969A77EA2F25C847BA4AC8662A8C16F",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "FA347E6AF4D36783F12CB763310A75269937AE488330F1A3CAB8056C942F91A1",
+                "NewFields": {
+                  "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE1007994750097F1D2878BB51",
+                  "Sequence": 30301447,
+                  "TakerGets": "13271946625",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "354764.1766493199"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 42,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 30301442,
+        "Sequence": 30301446,
+        "SigningPubKey": "021C987881039AD42AEC336FB8460F1B1F4DDF0839CAF3EAB1AF69DDF8012C30A3",
+        "TakerGets": "5547233687",
+        "TakerPays": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "127907.3377608915"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100CCA49D2EB536366FBBAD35BE3346B5CE25C6FA3A444E7A35A29371F066347E7D02207846E87AD22C2D3130E21179059EF862915836146297E9A7D99AC3F20D1657A8",
+        "hash": "406CED51BD822DF4090D8C52EBF8A61A4969A77EA2F25C847BA4AC8662A8C16F",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475008332DE3AEAE02",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "273FD50192D2B950C614CCF2715582AACD56CA88CAC6CE46E9B5BB67A64DAF71",
+                  "PreviousTxnLgrSeq": 94084599,
+                  "Sequence": 30301442,
+                  "TakerGets": "18603240972",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "429376.1959869767"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "5E38ED107D608C8AE28DCB274D3EEE03BAEC0729BA55E0B419254BCEDFFE3316"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE1007994750083119A37A6D29",
+                "NewFields": {
+                  "ExchangeRate": "50083119a37a6d29",
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE1007994750083119A37A6D29",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5008332de3aeae02",
+                  "Flags": 0,
+                  "PreviousTxnID": "273FD50192D2B950C614CCF2715582AACD56CA88CAC6CE46E9B5BB67A64DAF71",
+                  "PreviousTxnLgrSeq": 94084599,
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475008332DE3AEAE02",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475008332DE3AEAE02"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "Balance": "1000922637",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 30301447
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "7645DE0D353FF9ECB95EE6D8A5C51A666BBBA29860C30B45C529957871E586C1",
+                "PreviousFields": {
+                  "Balance": "1000922652",
+                  "Sequence": 30301446
+                },
+                "PreviousTxnID": "A2D199D8DE44D77342BE5940FC36B5A2E50A706F0F9709F4324A119DE4FB6A85",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "RootIndex": "C1806EB01C8FA2A0E78311B4D24FBFD21003E89934435DB975F40610FE0D1FAC"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "C1806EB01C8FA2A0E78311B4D24FBFD21003E89934435DB975F40610FE0D1FAC",
+                "PreviousTxnID": "A2D199D8DE44D77342BE5940FC36B5A2E50A706F0F9709F4324A119DE4FB6A85",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "F5A5E6E33DCE1B3A5DD9DE1A252D4BADBE360F532B4801D3809C4662B57C8588",
+                "NewFields": {
+                  "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE1007994750083119A37A6D29",
+                  "Sequence": 30301446,
+                  "TakerGets": "5547233687",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "127907.3377608915"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 41,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+        "Expiration": 792720015,
+        "Fee": "10",
+        "Flags": 65536,
+        "LastLedgerSequence": 94084626,
+        "OfferSequence": 90961359,
+        "Sequence": 0,
+        "SigningPubKey": "ED4A8371720A1D404927F0B32DD49BDE4F8E2A8177D027482492AEE4F3C5045834",
+        "TakerGets": "1183614270",
+        "TakerPays": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "2872.2294"
+        },
+        "TicketSequence": 90961364,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "EBAA52D950A25B3F9374EBA3335BB1D031FD19F698610F54A65F9979C9E4804037090DD5C528F17C34DFE7EA9A85C45263CDE498E2D513374282D8B4AC3A350E",
+        "hash": "41C32E3263D805CA78BD473900F08B59EA64CE8DA5FE2F86D98C29C37643D6F2",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "ae9",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "32D3BEA733A3C7B90A32A6A57DF912F7BE843090DD460A54255F8083E925C2ED",
+                "PreviousTxnID": "44650ABA7C531D015C494FD4035E6CA76886D0147997E3EBFEAA72C74EFB4FD6",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "420596F8BB737A8A028A70AA4ACE69CEC3462B404CF01F9929DB945583E1A9DA",
+                "NewFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089F08CF4FC202",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "Sequence": 90961364,
+                  "TakerGets": "1183614268",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "2872.2294"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "aea",
+                  "IndexPrevious": "412",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "53E435E1C3E5EBBA12349B35AD36843988423C4C6E64C6D3E92F508C6CEC005D",
+                "PreviousTxnID": "44650ABA7C531D015C494FD4035E6CA76886D0147997E3EBFEAA72C74EFB4FD6",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089F08CF4FC202",
+                "NewFields": {
+                  "ExchangeRate": "4f089f08cf4fc202",
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089F08CF4FC202",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB5CE391C5E01",
+                  "BookNode": "0",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "750921282CF97DC237E0FEFB17DCC69A4433AFF3913DFB022E92BC7DD932C746",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "Sequence": 90961359,
+                  "TakerGets": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "1905.276500906764"
+                  },
+                  "TakerPays": "788888690"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "674F45398F17B9CFBA015E6B2A5D5E95B2270A318EDD119990621160151F41BD"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Balance": "48203421469",
+                  "Flags": 0,
+                  "OwnerCount": 37,
+                  "Sequence": 90961404,
+                  "TicketCount": 23
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AB4F967F07A17B276A162D2BE831BB2B4BB7D28C58A71E2B47040114CE4599AE",
+                "PreviousFields": {
+                  "Balance": "48203421479",
+                  "OwnerCount": 38,
+                  "TicketCount": 24
+                },
+                "PreviousTxnID": "44650ABA7C531D015C494FD4035E6CA76886D0147997E3EBFEAA72C74EFB4FD6",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5a0eb5ce391c5e01",
+                  "Flags": 0,
+                  "PreviousTxnID": "750921282CF97DC237E0FEFB17DCC69A4433AFF3913DFB022E92BC7DD932C746",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "RootIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB5CE391C5E01",
+                  "TakerGetsCurrency": "524C555344000000000000000000000000000000",
+                  "TakerGetsIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB5CE391C5E01"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Flags": 0,
+                  "OwnerNode": "ae9",
+                  "PreviousTxnID": "A6F924B090289827515733829A2C4CAF2DABEA5920F6F1B845515F9E243D1D9D",
+                  "PreviousTxnLgrSeq": 94084581,
+                  "TicketSequence": 90961364
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "DDF2C063FEADD8B29743C8231B36DA091BDD497244FC8C470CB2988CF4801623"
+              }
+            }
+          ],
+          "TransactionIndex": 19,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 167782388,
+        "Sequence": 167782399,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "456048"
+        },
+        "TakerPays": "200000000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100EFE21EE9A631DC4FA3E153749AF6EE9E7E3C59F6E98AE8FE85CE21599B2808EE02206471253CD1E21930613FB436E0BBD9471B6C726D477648FA4AFD7ED4F9BFA918",
+        "hash": "43293CB7CA7BD8540D3783FF0060B4E812CFBD15E6ADC069EA19077CD4B7E507",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3",
+                "PreviousTxnID": "7DE34555988BFD9537C2C558DC51EA64F6BFFFCF33EA70DCDEEF94D1E5408001",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "0DFBABA66100106406A86619538778D95A13AB39387032D722B4E72E693E02F7",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5A0F94978D2FDC66",
+                  "Sequence": 167782399,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "456048"
+                  },
+                  "TakerPays": "200000000000"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "15035590610",
+                  "Flags": 0,
+                  "OwnerCount": 17,
+                  "Sequence": 167782400
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "15035590630",
+                  "Sequence": 167782399
+                },
+                "PreviousTxnID": "7DE34555988BFD9537C2C558DC51EA64F6BFFFCF33EA70DCDEEF94D1E5408001",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5a0f92297ef8238b",
+                  "Flags": 0,
+                  "PreviousTxnID": "079783E5B7EB1D31C238E604032086591D90985C67B58F4DCE95A59B62132DFD",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "RootIndex": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5A0F92297EF8238B",
+                  "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+                  "TakerGetsIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5A0F92297EF8238B"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5A0F94978D2FDC66",
+                "NewFields": {
+                  "ExchangeRate": "5a0f94978d2fdc66",
+                  "RootIndex": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5A0F94978D2FDC66",
+                  "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+                  "TakerGetsIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "F0B9A528CE25FE77C51C38040A7FEC016C2C841E74C1418D5A0F92297EF8238B",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "079783E5B7EB1D31C238E604032086591D90985C67B58F4DCE95A59B62132DFD",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "Sequence": 167782388,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "456325.9999999999"
+                  },
+                  "TakerPays": "200000000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "F41E142B35C6748A43DE04CF5805CE5E33AECA7D1BFE86F8001279B41CDBBEFB"
+              }
+            }
+          ],
+          "TransactionIndex": 37,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+        "Expiration": 792720015,
+        "Fee": "10",
+        "Flags": 65536,
+        "LastLedgerSequence": 94084626,
+        "OfferSequence": 90961363,
+        "Sequence": 0,
+        "SigningPubKey": "ED4A8371720A1D404927F0B32DD49BDE4F8E2A8177D027482492AEE4F3C5045834",
+        "TakerGets": "789076180",
+        "TakerPays": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "1912.91004"
+        },
+        "TicketSequence": 90961353,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "CAE3493AD6DBBFFD9AA1077FD3DBAC71F06AE10AFCF20865F29041A783B066CB5C84CBC7652E319ABB98A6A6C6B05B975DDB400240C56F30986A9F4237D1DB0E",
+        "hash": "44650ABA7C531D015C494FD4035E6CA76886D0147997E3EBFEAA72C74EFB4FD6",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "1348D7498E768827D182D4F78560A4F418F6585B423D017840E2B6FA9DA4725F",
+                "NewFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089CD597AB82DC",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "Sequence": 90961353,
+                  "TakerGets": "789075855",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "1912.91004"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "ae9",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "32D3BEA733A3C7B90A32A6A57DF912F7BE843090DD460A54255F8083E925C2ED",
+                "PreviousTxnID": "D19E12FE05E46721200731AE1139CD387856A40BA672C9E4A1B72816AC492CBC",
+                "PreviousTxnLgrSeq": 94084605
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "aea",
+                  "IndexPrevious": "412",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "53E435E1C3E5EBBA12349B35AD36843988423C4C6E64C6D3E92F508C6CEC005D",
+                "PreviousTxnID": "D19E12FE05E46721200731AE1139CD387856A40BA672C9E4A1B72816AC492CBC",
+                "PreviousTxnLgrSeq": 94084605
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089CD597AB82DC",
+                "NewFields": {
+                  "ExchangeRate": "4f089cd597ab82dc",
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089CD597AB82DC",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB20923DBB400",
+                  "BookNode": "0",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "46F2ACC03098D522C51262D955D6624F96775C266DE6180E1B719A80EBF09315",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "Sequence": 90961363,
+                  "TakerGets": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "1907.185737749861"
+                  },
+                  "TakerPays": "788888690"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "979CE9E7D42B501D532A7C60AF90457EE9DDE2EA396D132C8DE03191F1CD7F4D"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Balance": "48203421479",
+                  "Flags": 0,
+                  "OwnerCount": 38,
+                  "Sequence": 90961404,
+                  "TicketCount": 24
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AB4F967F07A17B276A162D2BE831BB2B4BB7D28C58A71E2B47040114CE4599AE",
+                "PreviousFields": {
+                  "Balance": "48203421489",
+                  "OwnerCount": 39,
+                  "TicketCount": 25
+                },
+                "PreviousTxnID": "D19E12FE05E46721200731AE1139CD387856A40BA672C9E4A1B72816AC492CBC",
+                "PreviousTxnLgrSeq": 94084605
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5a0eb20923dbb400",
+                  "Flags": 0,
+                  "PreviousTxnID": "46F2ACC03098D522C51262D955D6624F96775C266DE6180E1B719A80EBF09315",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "RootIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB20923DBB400",
+                  "TakerGetsCurrency": "524C555344000000000000000000000000000000",
+                  "TakerGetsIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB20923DBB400"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Flags": 0,
+                  "OwnerNode": "ae9",
+                  "PreviousTxnID": "A6F924B090289827515733829A2C4CAF2DABEA5920F6F1B845515F9E243D1D9D",
+                  "PreviousTxnLgrSeq": 94084581,
+                  "TicketSequence": 90961353
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "E533C261FD372F8735024CFAA5FA484DE27E52EB52FF46D0FD4C460033A961A4"
+              }
+            }
+          ],
+          "TransactionIndex": 18,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "",
+        "Fee": "0",
+        "LedgerSequence": 94084608,
+        "Sequence": 0,
+        "SigningPubKey": "",
+        "TransactionType": "UNLModify",
+        "UNLModifyDisabling": 1,
+        "UNLModifyValidator": "ED63CF929BE85B266A66584B3FE2EB97FC248203F0271DC9C833563E60418E7818",
+        "hash": "4489EC9209A02221FBFADE49CFD09C93D46C2AF3B0878FC2A8767B2F21DFA9BB",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "NegativeUNL",
+                "LedgerIndex": "2E8A59AA9D3B5B186B0B9E0F62E6C02587CA74A4D778938E957B6357D364B244",
+                "NewFields": {
+                  "ValidatorToDisable": "ED63CF929BE85B266A66584B3FE2EB97FC248203F0271DC9C833563E60418E7818"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 8,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 30424033,
+        "Sequence": 30424036,
+        "SigningPubKey": "037E9B02A63FFC298C82B66D250932A5DCF89361122925CB42339E3C769245084C",
+        "TakerGets": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "52665.90334952954"
+        },
+        "TakerPays": "4501851770",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304402200B1B629D23C9758A598775822D29163FF5E5CDD99D6A94C7389FAC33B5896065022079B8B01C4B9DBDFAEAE2F9C0EEFBFD5666F9F11C94D23727BA4460B4441AB42C",
+        "hash": "45BD6733BEAFCBC7801318C3A50E1703C2677E3556E36A188C804EA4D8104A02",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591E5E4F3C1757FC",
+                "NewFields": {
+                  "ExchangeRate": "591e5e4f3c1757fc",
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591E5E4F3C1757FC",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5923296540698951",
+                  "Flags": 0,
+                  "PreviousTxnID": "63528D19791CB93D762CEEDB1C5AEBF08538C8C75F2F51A340E52E6981272F32",
+                  "PreviousTxnLgrSeq": 94084600,
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975923296540698951",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975923296540698951"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "857A7A3B7BB47945C860F9B0B606F1E52DF85FD932F15B7763C3FA7A317F51B2",
+                "NewFields": {
+                  "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591E5E4F3C1757FC",
+                  "Sequence": 30424036,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "52665.90334952954"
+                  },
+                  "TakerPays": "4501851770"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975923296540698951",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "63528D19791CB93D762CEEDB1C5AEBF08538C8C75F2F51A340E52E6981272F32",
+                  "PreviousTxnLgrSeq": 94084600,
+                  "Sequence": 30424033,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "185726.1128283087"
+                  },
+                  "TakerPays": "18381571609"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "88F098A28BD29A7FA30657C7BF5D894FCEC69BD36462CE066067DC26006A53E2"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "Balance": "100882734",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 30424037
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C84DB7EC299936754ADF7B0342A2E3B441F5076DAD476769D5021BA104BF9A7E",
+                "PreviousFields": {
+                  "Balance": "100882749",
+                  "Sequence": 30424036
+                },
+                "PreviousTxnID": "DFE5582189D6192497C1199E17AA699F8D7F6226FCB8AA96F7BE4511BD2F3059",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "RootIndex": "D2932301FC455041F84607F18EEFB3E24C9B4B9269DAB4B79DEEBA3A96FED70E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "D2932301FC455041F84607F18EEFB3E24C9B4B9269DAB4B79DEEBA3A96FED70E",
+                "PreviousTxnID": "DFE5582189D6192497C1199E17AA699F8D7F6226FCB8AA96F7BE4511BD2F3059",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            }
+          ],
+          "TransactionIndex": 31,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rGDreBvnHrX1get7na3J4oowN19ny4GzFn",
+        "Amount": "68761969",
+        "DeliverMax": "68761969",
+        "Destination": "rpWJmMcPM4ynNfvhaZFYmPhBq5FYfDJBZu",
+        "DestinationTag": 1122005580,
+        "Fee": "20",
+        "Flags": 2147483648,
+        "LastLedgerSequence": 94085606,
+        "Sequence": 1132117,
+        "SigningPubKey": "02024F808D657322E73CEA9A0109CDBD9A3A56552CA87F847DD8558B47CD0F2E20",
+        "TransactionType": "Payment",
+        "TxnSignature": "3044022069269A524D6D731D35F537EBA7083380C34677A6DC7457AB9203940C01A2551B0220542B8F4F16FBFA9220C3FD90EFD65F4B26CA47117915B77BA4CBEBF0E9ECB2D2",
+        "hash": "4818FF59B8076B61E426F7533F602996D9216BF6C1496114692F2F99C92B7468",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rGDreBvnHrX1get7na3J4oowN19ny4GzFn",
+                  "Balance": "38870777688956",
+                  "Flags": 131072,
+                  "OwnerCount": 1,
+                  "Sequence": 1132118
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "8719BD164C9F79A760E19FB64691885E63CC595032E559971F89C1E22EAEC220",
+                "PreviousFields": {
+                  "Balance": "38870846450945",
+                  "Sequence": 1132117
+                },
+                "PreviousTxnID": "99CF320E484C82618E461F1EBA881482EB9CE52D74A222DFE06FEE8AE300AE5E",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpWJmMcPM4ynNfvhaZFYmPhBq5FYfDJBZu",
+                  "Balance": "102773830",
+                  "Flags": 1179648,
+                  "OwnerCount": 3,
+                  "RegularKey": "rMCsK7mwSfayZvTuXgJN2u3DgSb33B72KM",
+                  "Sequence": 78729447
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B3230D19A69EBE012B952C35D2542497A641BF9A669E8F10A5D9DE3A29D27512",
+                "PreviousFields": {
+                  "Balance": "34011861"
+                },
+                "PreviousTxnID": "67416F7C98E4B15E68EA0334750E079334687D745EB97A856FE3375933DF1371",
+                "PreviousTxnLgrSeq": 94084592
+              }
+            }
+          ],
+          "TransactionIndex": 59,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "68761969"
+        }
+      },
+      {
+        "Account": "rMTRWSAJ95hAEvCbymzixnshmBxRAR24u8",
+        "Fee": "12",
+        "Flags": 2228224,
+        "LastLedgerSequence": 94084626,
+        "LimitAmount": {
+          "currency": "464D4C4652000000000000000000000000000000",
+          "issuer": "rUe41xMLKy1NVdLQD6cdZftKMhEwDaRJkf",
+          "value": "0"
+        },
+        "Sequence": 92792887,
+        "SigningPubKey": "EDB288AD30C12F5BB6E624AD5AA1928E0E776F2550829FDEB0B446F9F498941F23",
+        "TransactionType": "TrustSet",
+        "TxnSignature": "13F1CDC8D31313D94B540F3DB79389CE2B58FB6E8A56AB86A1015BCF44FD12D8E29E50D49965B24D28D8C305DE0BC6B4FB3B72EE08BAB7522B1D254406B9AF0A",
+        "hash": "54B9C95ECB158ADB05123489313B0945BD7055F473A04EAEC78D20E6985B365F",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rMTRWSAJ95hAEvCbymzixnshmBxRAR24u8",
+                  "Balance": "29310034",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 92792888,
+                  "TicketCount": 5
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "5D6D4FD68FD53B048F6BA3B80C0A281B1024CB2153AF02D8CAAABF237F102F61",
+                "PreviousFields": {
+                  "Balance": "29310046",
+                  "Sequence": 92792887
+                },
+                "PreviousTxnID": "3946A1C56B20BE215D1522C783121FB7BCE37B8B0449BE485C05CA4BCD6534C3",
+                "PreviousTxnLgrSeq": 94080355
+              }
+            }
+          ],
+          "TransactionIndex": 70,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Amount": {
+          "currency": "OVO",
+          "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+          "value": "994.7055173312917"
+        },
+        "DeliverMax": {
+          "currency": "OVO",
+          "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+          "value": "994.7055173312917"
+        },
+        "Destination": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 94084609,
+        "SendMax": {
+          "currency": "MAG",
+          "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+          "value": "0.000002994714810208623"
+        },
+        "Sequence": 29665817,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TransactionType": "Payment",
+        "TxnSignature": "0E2D4C618E5D10662C9BCBEF68F6CE2C902BA0C299A095FD24CCBD07F5DC6B02121C564953A815BF349981F39825B47B27280D481EA320D7B84122507A1BB401",
+        "hash": "57020451A032CE52054116D073D9015DC7515F4645CA24514B35FEC079971FFE",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.01115925304089892"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "MAG",
+                    "issuer": "rfQYvidA2byigrb54AVH5kYWQteejseZma",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "MAG",
+                    "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+                    "value": "0"
+                  },
+                  "LowNode": "27c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "35F3441C51A649AA9B13DCF25C7707319036A4EE2F557E66733A480EB81C3ECA",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.01115640810029708"
+                  }
+                },
+                "PreviousTxnID": "842C902D24727B066525EC681B562AFEFF28B6645C479A41A7748FC865A40B8A",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "3900728.431313441"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "OVO",
+                    "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+                    "value": "0"
+                  },
+                  "HighNode": "344",
+                  "LowLimit": {
+                    "currency": "OVO",
+                    "issuer": "rfQYvidA2byigrb54AVH5kYWQteejseZma",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "4C3034DECE93CDBBB64431F07ECDD538D82F2AAA7A27A462B0B6FC02D0CF767E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "3901723.136830772"
+                  }
+                },
+                "PreviousTxnID": "842C902D24727B066525EC681B562AFEFF28B6645C479A41A7748FC865A40B8A",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0000000005401262636"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "MAG",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "HighNode": "8",
+                  "LowLimit": {
+                    "currency": "MAG",
+                    "issuer": "rXmagwMmnFtVet3uL26Q2iwk287SRvVMJ",
+                    "value": "0"
+                  },
+                  "LowNode": "214"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "6AEDB0D2B26C22AC4401CBDCEB4181C26081FE867AC3A8C233488A6D66724DE8",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "MAG",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-0.0000028454807281036"
+                  }
+                },
+                "PreviousTxnID": "1A08D366FC1A816E504CD9F819D35801A1F49429C031A917624B24E780D4631D",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "273266.3400572504"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "OVO",
+                    "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+                    "value": "0"
+                  },
+                  "HighNode": "33e",
+                  "LowLimit": {
+                    "currency": "OVO",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "CF7D03A277BB38033EE1039387650B3720EB33056781C1BE75B19A4FC6B999AD",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "272271.6345399191"
+                  }
+                },
+                "PreviousTxnID": "B4F866A6615F27437ED0D1B8423D254BC53F390363D16C402243EDCBE8BAF0A7",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "57020451A032CE52054116D073D9015DC7515F4645CA24514B35FEC079971FFE",
+                  "Balance": "97189454",
+                  "Flags": 0,
+                  "OwnerCount": 404,
+                  "Sequence": 29665818
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "1A08D366FC1A816E504CD9F819D35801A1F49429C031A917624B24E780D4631D",
+                  "Balance": "97189464",
+                  "Sequence": 29665817
+                },
+                "PreviousTxnID": "1A08D366FC1A816E504CD9F819D35801A1F49429C031A917624B24E780D4631D",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            }
+          ],
+          "TransactionIndex": 15,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "OVO",
+            "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+            "value": "994.7055173312917"
+          }
+        }
+      },
+      {
+        "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 144101818,
+        "Sequence": 144101822,
+        "SigningPubKey": "022D40673B44C82DEE1DDB8B9BB53DCCE4F97B27404DB850F068DD91D685E337EA",
+        "TakerGets": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "82658.86895481257"
+        },
+        "TakerPays": "5743342117",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "30450221008846E77A0EF45277E8321F35CD57B7EAB4C7A928CBF7A8571101BB028043BB080220033F6F5794604F30CB14B2EF74E33DCFD15BB4BD1EC1EAE334B7E7FACFCED7C7",
+        "hash": "600406517AEF040B3234E374B6FD1559E7B9B96CC1947C5248E7C0124C9DD7A6",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5918abff3089068d",
+                  "Flags": 0,
+                  "PreviousTxnID": "F83E8FE81619B5AE8F5543EA659A11ECF514A9090D7CD50CCB1B182B8A20FF5F",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975918ABFF3089068D",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975918ABFF3089068D"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975918AF64BF1C1F4E",
+                "NewFields": {
+                  "ExchangeRate": "5918af64bf1c1f4e",
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975918AF64BF1C1F4E",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975918ABFF3089068D",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "F83E8FE81619B5AE8F5543EA659A11ECF514A9090D7CD50CCB1B182B8A20FF5F",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "Sequence": 144101818,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "337530.384047471"
+                  },
+                  "TakerPays": "23439837890"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "48A3BBF2BF765C255E39089F869075205D2B4EA198F36ABEE037CC0CE5B25748"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "518CC34CFC1A2F5F640B1578205837CFD34705D5E81BE65285F6B82B0905D167",
+                "NewFields": {
+                  "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975918AF64BF1C1F4E",
+                  "Sequence": 144101822,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "82658.86895481257"
+                  },
+                  "TakerPays": "5743342117"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "RootIndex": "AEA3074F10FE15DAC592F8A0405C61FB7D4C98F588C2D55C84718FAFBBD2604A"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "AEA3074F10FE15DAC592F8A0405C61FB7D4C98F588C2D55C84718FAFBBD2604A",
+                "PreviousTxnID": "FE286600AC66A0438D0E01B5BA59E1EEAA0106A979248330E52D15C23F2416A2",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "Balance": "100345337",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 144101823
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E0311EB450B6177F969B94DBDDA83E99B7A0576ACD9079573876F16C0C004F06",
+                "PreviousFields": {
+                  "Balance": "100345352",
+                  "Sequence": 144101822
+                },
+                "PreviousTxnID": "FE286600AC66A0438D0E01B5BA59E1EEAA0106A979248330E52D15C23F2416A2",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            }
+          ],
+          "TransactionIndex": 1,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "366B536959564B4F33575A63375048345557343464",
+              "MemoType": "696E7465726E616C6F726465726964"
+            }
+          }
+        ],
+        "Sequence": 97505280,
+        "SigningPubKey": "034D6788B751D18BBE92CAF1255431512D6D187446D47FAEE20FDB0BFA8144DB1E",
+        "TakerGets": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "37959.345843"
+        },
+        "TakerPays": {
+          "currency": "ETH",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "14.559"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "30450221008899738092758F4061E79C1F9744EEB63B080D561C38792974BB72CCF9A456A602203F9505117885B7FFD64E36C74E0AD717FC739F2A0C63B1E8E0C37664790AA024",
+        "hash": "60E05E95317698F61A0737910912AED820EB0E49DF590A7FC878ABCE02547263",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "4327BA72D34E3964EE58A909DB6EB2ACB4F16B440CC3A8DE510DA04B4EAA1800",
+                "NewFields": {
+                  "ExchangeRate": "510da04b4eaa1800",
+                  "RootIndex": "4327BA72D34E3964EE58A909DB6EB2ACB4F16B440CC3A8DE510DA04B4EAA1800",
+                  "TakerGetsCurrency": "524C555344000000000000000000000000000000",
+                  "TakerGetsIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E",
+                  "TakerPaysCurrency": "0000000000000000000000004554480000000000",
+                  "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "6B9142712FC5AA9F80E02FDF5CD6E6A6D1ECD03F44B6B17CB897A946BCCD7952",
+                "NewFields": {
+                  "Account": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+                  "BookDirectory": "4327BA72D34E3964EE58A909DB6EB2ACB4F16B440CC3A8DE510DA04B4EAA1800",
+                  "OwnerNode": "1",
+                  "Sequence": 97505280,
+                  "TakerGets": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "37959.33691746928"
+                  },
+                  "TakerPays": {
+                    "currency": "ETH",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "14.559"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+                  "Balance": "60817108128",
+                  "Flags": 0,
+                  "OwnerCount": 34,
+                  "Sequence": 97505281
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "6BC9286C5146B76D0D140873B509D72581AABEB79037BF1D9849830FBF5A9FE6",
+                "PreviousFields": {
+                  "Balance": "60817108143",
+                  "OwnerCount": 33,
+                  "Sequence": 97505280
+                },
+                "PreviousTxnID": "44848B0C47923D08667AEE57B80676EB6659E41BE180A5A00C30CBF78EFA4F65",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+                  "RootIndex": "49B537464A9659478275132402EB6D5E8723F42ED20DB3CF4A4527A9A3F1589A"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "E06052755A83D52A63C3392B87634326BE0E4E68ECB59B7DF3A2B1851229208D",
+                "PreviousTxnID": "44848B0C47923D08667AEE57B80676EB6659E41BE180A5A00C30CBF78EFA4F65",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            }
+          ],
+          "TransactionIndex": 44,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rpWtr31qKz6rDzGZfhMUF1NroWiXZDziya",
+        "Amount": {
+          "currency": "5842415200000000000000000000000000000000",
+          "issuer": "rBbpmcuvmokBb7yFR6ZE8fNHbBLskyR8Ar",
+          "value": "999999999"
+        },
+        "DeliverMax": {
+          "currency": "5842415200000000000000000000000000000000",
+          "issuer": "rBbpmcuvmokBb7yFR6ZE8fNHbBLskyR8Ar",
+          "value": "999999999"
+        },
+        "DeliverMin": {
+          "currency": "5842415200000000000000000000000000000000",
+          "issuer": "rBbpmcuvmokBb7yFR6ZE8fNHbBLskyR8Ar",
+          "value": "1.5"
+        },
+        "Destination": "rpWtr31qKz6rDzGZfhMUF1NroWiXZDziya",
+        "Fee": "12",
+        "Flags": 131072,
+        "LastLedgerSequence": 94084626,
+        "SendMax": "1500000",
+        "Sequence": 93772863,
+        "SigningPubKey": "ED79AA87E74CA9A61EDA6A83CB714652A9154AF5104642E7462C89C4A536AA2939",
+        "TransactionType": "Payment",
+        "TxnSignature": "490E0594D699558D93B216A77851CB58148280E2D485E60004C2B7248EB98331ED1E0D025327B0475DE3EC467C96C3628295F4E02839761643CEB9644A7B8C00",
+        "hash": "78927D8976AE70F0007E00D8A60F40391394E8E827B0B57CC948BFA0A527854D",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "1D4DD25AFEA11FC87958159344FD6398D64C88D92CFB23EFC266C3C061E5E260",
+                  "Account": "rPL2Lit8teVgm68UVEsoU6Qb97TUJHFRd4",
+                  "Balance": "4044762378",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 93130999
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "7179192B121AA0A83CEDBC730EF186F7834579EDAF4E2FED35BC81C68C0D3D3A",
+                "PreviousFields": {
+                  "Balance": "4043262378"
+                },
+                "PreviousTxnID": "2B8603869E1185C3CE2EF692528980D01047C3D31A4CABB1EC287B286E38B5AD",
+                "PreviousTxnLgrSeq": 94084603
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpWtr31qKz6rDzGZfhMUF1NroWiXZDziya",
+                  "Balance": "6598338",
+                  "Flags": 0,
+                  "OwnerCount": 1,
+                  "Sequence": 93772864
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "D21C2B61C5ED71CDA15A100C9322CE5F31871841776B14E295C26924ABA5C58F",
+                "PreviousFields": {
+                  "Balance": "8098350",
+                  "Sequence": 93772863
+                },
+                "PreviousTxnID": "D04FAEC7612E01E48CBCF75B002615F285AEE63CB1F734115A5E7C480965E697",
+                "PreviousTxnLgrSeq": 94084601
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5842415200000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "28681.45873443"
+                  },
+                  "Flags": 65536,
+                  "HighLimit": {
+                    "currency": "5842415200000000000000000000000000000000",
+                    "issuer": "rBbpmcuvmokBb7yFR6ZE8fNHbBLskyR8Ar",
+                    "value": "0"
+                  },
+                  "HighNode": "4a",
+                  "LowLimit": {
+                    "currency": "5842415200000000000000000000000000000000",
+                    "issuer": "rpWtr31qKz6rDzGZfhMUF1NroWiXZDziya",
+                    "value": "99999999"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F029ED3BE4C82EC0E1DE3F470FEBE2B59B06C2C5E32E1DFD400146358F28DAAC",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5842415200000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  }
+                },
+                "PreviousTxnID": "E3376A5EA44AA36586A3217BF77075382760E25A82764759A17FE0D4E30B1346",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5842415200000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-77541406.67596129"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "5842415200000000000000000000000000000000",
+                    "issuer": "rPL2Lit8teVgm68UVEsoU6Qb97TUJHFRd4",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "5842415200000000000000000000000000000000",
+                    "issuer": "rBbpmcuvmokBb7yFR6ZE8fNHbBLskyR8Ar",
+                    "value": "0"
+                  },
+                  "LowNode": "6"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "FAC08FA3F02DC4218C01347A616F1EB2F6A53C0CEC562864F3CF638C5EF6D535",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5842415200000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-77570088.13469572"
+                  }
+                },
+                "PreviousTxnID": "2B8603869E1185C3CE2EF692528980D01047C3D31A4CABB1EC287B286E38B5AD",
+                "PreviousTxnLgrSeq": 94084603
+              }
+            }
+          ],
+          "DeliveredAmount": {
+            "currency": "5842415200000000000000000000000000000000",
+            "issuer": "rBbpmcuvmokBb7yFR6ZE8fNHbBLskyR8Ar",
+            "value": "28681.45873443"
+          },
+          "TransactionIndex": 16,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "5842415200000000000000000000000000000000",
+            "issuer": "rBbpmcuvmokBb7yFR6ZE8fNHbBLskyR8Ar",
+            "value": "28681.45873443"
+          }
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "Sequence": 123729334,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TakerGets": {
+          "currency": "LTC",
+          "issuer": "rcRzGWq6Ng3jeYhqnmM4zcWcUh69hrQ8V",
+          "value": "19.23285903654403"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "2479.798296306323"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "30440220393A643D6A8A78DD098FAA66450E2DD9C80F6268F76DF0453BA080635C8993E60220763D52B78CE84AD58E05C12C2162F812311D907CCBE450254F360FE5063E9B79",
+        "hash": "7C921B51A7FDB340DEEA210162FAD24366FC869904EB42CED6E9D6E682F6A309",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b14",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9DBB7ADE16C6B4D763193B6D41161ACF6E93F22C6F4401FFC89B89ADCC378328",
+                "PreviousTxnID": "8875B2DBC3122739C9084140C33525B198E6FED0B2DC63CB8623485AC056D6A1",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "91960028965",
+                  "Flags": 0,
+                  "OwnerCount": 137,
+                  "Sequence": 123729335
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "91960028975",
+                  "OwnerCount": 136,
+                  "Sequence": 123729334
+                },
+                "PreviousTxnID": "B83FC54EA93F2FCDDC1B982F784F63422D55FB6EE93258CAB077D473A49557C4",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CEA664F2B7C3F3A31B6DE8E3F179E3AE5E2C471FCD6039E7570494A95AC3AE00",
+                "NewFields": {
+                  "ExchangeRate": "570494a95ac3ae00",
+                  "RootIndex": "CEA664F2B7C3F3A31B6DE8E3F179E3AE5E2C471FCD6039E7570494A95AC3AE00",
+                  "TakerGetsCurrency": "0000000000000000000000004C54430000000000",
+                  "TakerGetsIssuer": "06B36AC50AC7331069070C6350B202EAF2125C7C",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "E3555A7EA5B71BE132F1156144BA06C11C34FEECA6246B4565AFD43D54D56270",
+                "NewFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "CEA664F2B7C3F3A31B6DE8E3F179E3AE5E2C471FCD6039E7570494A95AC3AE00",
+                  "OwnerNode": "19b15",
+                  "Sequence": 123729334,
+                  "TakerGets": {
+                    "currency": "LTC",
+                    "issuer": "rcRzGWq6Ng3jeYhqnmM4zcWcUh69hrQ8V",
+                    "value": "19.23285903654403"
+                  },
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "2479.798296306323"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 51,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rhubarbMVC2nzASf3qSGQcUKtLnAzqcBjp",
+        "Amount": {
+          "currency": "58525061794E6574000000000000000000000000",
+          "issuer": "r9rRLst96Ue4YTDQkWWkX1ePB6p6Ye4FkA",
+          "value": "1936.394762081382"
+        },
+        "DeliverMax": {
+          "currency": "58525061794E6574000000000000000000000000",
+          "issuer": "r9rRLst96Ue4YTDQkWWkX1ePB6p6Ye4FkA",
+          "value": "1936.394762081382"
+        },
+        "Destination": "rhubarbMVC2nzASf3qSGQcUKtLnAzqcBjp",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 94084609,
+        "SendMax": {
+          "currency": "4C41574153000000000000000000000000000000",
+          "issuer": "rfAWYnEAkQGAhbESWAMdNccWJvdcrgugMC",
+          "value": "341462.487829553"
+        },
+        "Sequence": 94793204,
+        "SigningPubKey": "ED9C7A917E06AE3550AEA072D25D3EAABDBB8D6AC1A1C0AF316866082D10145FF6",
+        "TransactionType": "Payment",
+        "TxnSignature": "CF7ECD5DBFFB285DBD3D5B3CDB362A5735A9F0061076F4FE4D14DDBD86856861284AE2DED56D29F9BB791A63F09993F3DBF508E6431FFAF513576CD70DDBD60A",
+        "hash": "7D3D5A6EABDE581B58CEC2CD03354BB4C0CCF37DDEABFBEE130F6CBC78BEE2C2",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-24004649.94610649"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rKNa1o3U7KKQJRBvXBQKdicqxARSWtV1D6",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rfAWYnEAkQGAhbESWAMdNccWJvdcrgugMC",
+                    "value": "0"
+                  },
+                  "LowNode": "14"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "054AA80318ED99E34DBF75EA0EEA8F4DE21BD52259760882FA454508FAC03805",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-23734325.47657476"
+                  }
+                },
+                "PreviousTxnID": "F8D26FD33FD5361C1C5F293213512D6D136FCC1D562FD7BD626F55282CECDA1D",
+                "PreviousTxnLgrSeq": 94084409
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rhubarbMVC2nzASf3qSGQcUKtLnAzqcBjp",
+                  "Balance": "5611216625",
+                  "Flags": 0,
+                  "OwnerCount": 1237,
+                  "Sequence": 94793205
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "7A794B5256B0129A726B10E003DC3EF737C4FB00216A74A2560B0B544D702136",
+                "PreviousFields": {
+                  "Balance": "5611216635",
+                  "Sequence": 94793204
+                },
+                "PreviousTxnID": "B7F6C0B673059887974E71DD5C50FAA1AE1F6D3A3893B2DA4455F2F6CEA85FCD",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rfAWYnEAkQGAhbESWAMdNccWJvdcrgugMC",
+                    "value": "0"
+                  },
+                  "HighNode": "13",
+                  "LowLimit": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rhubarbMVC2nzASf3qSGQcUKtLnAzqcBjp",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "a3"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "97EE65EC49FBD6A89E785DB49AEC04E11936B0017382C623F0B4266801C41F6C",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "270324.4695317294"
+                  }
+                },
+                "PreviousTxnID": "B7F6C0B673059887974E71DD5C50FAA1AE1F6D3A3893B2DA4455F2F6CEA85FCD",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-143193.6567691495"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "rKNa1o3U7KKQJRBvXBQKdicqxARSWtV1D6",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "r9rRLst96Ue4YTDQkWWkX1ePB6p6Ye4FkA",
+                    "value": "0"
+                  },
+                  "LowNode": "34c"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "B4F01D208B9BFC5C630BBE1525BD724D1A2CED0751BF9B803B7A954A3EC0AB69",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-144808.2660341646"
+                  }
+                },
+                "PreviousTxnID": "F8D26FD33FD5361C1C5F293213512D6D136FCC1D562FD7BD626F55282CECDA1D",
+                "PreviousTxnLgrSeq": 94084409
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1614.6092650151"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "r9rRLst96Ue4YTDQkWWkX1ePB6p6Ye4FkA",
+                    "value": "0"
+                  },
+                  "HighNode": "336",
+                  "LowLimit": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "rhubarbMVC2nzASf3qSGQcUKtLnAzqcBjp",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "95"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "BDDB87931825E4185EA1FD9EAF134270EBC1F74BBDFA967F67C511B5FC8034F4",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  }
+                },
+                "PreviousTxnID": "B6B97B64C5EBDC851491FBCB461D943A97E7F6E46DFCC5DE5E79F1A2F7D527AE",
+                "PreviousTxnLgrSeq": 94084569
+              }
+            }
+          ],
+          "DeliveredAmount": {
+            "currency": "58525061794E6574000000000000000000000000",
+            "issuer": "r9rRLst96Ue4YTDQkWWkX1ePB6p6Ye4FkA",
+            "value": "1614.6092650151"
+          },
+          "TransactionIndex": 5,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "58525061794E6574000000000000000000000000",
+            "issuer": "r9rRLst96Ue4YTDQkWWkX1ePB6p6Ye4FkA",
+            "value": "1614.6092650151"
+          }
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 167782387,
+        "Sequence": 167782398,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": "14935000000",
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "36936.61555142501"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304402206AAC240E20F376964DA5364BC14BF946DA5351066BEDF26EE5087E94C42A852402201C170D16E4A94C45FE9E761B9E332DD385D1C6F1A2798F3BD5C67BA36E3D1785",
+        "hash": "7DE34555988BFD9537C2C558DC51EA64F6BFFFCF33EA70DCDEEF94D1E5408001",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3",
+                "PreviousTxnID": "AFBC4B1DEE866310A10586B8A1F2C3BB00044FB3D20111BD3488E3E5B3DA5F28",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "15035590630",
+                  "Flags": 0,
+                  "OwnerCount": 17,
+                  "Sequence": 167782399
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "15035590650",
+                  "Sequence": 167782398
+                },
+                "PreviousTxnID": "AFBC4B1DEE866310A10586B8A1F2C3BB00044FB3D20111BD3488E3E5B3DA5F28",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4F08C95312966540",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "76C67ABC686A0553EA08EB6165D87E350732730B58BB54A25D826F1E77C51F9B",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "Sequence": 167782387,
+                  "TakerGets": "14935000000",
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "36936.621376075"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "86F0CC0375BEB2A2DA9B344C162267B9BBFC2C566E3ACBAC532083DD4592B112"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "DAA69EBFB86F266EEFAC3D21491B894E6643D7F2AC4CF5E2EBFD6696836305A7",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4F08C952FB5777C1",
+                  "Sequence": 167782398,
+                  "TakerGets": "14935000000",
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "36936.61555142501"
+                  }
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4F08C952FB5777C1",
+                "NewFields": {
+                  "ExchangeRate": "4f08c952fb5777c1",
+                  "RootIndex": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4F08C952FB5777C1",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f08c95312966540",
+                  "Flags": 0,
+                  "PreviousTxnID": "76C67ABC686A0553EA08EB6165D87E350732730B58BB54A25D826F1E77C51F9B",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "RootIndex": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4F08C95312966540",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DFA3B6DDAB58C7E8E5D944E736DA4B7046C30E4F460FD9DE4F08C95312966540"
+              }
+            }
+          ],
+          "TransactionIndex": 36,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rpgtbNuTeDtdBmLpjsL8KsdoukciuNSLtf",
+        "Amount": {
+          "currency": "504F4E474F000000000000000000000000000000",
+          "issuer": "rwCq6TENSo3Hh9LKipXnLaxaeXBXKubqki",
+          "value": "10641756.560621"
+        },
+        "Amount2": "99666",
+        "Asset": {
+          "currency": "504F4E474F000000000000000000000000000000",
+          "issuer": "rwCq6TENSo3Hh9LKipXnLaxaeXBXKubqki"
+        },
+        "Asset2": {
+          "currency": "XRP"
+        },
+        "Fee": "12",
+        "Flags": 1048576,
+        "LastLedgerSequence": 94084626,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "414D4D206465706F73697420696E69746961746564207669612058506D61726B65742E636F6D"
+            }
+          }
+        ],
+        "Sequence": 66662783,
+        "SigningPubKey": "02E1CC3E19157793F049F7CAC05FF774FAEE492153DEBF8B3CD66A3DB62CC9906C",
+        "SourceTag": 20221212,
+        "TransactionType": "AMMDeposit",
+        "TxnSignature": "3044022037A21C729887EC83B5089B9B60BC9B60558167BF6DBE52283DF67F8A7743701E0220722B939C7CE1AA49E57D8D1435F09B20DBD9AB8668BAEFC5AE0CF483B1D7C0B1",
+        "hash": "7F724230178309775772D7AFFEBFF9DD709BD943704C67B29753E0693D8A9E06",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "03ED41506EA49D3D0F6B7C8212D3C5DA22C2C8B1",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "19979315.9906"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "03ED41506EA49D3D0F6B7C8212D3C5DA22C2C8B1",
+                    "issuer": "rP5J7x4HyHKQUUfrfzvuq28iLwiKPf7yv5",
+                    "value": "0"
+                  },
+                  "HighNode": "33",
+                  "LowLimit": {
+                    "currency": "03ED41506EA49D3D0F6B7C8212D3C5DA22C2C8B1",
+                    "issuer": "rpgtbNuTeDtdBmLpjsL8KsdoukciuNSLtf",
+                    "value": "0"
+                  },
+                  "LowNode": "10"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "13CDEF389DB820B1DD9C01FB88AF9B4206326D320A2DD8539C5E502069283D4D",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "03ED41506EA49D3D0F6B7C8212D3C5DA22C2C8B1",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "19151789.9287"
+                  }
+                },
+                "PreviousTxnID": "04469ECB8605454A5976AC06D0879DDDBC2AE422060EBEF4A77FE4B44D1002D5",
+                "PreviousTxnLgrSeq": 94062134
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rP5J7x4HyHKQUUfrfzvuq28iLwiKPf7yv5",
+                  "Asset": {
+                    "currency": "XRP"
+                  },
+                  "Asset2": {
+                    "currency": "504F4E474F000000000000000000000000000000",
+                    "issuer": "rwCq6TENSo3Hh9LKipXnLaxaeXBXKubqki"
+                  },
+                  "AuctionSlot": {
+                    "Account": "rbBfeoq9ZzYhwzCzR3ssD2x79GXPrNkXy",
+                    "DiscountedFee": 33,
+                    "Expiration": 791777280,
+                    "Price": {
+                      "currency": "03ED41506EA49D3D0F6B7C8212D3C5DA22C2C8B1",
+                      "issuer": "rP5J7x4HyHKQUUfrfzvuq28iLwiKPf7yv5",
+                      "value": "45000000"
+                    }
+                  },
+                  "Flags": 0,
+                  "LPTokenBalance": {
+                    "currency": "03ED41506EA49D3D0F6B7C8212D3C5DA22C2C8B1",
+                    "issuer": "rP5J7x4HyHKQUUfrfzvuq28iLwiKPf7yv5",
+                    "value": "3310128109714975e-4"
+                  },
+                  "OwnerNode": "0",
+                  "TradingFee": 339,
+                  "VoteSlots": [
+                    {
+                      "VoteEntry": {
+                        "Account": "rLPbfj4zv3t7xCVvcGS9QopcxtfT5isS2m",
+                        "VoteWeight": 57686
+                      }
+                    },
+                    {
+                      "VoteEntry": {
+                        "Account": "rwSbj4GbJSxWEvDHhkN4ma54ZQ4NhAJGVn",
+                        "TradingFee": 1000,
+                        "VoteWeight": 126
+                      }
+                    },
+                    {
+                      "VoteEntry": {
+                        "Account": "rh1DG8rSu7VCg7WZoNuKbubaKb8aXM1iu4",
+                        "TradingFee": 1000,
+                        "VoteWeight": 1707
+                      }
+                    },
+                    {
+                      "VoteEntry": {
+                        "Account": "rxVZ3Z7bdjDmZDkCHhjAJDBK43dUzhvmP",
+                        "TradingFee": 1000,
+                        "VoteWeight": 27518
+                      }
+                    },
+                    {
+                      "VoteEntry": {
+                        "Account": "rPSpbdtRc1gwvyHkq1qw86XFaF6VKfqr9S",
+                        "TradingFee": 1000,
+                        "VoteWeight": 61
+                      }
+                    },
+                    {
+                      "VoteEntry": {
+                        "Account": "ra3urKnAtu3R96Cc3G7k46dWRWFkZtCEAb",
+                        "TradingFee": 1000,
+                        "VoteWeight": 34
+                      }
+                    },
+                    {
+                      "VoteEntry": {
+                        "Account": "rfGvXTdJhQkuTV8XBTGeiTNhKWQMJoBVzk",
+                        "TradingFee": 1000,
+                        "VoteWeight": 85
+                      }
+                    },
+                    {
+                      "VoteEntry": {
+                        "Account": "rUKt9SX1XcQA8q4QEvcGzXdMsar123FLKn",
+                        "TradingFee": 1000,
+                        "VoteWeight": 108
+                      }
+                    }
+                  ]
+                },
+                "LedgerEntryType": "AMM",
+                "LedgerIndex": "33A29FF46A9C5BD2E67936FC7E895026763ECCD54BED68573692253339DA4171",
+                "PreviousFields": {
+                  "LPTokenBalance": {
+                    "currency": "03ED41506EA49D3D0F6B7C8212D3C5DA22C2C8B1",
+                    "issuer": "rP5J7x4HyHKQUUfrfzvuq28iLwiKPf7yv5",
+                    "value": "3310119834454356e-4"
+                  }
+                },
+                "PreviousTxnID": "B47160AA7D90A20CAE59D7A2871DBD11F66CE52BC157D21A6C3CFB937D9113C3",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "504F4E474F000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-4256714378784309e-3"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "504F4E474F000000000000000000000000000000",
+                    "issuer": "rP5J7x4HyHKQUUfrfzvuq28iLwiKPf7yv5",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "504F4E474F000000000000000000000000000000",
+                    "issuer": "rwCq6TENSo3Hh9LKipXnLaxaeXBXKubqki",
+                    "value": "0"
+                  },
+                  "LowNode": "1"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "6BAF5F3BAE5160263E3E2802B305DB39EF84F003EDF9BB1A6B2D606620ED22E5",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "504F4E474F000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-4256703737075077e-3"
+                  }
+                },
+                "PreviousTxnID": "B47160AA7D90A20CAE59D7A2871DBD11F66CE52BC157D21A6C3CFB937D9113C3",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "504F4E474F000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "47.32837164"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "504F4E474F000000000000000000000000000000",
+                    "issuer": "rwCq6TENSo3Hh9LKipXnLaxaeXBXKubqki",
+                    "value": "0"
+                  },
+                  "HighNode": "1ba",
+                  "LowLimit": {
+                    "currency": "504F4E474F000000000000000000000000000000",
+                    "issuer": "rpgtbNuTeDtdBmLpjsL8KsdoukciuNSLtf",
+                    "value": "9999641898297400e-2"
+                  },
+                  "LowNode": "10"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "A08F622AD4DC9088B2F2E4C7B26ABB745B2B3BA9B8F49093CEB9CADBA3BDF3F7",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "504F4E474F000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "10641756.56062187"
+                  }
+                },
+                "PreviousTxnID": "F31D8D3A7EF4A6B712003418154D65CA77BB4B2A1A9A670C714FD2310F10B957",
+                "PreviousTxnLgrSeq": 94084600
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "33A29FF46A9C5BD2E67936FC7E895026763ECCD54BED68573692253339DA4171",
+                  "Account": "rP5J7x4HyHKQUUfrfzvuq28iLwiKPf7yv5",
+                  "Balance": "39866687388",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 92512005
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AB585F5087494DC672D8EF59A0EBDA1D5E847B6CE2E36EC5B5121817C9D276E6",
+                "PreviousFields": {
+                  "Balance": "39866587722"
+                },
+                "PreviousTxnID": "650305AC3EDD5A1093FB8055E951E48389FE325B50E685136BEFCFC4A463C567",
+                "PreviousTxnLgrSeq": 94084601
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpgtbNuTeDtdBmLpjsL8KsdoukciuNSLtf",
+                  "Balance": "933422329",
+                  "Flags": 0,
+                  "OwnerCount": 388,
+                  "Sequence": 66662784
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C2145E8D25C3233E0866BBC1B478BFB47233D415B69F8210A6EB312DD179CE00",
+                "PreviousFields": {
+                  "Balance": "933522007",
+                  "Sequence": 66662783
+                },
+                "PreviousTxnID": "F31D8D3A7EF4A6B712003418154D65CA77BB4B2A1A9A670C714FD2310F10B957",
+                "PreviousTxnLgrSeq": 94084600
+              }
+            }
+          ],
+          "TransactionIndex": 17,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 167782385,
+        "Sequence": 167782396,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": "14935000000",
+        "TakerPays": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "37929.8221"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304402207FC24417C280A877581BBDB065D1177D45FB44B27574F73EE23400B1DB66EC7F02207BFC0FD2F51E37EFE8527E61FC78AED52EB1B26F10C5F1A6B39E022CC900174C",
+        "hash": "7F95B207AEF1A05E5CE0814A865A067F540B425E26AD4650498B72311CF2ECE1",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3",
+                "PreviousTxnID": "1CCA9507B308F8DF78DBFED8F4030D0EC9B188E98AFFCB19EA0CDEDD317618ED",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "15035590670",
+                  "Flags": 0,
+                  "OwnerCount": 17,
+                  "Sequence": 167782397
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "15035590690",
+                  "Sequence": 167782396
+                },
+                "PreviousTxnID": "1CCA9507B308F8DF78DBFED8F4030D0EC9B188E98AFFCB19EA0CDEDD317618ED",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F0905CEAC267800",
+                "NewFields": {
+                  "ExchangeRate": "4f0905ceac267800",
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F0905CEAC267800",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f09067af7966000",
+                  "Flags": 0,
+                  "PreviousTxnID": "BA2B41293A026E5B06FE809B0C80C48F0F607A9276DF11A954A201FFDD529BDF",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F09067AF7966000",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F09067AF7966000"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "8D689E1D07E7887FC5832D380DA6DC4C5964C15CC67C443D34A7F74652D175A6",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F0905CEAC267800",
+                  "Sequence": 167782396,
+                  "TakerGets": "14935000000",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "37929.8221"
+                  }
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F09067AF7966000",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "BA2B41293A026E5B06FE809B0C80C48F0F607A9276DF11A954A201FFDD529BDF",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "Sequence": 167782385,
+                  "TakerGets": "14935000000",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "37940.874"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "C3DE277EDD8E0F5AA912C94E6BA439E82B3C74834767C019E932CB76305287A9"
+              }
+            }
+          ],
+          "TransactionIndex": 34,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 144101820,
+        "Sequence": 144101824,
+        "SigningPubKey": "022D40673B44C82DEE1DDB8B9BB53DCCE4F97B27404DB850F068DD91D685E337EA",
+        "TakerGets": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "254809.0466560966"
+        },
+        "TakerPays": "23793716053",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3044022020E5532F2948BA33875F93018750E73A066E10BEA481E3932FEA034B9AFA993202204AED7313D8BB9E9F036F9865D47A1115EA5BFF919AC7FD01A15FF72FAB15C14C",
+        "hash": "80C087E969C89E41CC153D8E96391114596CA13096615FD3CBECEC98A5F397E3",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5921282b906db6c1",
+                  "Flags": 0,
+                  "PreviousTxnID": "3A4F2024CF352C9C11259889E81514EBBA2C7C2BF70C9FF0B38539B31F57219E",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975921282B906DB6C1",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975921282B906DB6C1"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB709759212CBC5209DBD5",
+                "NewFields": {
+                  "ExchangeRate": "59212cbc5209dbd5",
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB709759212CBC5209DBD5",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "44DC8D88900D8B73630C3D6560B28EC6B81BE145EA025A8C4AB395AF22DAC3D8",
+                "NewFields": {
+                  "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB709759212CBC5209DBD5",
+                  "Sequence": 144101824,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "254809.0466560966"
+                  },
+                  "TakerPays": "23793716053"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975921282B906DB6C1",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "3A4F2024CF352C9C11259889E81514EBBA2C7C2BF70C9FF0B38539B31F57219E",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "Sequence": 144101820,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "154169.8336402234"
+                  },
+                  "TakerPays": "14388426682"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "9C20C00E971DD57BD157AC6EA8DF64C367452F76B90141E8C6A0A957EBD35A73"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "RootIndex": "AEA3074F10FE15DAC592F8A0405C61FB7D4C98F588C2D55C84718FAFBBD2604A"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "AEA3074F10FE15DAC592F8A0405C61FB7D4C98F588C2D55C84718FAFBBD2604A",
+                "PreviousTxnID": "B144ED0857D28D46399688B036CF896E6DBF1EB5EE1CB750B4E64B39C5771580",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "Balance": "100345307",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 144101825
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E0311EB450B6177F969B94DBDDA83E99B7A0576ACD9079573876F16C0C004F06",
+                "PreviousFields": {
+                  "Balance": "100345322",
+                  "Sequence": 144101824
+                },
+                "PreviousTxnID": "B144ED0857D28D46399688B036CF896E6DBF1EB5EE1CB750B4E64B39C5771580",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            }
+          ],
+          "TransactionIndex": 3,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rGDreBvnHrX1get7na3J4oowN19ny4GzFn",
+        "Amount": "27024428",
+        "DeliverMax": "27024428",
+        "Destination": "raQwCVAJVqjrVm1Nj5SFRcX8i22BhdC9WA",
+        "DestinationTag": 3814501049,
+        "Fee": "20",
+        "Flags": 2147483648,
+        "LastLedgerSequence": 94085606,
+        "Sequence": 1132118,
+        "SigningPubKey": "02024F808D657322E73CEA9A0109CDBD9A3A56552CA87F847DD8558B47CD0F2E20",
+        "TransactionType": "Payment",
+        "TxnSignature": "3045022100B1D592712A51621B26CBE58FB9E12F38284C6073C5D19BED2F307457B712903A02201777E20F309C3DBE32D4A440E0F8F4FA4E24CCE407C5A0E653D9B2238C415CB0",
+        "hash": "82410C3A99011DA1AB77C4C9D78147BCD7BD1809661F13F07A4B3E58A686B930",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rGDreBvnHrX1get7na3J4oowN19ny4GzFn",
+                  "Balance": "38870750664508",
+                  "Flags": 131072,
+                  "OwnerCount": 1,
+                  "Sequence": 1132119
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "8719BD164C9F79A760E19FB64691885E63CC595032E559971F89C1E22EAEC220",
+                "PreviousFields": {
+                  "Balance": "38870777688956",
+                  "Sequence": 1132118
+                },
+                "PreviousTxnID": "4818FF59B8076B61E426F7533F602996D9216BF6C1496114692F2F99C92B7468",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "raQwCVAJVqjrVm1Nj5SFRcX8i22BhdC9WA",
+                  "Balance": "2313854255041",
+                  "Flags": 131072,
+                  "OwnerCount": 1,
+                  "Sequence": 204571
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E5C6084FF22D11C5236D69FA9EA6F46ED694A663FCEDCE10D84B00BF09F74F1B",
+                "PreviousFields": {
+                  "Balance": "2313827230613"
+                },
+                "PreviousTxnID": "8F512098AB68A8775EAA6EBA34FAA4750AE4673F4AA7C5DD2734B8B76C9BE0DC",
+                "PreviousTxnLgrSeq": 94084606
+              }
+            }
+          ],
+          "TransactionIndex": 60,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "27024428"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 123729275,
+        "Sequence": 123729331,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "304402206C81B0B488049A99476DA63864503A78099E7EA96FE9B3EC4A3A9DBE5BFCA705022029F786B28ED332F61335C8354975F429CD501E6DBE03129C79129FA0FF864028",
+        "hash": "86EBE66B7D01F69A5B34C79DEC0F7B8621D4F485FB891E424F4CF4DBC6F2D11E",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "CEA664F2B7C3F3A31B6DE8E3F179E3AE5E2C471FCD6039E7570494A95AC3AE00",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "19b14",
+                  "PreviousTxnID": "BF6F729EE2D6C941EB84ADE4E14C0E0A2631CD2568AD83A426F087975CDB37FE",
+                  "PreviousTxnLgrSeq": 94084588,
+                  "Sequence": 123729275,
+                  "TakerGets": {
+                    "currency": "LTC",
+                    "issuer": "rcRzGWq6Ng3jeYhqnmM4zcWcUh69hrQ8V",
+                    "value": "27.1095319603214"
+                  },
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "3495.381058070019"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "147D99027772C5458660D16370C0CE1752F28DFEE90575DE20F2D8927FBEA0E1"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "91960028995",
+                  "Flags": 0,
+                  "OwnerCount": 138,
+                  "Sequence": 123729332
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "91960029005",
+                  "OwnerCount": 139,
+                  "Sequence": 123729331
+                },
+                "PreviousTxnID": "D3CAD77DA369288D6E9F3D828977F1B8BCDD59C622892D7D77E1C64D3008A947",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "570494a95ac3ae00",
+                  "Flags": 0,
+                  "PreviousTxnID": "D3CAD77DA369288D6E9F3D828977F1B8BCDD59C622892D7D77E1C64D3008A947",
+                  "PreviousTxnLgrSeq": 94084608,
+                  "RootIndex": "CEA664F2B7C3F3A31B6DE8E3F179E3AE5E2C471FCD6039E7570494A95AC3AE00",
+                  "TakerGetsCurrency": "0000000000000000000000004C54430000000000",
+                  "TakerGetsIssuer": "06B36AC50AC7331069070C6350B202EAF2125C7C",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CEA664F2B7C3F3A31B6DE8E3F179E3AE5E2C471FCD6039E7570494A95AC3AE00"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "19b15",
+                  "IndexPrevious": "19b13",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DF3339FE796ED3E629118B760BB5CDB86E3D496F8FCDAC784A7AEA7B40C68BEA",
+                "PreviousTxnID": "D3CAD77DA369288D6E9F3D828977F1B8BCDD59C622892D7D77E1C64D3008A947",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            }
+          ],
+          "TransactionIndex": 48,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Amount": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "0.009743698947400346"
+        },
+        "DeliverMax": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "0.009743698947400346"
+        },
+        "Destination": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 94084609,
+        "SendMax": {
+          "currency": "5377697373546563680000000000000000000000",
+          "issuer": "raq7pGaYrLZRa88v6Py9V5oWMYEqPYr8Tz",
+          "value": "0.7788400340257631"
+        },
+        "Sequence": 29665812,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TransactionType": "Payment",
+        "TxnSignature": "A3D016AB899AA5F2111ED2CFCC44877FBE6A46837AF3C88C7F201AFD50A9EE6387484181EAC54C40028C02613635B1953502EEA7E9F18551F1E3608F9556F10F",
+        "hash": "88D2EFCC697A12E2E40B7494897953BC58ECB7F293381437C0B07983B1877075",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.009743698947400346"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "0"
+                  },
+                  "HighNode": "237c",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "197E542413061266DC6995ADD18728149974484D717A415649AE12E89E297DA5",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  }
+                },
+                "PreviousTxnID": "5DDFB6E819730F37B7B1CD7101BA5D76ACC4166EDFF9D45AA6AD6A8251277FE5",
+                "PreviousTxnLgrSeq": 94084545
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-30365.9226435823"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "rGzrqeJ1WT5iiUcYVRArYEcioeMyUvRwJu",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "raq7pGaYrLZRa88v6Py9V5oWMYEqPYr8Tz",
+                    "value": "0"
+                  },
+                  "LowNode": "9d2"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "4977FF3D23BEA01F381AAF8692AF32D4915A706498856EE31357F762AE211B6B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-30365.18274945764"
+                  }
+                },
+                "PreviousTxnID": "FB5A8C974C98AEF99D4D7B39E19615E70F6DDCB2D7D3661C3D3D055EBCEE628B",
+                "PreviousTxnLgrSeq": 94084587
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-401.0411529242131"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rGzrqeJ1WT5iiUcYVRArYEcioeMyUvRwJu",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "0"
+                  },
+                  "LowNode": "236b"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "5F46C4CC0E76D352F08758B6CC13BB2FE6EBF12F4BF29F7A5CB6F8709FDEE1BD",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-401.0509161105584"
+                  }
+                },
+                "PreviousTxnID": "FB5A8C974C98AEF99D4D7B39E19615E70F6DDCB2D7D3661C3D3D055EBCEE628B",
+                "PreviousTxnLgrSeq": 94084587
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "88D2EFCC697A12E2E40B7494897953BC58ECB7F293381437C0B07983B1877075",
+                  "Balance": "97189504",
+                  "Flags": 0,
+                  "OwnerCount": 404,
+                  "Sequence": 29665813
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "B4F866A6615F27437ED0D1B8423D254BC53F390363D16C402243EDCBE8BAF0A7",
+                  "Balance": "97189514",
+                  "Sequence": 29665812
+                },
+                "PreviousTxnID": "B4F866A6615F27437ED0D1B8423D254BC53F390363D16C402243EDCBE8BAF0A7",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0015449983893466"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "raq7pGaYrLZRa88v6Py9V5oWMYEqPYr8Tz",
+                    "value": "0"
+                  },
+                  "HighNode": "9d4",
+                  "LowLimit": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "EDFD482EE5A971AE673A8B5EB79405006DB3287A0B4B76C7888BAF899FF62FF7",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.7414391230515426"
+                  }
+                },
+                "PreviousTxnID": "B4F866A6615F27437ED0D1B8423D254BC53F390363D16C402243EDCBE8BAF0A7",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            }
+          ],
+          "TransactionIndex": 10,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "USD",
+            "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+            "value": "0.009743698947400346"
+          }
+        }
+      },
+      {
+        "Account": "rUqqN1KKvLSknssUXrLX48vtnNdpvaqsZ7",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 30447243,
+        "Sequence": 30447244,
+        "SigningPubKey": "022E70597C73E359D20C5939F9A9009B42D51DAD22E633762832E44336B95D177C",
+        "TakerGets": {
+          "currency": "CNY",
+          "issuer": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y",
+          "value": "1736029.133"
+        },
+        "TakerPays": "100000000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "30440220294E28D97D538C5BE0B82E96950A6BAE2FB57D2C5E249B486750AAC64035493902206D01A9A65D9FFCA7EE62578263488D0F03DBE2359AE2D2D11832B975A6435F4A",
+        "hash": "898C518D9A5402DA2CBE4EF563C90C6B963B1E2B8193738DE8320AD82C3F9640",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rUqqN1KKvLSknssUXrLX48vtnNdpvaqsZ7",
+                  "RootIndex": "1BBEACDDD4D74F0AC4548C926F22916D6B00C59C24FFC036D6D66F0456A3A947"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1BBEACDDD4D74F0AC4548C926F22916D6B00C59C24FFC036D6D66F0456A3A947",
+                "PreviousTxnID": "24EAC52145FC7B8B31E4FD903268833174AF25F285B7F55813F88F86A3DCCA85",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "300435B0896C3FEDC9EC6C875EAA73206FF02FAF0E64C4A418551BE70BBF4020",
+                "NewFields": {
+                  "Account": "rUqqN1KKvLSknssUXrLX48vtnNdpvaqsZ7",
+                  "BookDirectory": "49789A0B460DC77A2CED9349C432AEA97352345BA3C7313A591476EFD629D9F8",
+                  "Sequence": 30447244,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y",
+                    "value": "1736029.133"
+                  },
+                  "TakerPays": "100000000000"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUqqN1KKvLSknssUXrLX48vtnNdpvaqsZ7",
+                  "Balance": "100867187",
+                  "Flags": 0,
+                  "OwnerCount": 2,
+                  "Sequence": 30447245
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "47AA01718D2EEC8C55C99463B8BA8BC4E1EDD346737FE9AC9A715B10653E7326",
+                "PreviousFields": {
+                  "Balance": "100867202",
+                  "Sequence": 30447244
+                },
+                "PreviousTxnID": "24EAC52145FC7B8B31E4FD903268833174AF25F285B7F55813F88F86A3DCCA85",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "49789A0B460DC77A2CED9349C432AEA97352345BA3C7313A591476EFD629D9F8",
+                "NewFields": {
+                  "ExchangeRate": "591476efd629d9f8",
+                  "RootIndex": "49789A0B460DC77A2CED9349C432AEA97352345BA3C7313A591476EFD629D9F8",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "CED6E99370D5C00EF4EBF72567DA99F5661BFB3A"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "591476efe304c98f",
+                  "Flags": 0,
+                  "PreviousTxnID": "24EAC52145FC7B8B31E4FD903268833174AF25F285B7F55813F88F86A3DCCA85",
+                  "PreviousTxnLgrSeq": 94084607,
+                  "RootIndex": "49789A0B460DC77A2CED9349C432AEA97352345BA3C7313A591476EFE304C98F",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "CED6E99370D5C00EF4EBF72567DA99F5661BFB3A",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "49789A0B460DC77A2CED9349C432AEA97352345BA3C7313A591476EFE304C98F"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rUqqN1KKvLSknssUXrLX48vtnNdpvaqsZ7",
+                  "BookDirectory": "49789A0B460DC77A2CED9349C432AEA97352345BA3C7313A591476EFE304C98F",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "24EAC52145FC7B8B31E4FD903268833174AF25F285B7F55813F88F86A3DCCA85",
+                  "PreviousTxnLgrSeq": 94084607,
+                  "Sequence": 30447243,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y",
+                    "value": "1736029.068"
+                  },
+                  "TakerPays": "100000000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "DA499D5CB497C363A798557B35C9ED5463A42287B22B3538356A6D69BDCB6135"
+              }
+            }
+          ],
+          "TransactionIndex": 63,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "4D756532417938746A66725F5934784A6847466158",
+              "MemoType": "696E7465726E616C6F726465726964"
+            }
+          }
+        ],
+        "OfferSequence": 93305416,
+        "Sequence": 93305419,
+        "SigningPubKey": "025EBE8E351CAC5C641624238CD36A360631728177A5314566CC6BA0BAD4EF65FC",
+        "TakerGets": "1732873",
+        "TakerPays": {
+          "currency": "434F524500000000000000000000000000000000",
+          "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+          "value": "23.074816"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "30440220644F74CB2C0D6729B184EF2EEFAEC62DF90593C03714D4F508E06FEA7C3C883702207C452DC5F9F01EC023C1639A3983E0CF129ABA8D317B80AF239F09741ACBA228",
+        "hash": "8DE11442A8DB0B97E7F6B4718E062B7C232FE7734A32E606D883577421EAC61C",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "00F1E982285D673B0EB19CE82A2510B261818B94ADB09B7A341FA9253E0DA17E",
+                "NewFields": {
+                  "Account": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+                  "BookDirectory": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004BB13A93D79D9",
+                  "Sequence": 93305419,
+                  "TakerGets": "1732873",
+                  "TakerPays": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "23.074816"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+                  "RootIndex": "625124F968DCC1DEBB9EBE2C902DD6DE00945C218CC672DB067A8B30DC2F8542"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "625124F968DCC1DEBB9EBE2C902DD6DE00945C218CC672DB067A8B30DC2F8542",
+                "PreviousTxnID": "21532642DFDA93CDA88147D6AFA4C3DF647CF351D64180104CBF23DF68FC8857",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+                  "Balance": "68142050847",
+                  "Flags": 0,
+                  "OwnerCount": 11,
+                  "Sequence": 93305420
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "9C1D8ABFBDC2F6A287CF320407BF8957B3CA5FE87C52C1EAD494E867A32ED9DB",
+                "PreviousFields": {
+                  "Balance": "68142050862",
+                  "Sequence": 93305419
+                },
+                "PreviousTxnID": "21532642DFDA93CDA88147D6AFA4C3DF647CF351D64180104CBF23DF68FC8857",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rE5rYEY8W4ZKzKUg3Q9by6cz33sRKWbADR",
+                  "BookDirectory": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004BBF7079C6977",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "73B0BE40BE76D877702D8D3A362B697D16933C4D7C452F967ECB0298DD55D850",
+                  "PreviousTxnLgrSeq": 94084607,
+                  "Sequence": 93305416,
+                  "TakerGets": "1732028",
+                  "TakerPays": {
+                    "currency": "434F524500000000000000000000000000000000",
+                    "issuer": "rcoreNywaoz2ZCQ8Lg2EbSLnGuRBmun6D",
+                    "value": "23.080478"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "A4C3ADA7C291C966103CDC22647946983C0A6E673C4F82D59A7DB7E4BD6B895B"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004BB13A93D79D9",
+                "NewFields": {
+                  "ExchangeRate": "5004bb13a93d79d9",
+                  "RootIndex": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004BB13A93D79D9",
+                  "TakerPaysCurrency": "434F524500000000000000000000000000000000",
+                  "TakerPaysIssuer": "06C4F77E3CBA482FB688F8AA92DCA0A10A8FD774"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5004bbf7079c6977",
+                  "Flags": 0,
+                  "PreviousTxnID": "73B0BE40BE76D877702D8D3A362B697D16933C4D7C452F967ECB0298DD55D850",
+                  "PreviousTxnLgrSeq": 94084607,
+                  "RootIndex": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004BBF7079C6977",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "434F524500000000000000000000000000000000",
+                  "TakerPaysIssuer": "06C4F77E3CBA482FB688F8AA92DCA0A10A8FD774"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B4DFE259D685BAE2D7B72ED8C3C7587FA959B5A565CEC95F5004BBF7079C6977"
+              }
+            }
+          ],
+          "TransactionIndex": 56,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rNVyr1fqjobUQRzG4H45saNhjyV8L4QwHp",
+        "Fee": "12",
+        "Flags": 2228224,
+        "LastLedgerSequence": 94084626,
+        "LimitAmount": {
+          "currency": "584D454D45000000000000000000000000000000",
+          "issuer": "rUNa1wQ4kNXLxC6MraVqQabJtTpptp7NJA",
+          "value": "0"
+        },
+        "Sequence": 92068020,
+        "SigningPubKey": "0358A99F9B8BF334739A5393B82FF18FCDAF30F7AC79AD9245BA761100EBA77FB1",
+        "SourceTag": 74920348,
+        "TransactionType": "TrustSet",
+        "TxnSignature": "30440220575028151767157FF3E005FD123DBF35D9B5ED366D396F2DD011D722410F61880220391124C90DE38C912DDD3759D58C00E77AC3ADF3EF12F84CCBEEC6EADA350F02",
+        "hash": "8E875478A8C686AD2B12AC6F66975A0DAE74219BDFAF8D68ACE2FD223FB784C7",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "21",
+                  "IndexPrevious": "1f",
+                  "Owner": "rUNa1wQ4kNXLxC6MraVqQabJtTpptp7NJA",
+                  "RootIndex": "15C127E382A7F47422036987E845E0CDF692E105FEDEABE64C35BB07CC1096F5"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "23B47835F4F9A99B60EE78CC2E934D9151B9510DD95D54CF055A70899B88844D",
+                "PreviousTxnID": "25BF797886114BF622FA5E8933FC15CFA4CFA88FE4942BA89F75B8145C2064BA",
+                "PreviousTxnLgrSeq": 94062791
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "6",
+                  "Owner": "rNVyr1fqjobUQRzG4H45saNhjyV8L4QwHp",
+                  "RootIndex": "90FDD2CD7F8F7F477E41F9A8FDC3B8FAFF55CF8830EB35BCC498CD73819662E8"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "ABB9643B4275EA7C6337335E7A2F2535E1EFEA56B097A7297294920D4E297B0E",
+                "PreviousTxnID": "54548DC0DDF8BC8CFB23093F8AE2C7ABCBE7097B84B546EF9D4B8F42BD5F88A9",
+                "PreviousTxnLgrSeq": 94084603
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rNVyr1fqjobUQRzG4H45saNhjyV8L4QwHp",
+                  "Balance": "6780888",
+                  "Flags": 0,
+                  "OwnerCount": 23,
+                  "Sequence": 92068021
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "D59A463D35E7015882B592BCDAE4ADBE0B7408874FB320E8BCA06ED506AB7B88",
+                "PreviousFields": {
+                  "Balance": "6780900",
+                  "OwnerCount": 24,
+                  "Sequence": 92068020
+                },
+                "PreviousTxnID": "54548DC0DDF8BC8CFB23093F8AE2C7ABCBE7097B84B546EF9D4B8F42BD5F88A9",
+                "PreviousTxnLgrSeq": 94084603
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "584D454D45000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 2097152,
+                  "HighLimit": {
+                    "currency": "584D454D45000000000000000000000000000000",
+                    "issuer": "rNVyr1fqjobUQRzG4H45saNhjyV8L4QwHp",
+                    "value": "0"
+                  },
+                  "HighNode": "7",
+                  "LowLimit": {
+                    "currency": "584D454D45000000000000000000000000000000",
+                    "issuer": "rUNa1wQ4kNXLxC6MraVqQabJtTpptp7NJA",
+                    "value": "0"
+                  },
+                  "LowNode": "20",
+                  "PreviousTxnID": "2C6AAF125E3891739E516D9C04418311E1282CCDA384214FB1B7115384685E6C",
+                  "PreviousTxnLgrSeq": 93967780
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "DB7F679CC44CDAF4F6359A2C3337E5DB1B2006F39120190F7EE12F08FD1E0842",
+                "PreviousFields": {
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "584D454D45000000000000000000000000000000",
+                    "issuer": "rNVyr1fqjobUQRzG4H45saNhjyV8L4QwHp",
+                    "value": "9999.99999999379"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "EBE091B6BBF486B625B04400DE011E04357AA90F0AD079A64ACF2AA78CEC5B73",
+                "PreviousTxnID": "906470DC76529747DC6003BC8266BC9F2DC7645D52FCF7157A927D7A8ABA5B29",
+                "PreviousTxnLgrSeq": 94083220
+              }
+            }
+          ],
+          "TransactionIndex": 67,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 143700481,
+        "Sequence": 143700485,
+        "SigningPubKey": "039451ECAC6D4EB75E3C926E7DC7BA7721719A1521502F99EC7EB2FE87CEE9E824",
+        "TakerGets": "17892237542",
+        "TakerPays": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "388986.9059867146"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3044022071A02B665E688311D6A28DD8076C7B5E4E322979E3DDA378F171C17C53217A350220242AB0BCFB2D298FE6BA5928DA61B9550E20F73578E2D96D0C2344EDA17A0C26",
+        "hash": "92631532977C634CA40221035BAA3E4FFDE6EB2B3B229AE36DE7465600ABDF0E",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "RootIndex": "07CE63F6E62E095CAF97BC77572A203D75ECB68219F97505AC5DF2DB061C9D96"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "07CE63F6E62E095CAF97BC77572A203D75ECB68219F97505AC5DF2DB061C9D96",
+                "PreviousTxnID": "B41B4A1755A29B0303E9B8BAFF0222F8057C6B1417E9FA8F3CB88C65752DD1B9",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475007BA5A56A10993",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "4F1E545E91E29B42C00924EC045DAF2C794FB7C16884106CCCDBB41F9F31068E",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "Sequence": 143700481,
+                  "TakerGets": "11219773357",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "244054.9784331323"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "266B266EF9EA427499A17991C0DB5AF7DC25F2E37A6FBD52C710DCCAFA611EDC"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "Balance": "1000571169",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 143700486
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "47FE64F9223D604034486F4DA7A175D5DA7F8A096952261CF8F3D77B74DC4AFA",
+                "PreviousFields": {
+                  "Balance": "1000571184",
+                  "Sequence": 143700485
+                },
+                "PreviousTxnID": "B41B4A1755A29B0303E9B8BAFF0222F8057C6B1417E9FA8F3CB88C65752DD1B9",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475007B94A6465CB62",
+                "NewFields": {
+                  "ExchangeRate": "5007b94a6465cb62",
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475007B94A6465CB62",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5007ba5a56a10993",
+                  "Flags": 0,
+                  "PreviousTxnID": "4F1E545E91E29B42C00924EC045DAF2C794FB7C16884106CCCDBB41F9F31068E",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475007BA5A56A10993",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475007BA5A56A10993"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "EFB1BE67D75D35AA81F38238D27161EA1FA546AF471DFFDD44277736BDBCC30D",
+                "NewFields": {
+                  "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475007B94A6465CB62",
+                  "Sequence": 143700485,
+                  "TakerGets": "17892237542",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "388986.9059867146"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 76,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rnwKB3Ba1WaVphVJAFfgPwb5oLjUopYTrB",
+        "Fee": "12",
+        "Flags": 2228224,
+        "LastLedgerSequence": 94084626,
+        "LimitAmount": {
+          "currency": "5748590000000000000000000000000000000000",
+          "issuer": "rUikrq6kQdeuQAmowgRtazfi46qvQHzEBD",
+          "value": "0"
+        },
+        "Sequence": 92796107,
+        "SigningPubKey": "EDB0FB6AE5994804AA85C59F73A460350B2DFA3B2319442B1DCF67653DBF2C43FB",
+        "TransactionType": "TrustSet",
+        "TxnSignature": "56F2CD152C47A643E189B2F712EE2A7EBB5C25E0F022F765DB3C4E8A837BB0586ADE0361240F8739E3B4380E60F9CB2AD00676148C379FA1936515E56109B708",
+        "hash": "94AF3D37D357413E8DB65202518768798DEA926EF96D5A5836B2D76D5DABCE3A",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rnwKB3Ba1WaVphVJAFfgPwb5oLjUopYTrB",
+                  "Balance": "29137296",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 92796108,
+                  "TicketCount": 5
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "47E99CDE63ECC189D6169E1D3B5F1B5C6865A744CE1E6DA5887F41F62D46980A",
+                "PreviousFields": {
+                  "Balance": "29137308",
+                  "Sequence": 92796107
+                },
+                "PreviousTxnID": "10E5F603AD6482E0F3C3CB6CD1690C01DFE0E7D3FBF5E0ED3482664791E54AAA",
+                "PreviousTxnLgrSeq": 94080355
+              }
+            }
+          ],
+          "TransactionIndex": 7,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "Sequence": 123729336,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TakerGets": "20900828807",
+        "TakerPays": {
+          "currency": "EUR",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "50252.07481291395"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100A332137DCC92EDB97141709E144964EDA6F73F73FD042DA4A436A59BD254860A02206E8F35BA63C886034B9EB92D69F4EEBEFD7074D29B67EEA29FC88B5DD3D585E5",
+        "hash": "98A43B919AEB47DB68EED3A31D88F9EF13215FA605F2553AB25CF248FD524C4E",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "6D8BFE82A628201D6B69E4E090F35E10ADD5CAD0AC494D729B46FBBF99DDFBE1",
+                "NewFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624F088AB51454EC45",
+                  "OwnerNode": "19b15",
+                  "Sequence": 123729336,
+                  "TakerGets": "20900828807",
+                  "TakerPays": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "50252.07481291395"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b14",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9DBB7ADE16C6B4D763193B6D41161ACF6E93F22C6F4401FFC89B89ADCC378328",
+                "PreviousTxnID": "D9B2B0AEA084E8C1DBA6024BFDF9B77AB1F701ED45F1B746F7E8E6F0AA3E0471",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "91960028945",
+                  "Flags": 0,
+                  "OwnerCount": 139,
+                  "Sequence": 123729337
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "91960028955",
+                  "OwnerCount": 138,
+                  "Sequence": 123729336
+                },
+                "PreviousTxnID": "D9B2B0AEA084E8C1DBA6024BFDF9B77AB1F701ED45F1B746F7E8E6F0AA3E0471",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624F088AB51454EC45",
+                "NewFields": {
+                  "ExchangeRate": "4f088ab51454ec45",
+                  "RootIndex": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624F088AB51454EC45",
+                  "TakerPaysCurrency": "0000000000000000000000004555520000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 53,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "Sequence": 123729337,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TakerGets": "29377046113",
+        "TakerPays": {
+          "currency": "EUR",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "70631.53010337884"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304402201582A48F50CD55AC7A21886CA243267D4C9E60105B6324AB188B65CC87BB8CFF02202DC29714457A0AF440D878D1FFC724FED9816E05A19DB8727215C227A738BAEE",
+        "hash": "995149CE0F27F46B7CA1F1E39DAC35601C6F08DFF97191DD5009CE7EE766CFB7",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b14",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9DBB7ADE16C6B4D763193B6D41161ACF6E93F22C6F4401FFC89B89ADCC378328",
+                "PreviousTxnID": "98A43B919AEB47DB68EED3A31D88F9EF13215FA605F2553AB25CF248FD524C4E",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "91960028935",
+                  "Flags": 0,
+                  "OwnerCount": 140,
+                  "Sequence": 123729338
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "91960028945",
+                  "OwnerCount": 139,
+                  "Sequence": 123729337
+                },
+                "PreviousTxnID": "98A43B919AEB47DB68EED3A31D88F9EF13215FA605F2553AB25CF248FD524C4E",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624F088AB51455472E",
+                "NewFields": {
+                  "ExchangeRate": "4f088ab51455472e",
+                  "RootIndex": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624F088AB51455472E",
+                  "TakerPaysCurrency": "0000000000000000000000004555520000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                }
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "D182D790EA97257A7B9219672888208443407BB1F29A97082F52859DD9626B31",
+                "NewFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624F088AB51455472E",
+                  "OwnerNode": "19b15",
+                  "Sequence": 123729337,
+                  "TakerGets": "29377046113",
+                  "TakerPays": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "70631.53010337884"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 54,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBFVZq2vH2KhFJDxf9ojgA7tRWrDsvyUGj",
+        "Fee": "12",
+        "Flags": 2228224,
+        "LastLedgerSequence": 94084626,
+        "LimitAmount": {
+          "currency": "5748590000000000000000000000000000000000",
+          "issuer": "rUikrq6kQdeuQAmowgRtazfi46qvQHzEBD",
+          "value": "0"
+        },
+        "Sequence": 92751140,
+        "SigningPubKey": "EDD638C645847EF0982BCE03A93AC3F7F8A65B36E5B7A8AA8011A226F8A965DC87",
+        "TransactionType": "TrustSet",
+        "TxnSignature": "BC9FF66B3F56DF463391DBB87EF4F628A35E98662CC546B8EB22B9BB33EDE462C5B33A79575B636A7A0D881FF5F702F2B26E976B8DDDB0A1D53F325E6555C402",
+        "hash": "996976870B00622A48B69B97A34C1A063F5F40DE70C903C04F2FD67E8D74947C",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBFVZq2vH2KhFJDxf9ojgA7tRWrDsvyUGj",
+                  "Balance": "29989868",
+                  "Flags": 0,
+                  "OwnerCount": 6,
+                  "Sequence": 92751141,
+                  "TicketCount": 6
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "9B67D8540B6FB36B65F9B9FD5BE8E96D0799D4D711CBAB513DAE589CABDC897D",
+                "PreviousFields": {
+                  "Balance": "29989880",
+                  "Sequence": 92751140
+                },
+                "PreviousTxnID": "A2CBF888374EC61760183C3E29B1DB86FA975B81AE07F99865E865E4C27D7D93",
+                "PreviousTxnLgrSeq": 94080355
+              }
+            }
+          ],
+          "TransactionIndex": 39,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+        "Expiration": 792720015,
+        "Fee": "10",
+        "Flags": 65536,
+        "LastLedgerSequence": 94084626,
+        "OfferSequence": 90961378,
+        "Sequence": 0,
+        "SigningPubKey": "ED4A8371720A1D404927F0B32DD49BDE4F8E2A8177D027482492AEE4F3C5045834",
+        "TakerGets": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "2855.04333"
+        },
+        "TakerPays": "1183614270",
+        "TicketSequence": 90961385,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "C31F96907B604A805DF3B3556CA6A9C7B763D4C3E10248DCCB6A6DBA31C9463AC6FE9C41F57B854C8127A63E8D3CACA436CE0C10F80082FDEEE667CC7AA87200",
+        "hash": "9AF16F22553695556DC8E4A57F0CD49ECB2A5DDA274791454BDB273192586A4B",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Flags": 0,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "A6F924B090289827515733829A2C4CAF2DABEA5920F6F1B845515F9E243D1D9D",
+                  "PreviousTxnLgrSeq": 94084581,
+                  "TicketSequence": 90961385
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "04477E6690BA2A6512C203036F68FAA2949BDE06ABC10BBC0B876515FB8CD282"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "30A0AA5DA10DFA964FA4331FC67354E427DC2F395BEF619AB576B7A1866834FA",
+                "NewFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EBA7D4D080A00",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "Sequence": 90961385,
+                  "TakerGets": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "2855.042879400014"
+                  },
+                  "TakerPays": "1183614270"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "412",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "32D3BEA733A3C7B90A32A6A57DF912F7BE843090DD460A54255F8083E925C2ED",
+                "PreviousTxnID": "9ECD38CF03E1B9C7E2AF83E0CCDC24AC4AF197CCE821722F28C5FE047A1E9D61",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f08a1c134c4a1d2",
+                  "Flags": 0,
+                  "PreviousTxnID": "EE1EE14CDE2B4173680E3CC3B51A8C1DDB2072A9C07117416CC321B61BE53D76",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F08A1C134C4A1D2",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F08A1C134C4A1D2"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F08A1C134C4A1D2",
+                  "BookNode": "0",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "EE1EE14CDE2B4173680E3CC3B51A8C1DDB2072A9C07117416CC321B61BE53D76",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "Sequence": 90961378,
+                  "TakerGets": "1972220920",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "4791.80853"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "A42B2FF05A4809671E9EF08EC908C9FC505E85197CB82EC28D226416DA205437"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Balance": "48203421419",
+                  "Flags": 0,
+                  "OwnerCount": 32,
+                  "Sequence": 90961404,
+                  "TicketCount": 18
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AB4F967F07A17B276A162D2BE831BB2B4BB7D28C58A71E2B47040114CE4599AE",
+                "PreviousFields": {
+                  "Balance": "48203421429",
+                  "OwnerCount": 33,
+                  "TicketCount": 19
+                },
+                "PreviousTxnID": "9ECD38CF03E1B9C7E2AF83E0CCDC24AC4AF197CCE821722F28C5FE047A1E9D61",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EBA7D4D080A00",
+                "NewFields": {
+                  "ExchangeRate": "5a0eba7d4d080a00",
+                  "RootIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EBA7D4D080A00",
+                  "TakerGetsCurrency": "524C555344000000000000000000000000000000",
+                  "TakerGetsIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 24,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rELS4xDgjp8ZfR6MQGfPVhB5Pn42pvYJKW",
+        "Expiration": 792634803,
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 94084617,
+        "OfferSequence": 69213268,
+        "Sequence": 69213269,
+        "SigningPubKey": "03E41AE33C5913DA2470972AF0667B08BCC306483D83853C674DEC1111CBE28D71",
+        "TakerGets": {
+          "currency": "ELS",
+          "issuer": "rHXuEaRYnnJHbDeuBH5w8yPh5uwNVh5zAg",
+          "value": "55555.43908686671"
+        },
+        "TakerPays": "50000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "30440220753959B33DD4FDA467FAE91A6EAD3FB22548471935DB2E45FE826C42D06DCCC4022037D267D166E858FF15B5A27849385F7B8085F4A348A8BB7622001F765117A154",
+        "hash": "9BF31B2E4C73CD15C078F07137112E83B104965D474545611D2AA57A4EB7E823",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rELS4xDgjp8ZfR6MQGfPVhB5Pn42pvYJKW",
+                  "RootIndex": "0751804A2E2188EACDC2B90951C1E46212B0F239F29EB54DAFCEBEC48BE2C7BA"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0751804A2E2188EACDC2B90951C1E46212B0F239F29EB54DAFCEBEC48BE2C7BA",
+                "PreviousTxnID": "9119DF096827C8FEB825C34EC93402745AB639B1AA369114354C8E3A18FD2D32",
+                "PreviousTxnLgrSeq": 94084530
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "2CBF5C267C7BBD4B45391175A9573502FF01CC81AB7ADA50C5AA0CE0FC726BE7",
+                "NewFields": {
+                  "Account": "rELS4xDgjp8ZfR6MQGfPVhB5Pn42pvYJKW",
+                  "BookDirectory": "E5C94F1371961189FB277B38B4FB0AA0423970BB4A3C7599571FF9782F98D4AD",
+                  "Expiration": 792634803,
+                  "Sequence": 69213269,
+                  "TakerGets": {
+                    "currency": "ELS",
+                    "issuer": "rHXuEaRYnnJHbDeuBH5w8yPh5uwNVh5zAg",
+                    "value": "55555.43908686671"
+                  },
+                  "TakerPays": "50000000"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rELS4xDgjp8ZfR6MQGfPVhB5Pn42pvYJKW",
+                  "BookDirectory": "E5C94F1371961189FB277B38B4FB0AA0423970BB4A3C7599571FF97A164FB286",
+                  "BookNode": "0",
+                  "Expiration": 792634503,
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "9119DF096827C8FEB825C34EC93402745AB639B1AA369114354C8E3A18FD2D32",
+                  "PreviousTxnLgrSeq": 94084530,
+                  "Sequence": 69213268,
+                  "TakerGets": {
+                    "currency": "ELS",
+                    "issuer": "rHXuEaRYnnJHbDeuBH5w8yPh5uwNVh5zAg",
+                    "value": "55555.38868149835"
+                  },
+                  "TakerPays": "50000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "B93A936D49B086DBFA0BB87F819ECE2B754A2A5BD3719E15BE7BFCADF9FCCBCC"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "E5C94F1371961189FB277B38B4FB0AA0423970BB4A3C7599571FF9782F98D4AD",
+                "NewFields": {
+                  "ExchangeRate": "571ff9782f98d4ad",
+                  "RootIndex": "E5C94F1371961189FB277B38B4FB0AA0423970BB4A3C7599571FF9782F98D4AD",
+                  "TakerGetsCurrency": "000000000000000000000000454C530000000000",
+                  "TakerGetsIssuer": "B55A1A058BEB283284811E4E9ACA8432194C59E5"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "571ff97a164fb286",
+                  "Flags": 0,
+                  "PreviousTxnID": "9119DF096827C8FEB825C34EC93402745AB639B1AA369114354C8E3A18FD2D32",
+                  "PreviousTxnLgrSeq": 94084530,
+                  "RootIndex": "E5C94F1371961189FB277B38B4FB0AA0423970BB4A3C7599571FF97A164FB286",
+                  "TakerGetsCurrency": "000000000000000000000000454C530000000000",
+                  "TakerGetsIssuer": "B55A1A058BEB283284811E4E9ACA8432194C59E5",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "E5C94F1371961189FB277B38B4FB0AA0423970BB4A3C7599571FF97A164FB286"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rELS4xDgjp8ZfR6MQGfPVhB5Pn42pvYJKW",
+                  "Balance": "92696500",
+                  "Flags": 0,
+                  "OwnerCount": 2,
+                  "Sequence": 69213270
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "FCB1B01FE0B36F433358D0A0F4328C871C9C8C3EC485C6B452FFDBDD04C3B9A0",
+                "PreviousFields": {
+                  "Balance": "92696520",
+                  "Sequence": 69213269
+                },
+                "PreviousTxnID": "9119DF096827C8FEB825C34EC93402745AB639B1AA369114354C8E3A18FD2D32",
+                "PreviousTxnLgrSeq": 94084530
+              }
+            }
+          ],
+          "TransactionIndex": 69,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r4ub6QN7LLScGjh7myqXpje4hfuk2Jrw1H",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 94084625,
+        "Sequence": 72967536,
+        "SigningPubKey": "ED6DC78BE40D14860C6535E47DD8D4048E40A8438549405C13F3524872FAEDA414",
+        "TakerGets": {
+          "currency": "XAH",
+          "issuer": "rswh1fvyLqHizBS2awu1vs6QcmwTBd9qiv",
+          "value": "324.221"
+        },
+        "TakerPays": "10000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "B77A12EC985011717E820E73DE4550690A2CA49CA746B5D56187BAFC72BBE99A24BC2B708E3F063D001A3AAA7BA8CC7C8A6DE36EE5987C76F75C7AE94D0C7A01",
+        "hash": "9E14A1D1076C6785CCB53A4155A5A25BDC27355F6F1BDE348BBC7CED42613A84",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "3D979FC6B9C0671BE19DC633803FEF5F3189668087082E10590AF52B4446ADED",
+                "NewFields": {
+                  "ExchangeRate": "590af52b4446aded",
+                  "RootIndex": "3D979FC6B9C0671BE19DC633803FEF5F3189668087082E10590AF52B4446ADED",
+                  "TakerGetsCurrency": "0000000000000000000000005841480000000000",
+                  "TakerGetsIssuer": "17A73888B98222E485D927BCDFD63FC3895AD2AE"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "r4ub6QN7LLScGjh7myqXpje4hfuk2Jrw1H",
+                  "RootIndex": "5DA0D19747B416190C0637B96023E73330D493E287C197E660B3ABFB919CCDC9"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "5DA0D19747B416190C0637B96023E73330D493E287C197E660B3ABFB919CCDC9",
+                "PreviousTxnID": "D6F5AE29ECF5AA0360192A641B92D648319A2B2E943447E1EFD0C5F5DC6668EC",
+                "PreviousTxnLgrSeq": 94084601
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "8C51D2811A4DEEB53B940B02874C0B190D38DDA68D4E4C4986B61EE5C42A2A2E",
+                "NewFields": {
+                  "Account": "r4ub6QN7LLScGjh7myqXpje4hfuk2Jrw1H",
+                  "BookDirectory": "3D979FC6B9C0671BE19DC633803FEF5F3189668087082E10590AF52B4446ADED",
+                  "Sequence": 72967536,
+                  "TakerGets": {
+                    "currency": "XAH",
+                    "issuer": "rswh1fvyLqHizBS2awu1vs6QcmwTBd9qiv",
+                    "value": "324.221"
+                  },
+                  "TakerPays": "10000000"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r4ub6QN7LLScGjh7myqXpje4hfuk2Jrw1H",
+                  "Balance": "103454578",
+                  "Flags": 0,
+                  "OwnerCount": 2,
+                  "Sequence": 72967537
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "97669D4E58964F796BEB1BBB5A46B8F8A45344167D7E844E8C48DEDEFC8DF50E",
+                "PreviousFields": {
+                  "Balance": "103454590",
+                  "OwnerCount": 1,
+                  "Sequence": 72967536
+                },
+                "PreviousTxnID": "D6F5AE29ECF5AA0360192A641B92D648319A2B2E943447E1EFD0C5F5DC6668EC",
+                "PreviousTxnLgrSeq": 94084601
+              }
+            }
+          ],
+          "TransactionIndex": 73,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+        "Expiration": 792720015,
+        "Fee": "10",
+        "Flags": 65536,
+        "LastLedgerSequence": 94084626,
+        "OfferSequence": 90961370,
+        "Sequence": 0,
+        "SigningPubKey": "ED4A8371720A1D404927F0B32DD49BDE4F8E2A8177D027482492AEE4F3C5045834",
+        "TakerGets": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "1907.18135"
+        },
+        "TakerPays": "789076180",
+        "TicketSequence": 90961377,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "8AC93CFA0D6B3D4CB247596FB729CDA1C71C5BE689BCC3B3B383AFFE30EAF6082B966B47682C46847A90A7B23FC363778DB75A9FA81F43CDE3E84248CEC83807",
+        "hash": "9ECD38CF03E1B9C7E2AF83E0CCDC24AC4AF197CCE821722F28C5FE047A1E9D61",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "1A710A9FD424E1725E8C073ADBF6E13265FE6B90FB23D453BDCBEF6A18CF026F",
+                "NewFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB2F057453E00",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "Sequence": 90961377,
+                  "TakerGets": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "1907.18116109291"
+                  },
+                  "TakerPays": "789076180"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "412",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "32D3BEA733A3C7B90A32A6A57DF912F7BE843090DD460A54255F8083E925C2ED",
+                "PreviousFields": {
+                  "IndexPrevious": "ae9"
+                },
+                "PreviousTxnID": "AF0DF94A96F5DCBF4DB325D900E72EEAC7FC11C6FA31FBC73E9CE27AE3CCF350",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "aea",
+                  "IndexPrevious": "412",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "PreviousTxnID": "AF0DF94A96F5DCBF4DB325D900E72EEAC7FC11C6FA31FBC73E9CE27AE3CCF350",
+                  "PreviousTxnLgrSeq": 94084608,
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "53E435E1C3E5EBBA12349B35AD36843988423C4C6E64C6D3E92F508C6CEC005D"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f08a3f46c6f10fb",
+                  "Flags": 0,
+                  "PreviousTxnID": "FEE4C0CCBFC7A0A86DE6F6E7E51D2D06C255FFFD5C8FC2DEAFF49427805A1627",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F08A3F46C6F10FB",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F08A3F46C6F10FB"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "aea",
+                  "IndexPrevious": "0",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "57103BFCB0CF9306E18A39838EBCF3329EB5BF2B2C1A0C829E19CB6E97D1B9CF",
+                "PreviousFields": {
+                  "IndexNext": "ae9"
+                },
+                "PreviousTxnID": "425F582A8F41173A5B0A28783464663B2FA093C3620FD1F6546A4629BEF93D47",
+                "PreviousTxnLgrSeq": 94084599
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Balance": "48203421429",
+                  "Flags": 0,
+                  "OwnerCount": 33,
+                  "Sequence": 90961404,
+                  "TicketCount": 19
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AB4F967F07A17B276A162D2BE831BB2B4BB7D28C58A71E2B47040114CE4599AE",
+                "PreviousFields": {
+                  "Balance": "48203421439",
+                  "OwnerCount": 34,
+                  "TicketCount": 20
+                },
+                "PreviousTxnID": "AF0DF94A96F5DCBF4DB325D900E72EEAC7FC11C6FA31FBC73E9CE27AE3CCF350",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F08A3F46C6F10FB",
+                  "BookNode": "0",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "FEE4C0CCBFC7A0A86DE6F6E7E51D2D06C255FFFD5C8FC2DEAFF49427805A1627",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "Sequence": 90961370,
+                  "TakerGets": "3944443449",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "9593.16258"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "AFB30414096F34EA7A7D46455494269D4C115636BE0EC2B80CBEB74880270A50"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB2F057453E00",
+                "NewFields": {
+                  "ExchangeRate": "5a0eb2f057453e00",
+                  "RootIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB2F057453E00",
+                  "TakerGetsCurrency": "524C555344000000000000000000000000000000",
+                  "TakerGetsIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Flags": 0,
+                  "OwnerNode": "ae9",
+                  "PreviousTxnID": "A6F924B090289827515733829A2C4CAF2DABEA5920F6F1B845515F9E243D1D9D",
+                  "PreviousTxnLgrSeq": 94084581,
+                  "TicketSequence": 90961377
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "FB5EDAB097EC09D7A4B322E2C99BD9A5F679886D8D2095D7685399602A39E177"
+              }
+            }
+          ],
+          "TransactionIndex": 23,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 30301441,
+        "Sequence": 30301445,
+        "SigningPubKey": "021C987881039AD42AEC336FB8460F1B1F4DDF0839CAF3EAB1AF69DDF8012C30A3",
+        "TakerGets": "10189405910",
+        "TakerPays": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "202666.2646096955"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100AB0D0941152C8E518557BFD1E8482A38850CF1A119B429F623A15949F5DAEC400220304E447F3976DF01BFE8B72E0A37506F513B9DD707A9DF506D4ED30BDAA2DB9B",
+        "hash": "A2D199D8DE44D77342BE5940FC36B5A2E50A706F0F9709F4324A119DE4FB6A85",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500712C56DFC5FEA",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "AC634E95B979374995FA52D59A83D568C9026EFBD9095FB2195A27B3B0ACB362",
+                  "PreviousTxnLgrSeq": 94084599,
+                  "Sequence": 30301441,
+                  "TakerGets": "12371383046",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "246309.7827588554"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "32563B7D525C4FCF44E48FF985C7E4CBA38CD82DF1F174BE94CE3199E488C8EE"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500710F9D2697AD1",
+                "NewFields": {
+                  "ExchangeRate": "500710f9d2697ad1",
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500710F9D2697AD1",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "500712c56dfc5fea",
+                  "Flags": 0,
+                  "PreviousTxnID": "AC634E95B979374995FA52D59A83D568C9026EFBD9095FB2195A27B3B0ACB362",
+                  "PreviousTxnLgrSeq": 94084599,
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500712C56DFC5FEA",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500712C56DFC5FEA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "Balance": "1000922652",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 30301446
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "7645DE0D353FF9ECB95EE6D8A5C51A666BBBA29860C30B45C529957871E586C1",
+                "PreviousFields": {
+                  "Balance": "1000922667",
+                  "Sequence": 30301445
+                },
+                "PreviousTxnID": "BD0872BB78B9F9A7A37B0510F53044F9137E9428E8CC90FAD4461AA644A642E4",
+                "PreviousTxnLgrSeq": 94084599
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "C148BF75768399490E4FA0A4210451EAA021F10FA57740F26CB0BE53850EB4CB",
+                "NewFields": {
+                  "Account": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500710F9D2697AD1",
+                  "Sequence": 30301445,
+                  "TakerGets": "10189405910",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "202666.2646096955"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rUTEn2jLLv4ESmrUqQmhZfEfDN3LorhgvZ",
+                  "RootIndex": "C1806EB01C8FA2A0E78311B4D24FBFD21003E89934435DB975F40610FE0D1FAC"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "C1806EB01C8FA2A0E78311B4D24FBFD21003E89934435DB975F40610FE0D1FAC",
+                "PreviousTxnID": "BD0872BB78B9F9A7A37B0510F53044F9137E9428E8CC90FAD4461AA644A642E4",
+                "PreviousTxnLgrSeq": 94084599
+              }
+            }
+          ],
+          "TransactionIndex": 40,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Amount": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "0.009704169982593124"
+        },
+        "DeliverMax": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "0.009704169982593124"
+        },
+        "Destination": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 94084609,
+        "SendMax": {
+          "currency": "5341564500000000000000000000000000000000",
+          "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+          "value": "0.0002985896345682035"
+        },
+        "Sequence": 29665815,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TransactionType": "Payment",
+        "TxnSignature": "E6C15D1583A5D958246AEC0C7F61D71F770523726E1D3D1D639707E0245CF617416DDA1381B1E65212478B0559EC3831A0434C84BE608B5649C74FFC66144F09",
+        "hash": "A602880FA0F31697D7454A2FFAC5981F5451027C83DDDEC2D5879D9F8B56E98E",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "374.5513114202406"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "0"
+                  },
+                  "HighNode": "627",
+                  "LowLimit": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "raFbBJ3AVG1vrKS9DiKotxZnMbKuHxuecb",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "551510FCF1F0FDF14360C2D530D9449DBC89CA80D0BD1B07D55F5CC030EFB9EE",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "374.5610155902232"
+                  }
+                },
+                "PreviousTxnID": "A4784B507419D46CE2FAD83EC4305BE86E9E6CD109AC07986E467F3E9F2A3A18",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000000021191451317"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+                    "value": "0"
+                  },
+                  "HighNode": "257",
+                  "LowLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "27"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "5F1CF805D1229FC7954D8E8D5B5CC87B90D02A82BFE8475E1A768AAC1E99775A",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0002836618851887548"
+                  }
+                },
+                "PreviousTxnID": "C6CCF1D66193D6ACA31590E5452927E415C4E7E635301DE5198D03415927EEF8",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.009704832179073668"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "0"
+                  },
+                  "HighNode": "3a7",
+                  "LowLimit": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "2a"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "A92E75B22F28DBE5B8DA92B6365E02506C19727082EAF5E32E321F569131D24B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000006621964805439"
+                  }
+                },
+                "PreviousTxnID": "C0AC5CB24DF0450AC4AFA437C9626782B3017F2E6B2A73903B69E8922C759B77",
+                "PreviousTxnLgrSeq": 94084605
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "A602880FA0F31697D7454A2FFAC5981F5451027C83DDDEC2D5879D9F8B56E98E",
+                  "Balance": "97189474",
+                  "Flags": 0,
+                  "OwnerCount": 404,
+                  "Sequence": 29665816
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "C6CCF1D66193D6ACA31590E5452927E415C4E7E635301DE5198D03415927EEF8",
+                  "Balance": "97189484",
+                  "Sequence": 29665815
+                },
+                "PreviousTxnID": "C6CCF1D66193D6ACA31590E5452927E415C4E7E635301DE5198D03415927EEF8",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "10.94791755289698"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+                    "value": "0"
+                  },
+                  "HighNode": "25a",
+                  "LowLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "raFbBJ3AVG1vrKS9DiKotxZnMbKuHxuecb",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F93714A9EE83A7D157B3B1DD40D2972139ACF334D8C297809695F467323C2F36",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "10.94763389313094"
+                  }
+                },
+                "PreviousTxnID": "A4784B507419D46CE2FAD83EC4305BE86E9E6CD109AC07986E467F3E9F2A3A18",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            }
+          ],
+          "TransactionIndex": 13,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "524C555344000000000000000000000000000000",
+            "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+            "value": "0.009704169982593124"
+          }
+        }
+      },
+      {
+        "Account": "rKU2yaZi8bzDAKjGDtw5KRmxiqm1oFWkWS",
+        "Fee": "12",
+        "Flags": 2228224,
+        "LastLedgerSequence": 94084626,
+        "LimitAmount": {
+          "currency": "5748590000000000000000000000000000000000",
+          "issuer": "rUikrq6kQdeuQAmowgRtazfi46qvQHzEBD",
+          "value": "0"
+        },
+        "Sequence": 92514129,
+        "SigningPubKey": "ED5E7E59D2D728B8DC1200F6BE56829F27EDDF92DB2D67D117738EA349DEAF7B09",
+        "TransactionType": "TrustSet",
+        "TxnSignature": "EB6101382EA2D3F46AD831A956BE853B152624F8447BAAA36330225AF5E8C23AC3899C41B9110315C7E442756CA35CB892FC75F89DC974AAA54B40E798E9E700",
+        "hash": "A63B38D8A47B8E267F3B9AD4024AA3D73EED00728EADBBCAA8054BDBF0C5D18F",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rKU2yaZi8bzDAKjGDtw5KRmxiqm1oFWkWS",
+                  "Balance": "29969841",
+                  "Flags": 0,
+                  "OwnerCount": 6,
+                  "Sequence": 92514130,
+                  "TicketCount": 6
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1C705E24543DF87C621F03F454F78A82E415FE9B59821100660303A715F693D3",
+                "PreviousFields": {
+                  "Balance": "29969853",
+                  "Sequence": 92514129
+                },
+                "PreviousTxnID": "90D9E0EA5C771E5D75CD68DE67E7FE7C81F369550E12D4FB62A5BAF9C2BE9771",
+                "PreviousTxnLgrSeq": 94080355
+              }
+            }
+          ],
+          "TransactionIndex": 81,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rDrvRfz24oqMZFoH8a45CE1qEo8U8m1EAX",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 94084621,
+        "OfferSequence": 88619462,
+        "Sequence": 0,
+        "SigningPubKey": "EDBCC48EBFB7A77F0318265D45D93F860C9295E28FF89A57C7FDE6D2501441E750",
+        "TakerGets": "2147660",
+        "TakerPays": {
+          "currency": "XQN",
+          "issuer": "rahuJ7WNoKBATKEDDhx5t3Tj3f2jGhbNjd",
+          "value": "148114.459543371"
+        },
+        "TicketSequence": 88619463,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "6B74B6446A1933C4C674764F98808D56B6BA8033CF5C9CD1C5AE81FAB2258B3BFF590B05BD4546A0785087288E0F3980BF751EF560A93FC08422FB1200D1AB06",
+        "hash": "A9DC504A4AD0F51BAA4233AAB40AAA0AB1ECCBC49740BFE1383F18337A2F852C",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rDrvRfz24oqMZFoH8a45CE1qEo8U8m1EAX",
+                  "Flags": 0,
+                  "OwnerNode": "9f6a",
+                  "PreviousTxnID": "E2C589482CFCB38CEF393F3FD4AC7060CFBB09B6F9F79CA3AD7B8DCD690AA56D",
+                  "PreviousTxnLgrSeq": 94084513,
+                  "TicketSequence": 88619463
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "0EECB664B614B4A46A4990FA563A007E38FC1E69C82F141959B06CAE48A84DFA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rDrvRfz24oqMZFoH8a45CE1qEo8U8m1EAX",
+                  "Balance": "861688492",
+                  "Flags": 0,
+                  "OwnerCount": 171,
+                  "Sequence": 88619466,
+                  "TicketCount": 13
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "5681BA06B7D08AD12A85CBCFD767A2E61D3D9BD590BBB5DDCBB35F22BAADA70F",
+                "PreviousFields": {
+                  "Balance": "861688504",
+                  "OwnerCount": 172,
+                  "TicketCount": 14
+                },
+                "PreviousTxnID": "FB8EAF3BA6D534D9CF5072ADA03DEA1512D1EB2DADD19F0308B765DF313F2A97",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "814D1175BBEBDDFA95DD76A3439D716FC17A983BF20D509CD2F62E764A398E41",
+                "NewFields": {
+                  "Account": "rDrvRfz24oqMZFoH8a45CE1qEo8U8m1EAX",
+                  "BookDirectory": "E9865B19CF8CC68B55AF3FE9BB6D883D9622C024915DFD185318806B8A500A15",
+                  "OwnerNode": "9f6a",
+                  "Sequence": 88619463,
+                  "TakerGets": "2147645",
+                  "TakerPays": {
+                    "currency": "XQN",
+                    "issuer": "rahuJ7WNoKBATKEDDhx5t3Tj3f2jGhbNjd",
+                    "value": "148114.459543371"
+                  }
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rDrvRfz24oqMZFoH8a45CE1qEo8U8m1EAX",
+                  "BookDirectory": "E9865B19CF8CC68B55AF3FE9BB6D883D9622C024915DFD185318806B8A500A15",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "9f6a",
+                  "PreviousTxnID": "4E7709B99AE33172137E754F9B3C83B295F98827DF04CA3ED06F5BE70590416A",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "Sequence": 88619462,
+                  "TakerGets": "2147645",
+                  "TakerPays": {
+                    "currency": "XQN",
+                    "issuer": "rahuJ7WNoKBATKEDDhx5t3Tj3f2jGhbNjd",
+                    "value": "148114.459543371"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "824C17869C739C8BA6700A9F884072C5457DF61EC0171C383D650BC39A081ADA"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "9f60",
+                  "Owner": "rDrvRfz24oqMZFoH8a45CE1qEo8U8m1EAX",
+                  "RootIndex": "803D7CD7108997F42FA4DF5C63A16BCA2FF1232D2879FF9F357BCFC04C2CFF4C"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B3A97CB20739AFA0535FABDC2B08CD14A2FF05E2518F744BE24368F35DC1AA12",
+                "PreviousTxnID": "FB8EAF3BA6D534D9CF5072ADA03DEA1512D1EB2DADD19F0308B765DF313F2A97",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5318806b8a500a15",
+                  "Flags": 0,
+                  "RootIndex": "E9865B19CF8CC68B55AF3FE9BB6D883D9622C024915DFD185318806B8A500A15",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "00000000000000000000000058514E0000000000",
+                  "TakerPaysIssuer": "37958924887BC1C5C48D9F27989AA12988C6096D"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "E9865B19CF8CC68B55AF3FE9BB6D883D9622C024915DFD185318806B8A500A15"
+              }
+            }
+          ],
+          "TransactionIndex": 65,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+        "Expiration": 792720015,
+        "Fee": "10",
+        "Flags": 65536,
+        "LastLedgerSequence": 94084626,
+        "OfferSequence": 90961355,
+        "Sequence": 0,
+        "SigningPubKey": "ED4A8371720A1D404927F0B32DD49BDE4F8E2A8177D027482492AEE4F3C5045834",
+        "TakerGets": "1972690450",
+        "TakerPays": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "4791.82292"
+        },
+        "TicketSequence": 90961372,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "AD77C54B52AD4F7D49AAEDFCD5B0FA5EB684133DC095570138311137E717F22F60015B284850B77A1084536601E62B6A4289DFABBF7330D9832EAAA72710400B",
+        "hash": "AF0DF94A96F5DCBF4DB325D900E72EEAC7FC11C6FA31FBC73E9CE27AE3CCF350",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "ae9",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "32D3BEA733A3C7B90A32A6A57DF912F7BE843090DD460A54255F8083E925C2ED",
+                "PreviousTxnID": "1782C1B4315FA0CBD0005C53A718A1B8ED005AEA008067A3269B048EC625CBDD",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089F8D85F26E8B",
+                  "BookNode": "0",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "FEDAED4D458D230A6641FF06ED9ED2DE3FB3765E19D21D4EA524E4EA1106C6B7",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "Sequence": 90961355,
+                  "TakerGets": "1183333038",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "2872.22145"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "419AA882C97C4F3A32880A2566EFA280E36F1788D40F4BB6B72D5E21E826B72A"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "aea",
+                  "IndexPrevious": "412",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "53E435E1C3E5EBBA12349B35AD36843988423C4C6E64C6D3E92F508C6CEC005D",
+                "PreviousTxnID": "1782C1B4315FA0CBD0005C53A718A1B8ED005AEA008067A3269B048EC625CBDD",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f089f8d85f26e8b",
+                  "Flags": 0,
+                  "PreviousTxnID": "FEDAED4D458D230A6641FF06ED9ED2DE3FB3765E19D21D4EA524E4EA1106C6B7",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089F8D85F26E8B",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F089F8D85F26E8B"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F08A13C7E1B0E27",
+                "NewFields": {
+                  "ExchangeRate": "4f08a13c7e1b0e27",
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F08A13C7E1B0E27",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Balance": "48203421439",
+                  "Flags": 0,
+                  "OwnerCount": 34,
+                  "Sequence": 90961404,
+                  "TicketCount": 20
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AB4F967F07A17B276A162D2BE831BB2B4BB7D28C58A71E2B47040114CE4599AE",
+                "PreviousFields": {
+                  "Balance": "48203421449",
+                  "OwnerCount": 35,
+                  "TicketCount": 21
+                },
+                "PreviousTxnID": "1782C1B4315FA0CBD0005C53A718A1B8ED005AEA008067A3269B048EC625CBDD",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "C675517E37485F04CAA08D09FDD566928FAC14072AE0CA458FA8521766474BA6",
+                "NewFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F08A13C7E1B0E27",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "Sequence": 90961372,
+                  "TakerGets": "1972689639",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "4791.82292"
+                  }
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Flags": 0,
+                  "OwnerNode": "ae9",
+                  "PreviousTxnID": "A6F924B090289827515733829A2C4CAF2DABEA5920F6F1B845515F9E243D1D9D",
+                  "PreviousTxnLgrSeq": 94084581,
+                  "TicketSequence": 90961372
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "D369DAD33544DF8E6E98B9D0C1CC6631BC343FF36C8FEF7BD0BD02262A948FFE"
+              }
+            }
+          ],
+          "TransactionIndex": 22,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+        "Fee": "20",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 167782386,
+        "Sequence": 167782397,
+        "SigningPubKey": "0253C1DFDCF898FE85F16B71CCE80A5739F7223D54CC9EBA4749616593470298C5",
+        "TakerGets": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "477908.2676"
+        },
+        "TakerPays": "200000000000",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100B3CE8B4E397D6D113917F109ECD2311F951030C78669FF39BFBF940297F6C295022051FB8B78CA695999A25C9F8B425C63D03BE3B00911D8C46BF63331A8BCB49FAD",
+        "hash": "AFBC4B1DEE866310A10586B8A1F2C3BB00044FB3D20111BD3488E3E5B3DA5F28",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "RootIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "0A2600D85F8309FE7F75A490C19613F1CE0C37483B856DB69B8140154C2335F3",
+                "PreviousTxnID": "7F95B207AEF1A05E5CE0814A865A067F540B425E26AD4650498B72311CF2ECE1",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "Balance": "15035590650",
+                  "Flags": 0,
+                  "OwnerCount": 17,
+                  "Sequence": 167782398
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "1ED8DDFD80F275CB1CE7F18BB9D906655DE8029805D8B95FB9020B30425821EB",
+                "PreviousFields": {
+                  "Balance": "15035590670",
+                  "Sequence": 167782397
+                },
+                "PreviousTxnID": "7F95B207AEF1A05E5CE0814A865A067F540B425E26AD4650498B72311CF2ECE1",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5a0ede258600e7dc",
+                  "Flags": 0,
+                  "PreviousTxnID": "1F2A5340F8E3DE7264852AB45FF128B7FD836A21A40EA9295DDE0C2CB3E321E3",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "RootIndex": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5A0EDE258600E7DC",
+                  "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+                  "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5A0EDE258600E7DC"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5A0EDE25C8CFD918",
+                "NewFields": {
+                  "ExchangeRate": "5a0ede25c8cfd918",
+                  "RootIndex": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5A0EDE25C8CFD918",
+                  "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+                  "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5A0EDE258600E7DC",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "1F2A5340F8E3DE7264852AB45FF128B7FD836A21A40EA9295DDE0C2CB3E321E3",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "Sequence": 167782386,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "477908.3956"
+                  },
+                  "TakerPays": "200000000000"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "721EB9FA3A4C5DEE5A0B9B237CC15C6DA6C23B63764764C4081F8F9EC67D3227"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "8616F1E46276A8A29C1A59E1555BDC0DDC3C3CECA58559CD4D39DE7042264FB5",
+                "NewFields": {
+                  "Account": "rBTwLga3i2gz3doX6Gva3MgEV8ZCD8jjah",
+                  "BookDirectory": "4627DFFCFF8B5A265EDBD8AE8C14A52325DBFEDAF4F5C32E5A0EDE25C8CFD918",
+                  "Sequence": 167782397,
+                  "TakerGets": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "477908.2676"
+                  },
+                  "TakerPays": "200000000000"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 35,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 144101819,
+        "Sequence": 144101823,
+        "SigningPubKey": "022D40673B44C82DEE1DDB8B9BB53DCCE4F97B27404DB850F068DD91D685E337EA",
+        "TakerGets": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "175880.080312247"
+        },
+        "TakerPays": "14167002716",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304402200B5764B7323F93788CF61F3FF44DA61BAF14738123ACF8D747DA24EEBBB1E725022052C480C11435893DFB338DC291DE2333268B91BF4257FA3E10A265837944719D",
+        "hash": "B144ED0857D28D46399688B036CF896E6DBF1EB5EE1CB750B4E64B39C5771580",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "591c99f8079989c7",
+                  "Flags": 0,
+                  "PreviousTxnID": "22D17DB049759921024643ACCE3E267B545B61888F8D3BD4334FD34541EB1D42",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591C99F8079989C7",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591C99F8079989C7"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591C9DE8994C7B12",
+                "NewFields": {
+                  "ExchangeRate": "591c9de8994c7b12",
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591C9DE8994C7B12",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591C99F8079989C7",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "22D17DB049759921024643ACCE3E267B545B61888F8D3BD4334FD34541EB1D42",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "Sequence": 144101819,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "34994.6523394669"
+                  },
+                  "TakerPays": "2817275949"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "58CC8A9D58CDEFC7E558E083B1D8CBD508E893A16EFAF927DFA37583C34F1935"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "RootIndex": "AEA3074F10FE15DAC592F8A0405C61FB7D4C98F588C2D55C84718FAFBBD2604A"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "AEA3074F10FE15DAC592F8A0405C61FB7D4C98F588C2D55C84718FAFBBD2604A",
+                "PreviousTxnID": "600406517AEF040B3234E374B6FD1559E7B9B96CC1947C5248E7C0124C9DD7A6",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "C9844901B27807FDCC1E98424DEB10F947104BA9098D9A405AEDAAF3B3BB371A",
+                "NewFields": {
+                  "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591C9DE8994C7B12",
+                  "Sequence": 144101823,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "175880.080312247"
+                  },
+                  "TakerPays": "14167002716"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "Balance": "100345322",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 144101824
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E0311EB450B6177F969B94DBDDA83E99B7A0576ACD9079573876F16C0C004F06",
+                "PreviousFields": {
+                  "Balance": "100345337",
+                  "Sequence": 144101823
+                },
+                "PreviousTxnID": "600406517AEF040B3234E374B6FD1559E7B9B96CC1947C5248E7C0124C9DD7A6",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            }
+          ],
+          "TransactionIndex": 2,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 143700482,
+        "Sequence": 143700484,
+        "SigningPubKey": "039451ECAC6D4EB75E3C926E7DC7BA7721719A1521502F99EC7EB2FE87CEE9E824",
+        "TakerGets": "12495760185",
+        "TakerPays": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "234340.1133430221"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304402200339EC464DA0FFFE333C665D8CA29588AAD3BEFC86E45838978FABB7285DF35B02200805FA5C7E4DB8392E9AF1E484814D42E6046FE58EFE57E602631DBA50C4440D",
+        "hash": "B41B4A1755A29B0303E9B8BAFF0222F8057C6B1417E9FA8F3CB88C65752DD1B9",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "RootIndex": "07CE63F6E62E095CAF97BC77572A203D75ECB68219F97505AC5DF2DB061C9D96"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "07CE63F6E62E095CAF97BC77572A203D75ECB68219F97505AC5DF2DB061C9D96",
+                "PreviousTxnID": "29C80692C5948BDB2B0BB15BC622F7F55E7B1D3C8BB9706514E4B0C93D94F80A",
+                "PreviousTxnLgrSeq": 94084606
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475008F5742508CA67",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "CC420A9ABF281E07FE7CB3E6EB4FA28CB6FB73F9F44EDEE23E4403C4FFA256D1",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "Sequence": 143700482,
+                  "TakerGets": "18745454168",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "472700.1812146666"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "085252F376D68D77F60E49299CD72D40CA0D39B3DD24289ED176E50ABD860E68"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "Balance": "1000571184",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 143700485
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "47FE64F9223D604034486F4DA7A175D5DA7F8A096952261CF8F3D77B74DC4AFA",
+                "PreviousFields": {
+                  "Balance": "1000571199",
+                  "Sequence": 143700484
+                },
+                "PreviousTxnID": "29C80692C5948BDB2B0BB15BC622F7F55E7B1D3C8BB9706514E4B0C93D94F80A",
+                "PreviousTxnLgrSeq": 94084606
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475006A9A093D1277A",
+                "NewFields": {
+                  "ExchangeRate": "5006a9a093d1277a",
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475006A9A093D1277A",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5008f5742508ca67",
+                  "Flags": 0,
+                  "PreviousTxnID": "CC420A9ABF281E07FE7CB3E6EB4FA28CB6FB73F9F44EDEE23E4403C4FFA256D1",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475008F5742508CA67",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475008F5742508CA67"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "8847405BE430A0CC44B50D5F08C46EDF37580EAC381E86A5A1CED80DE104CCE2",
+                "NewFields": {
+                  "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475006A9A093D1277A",
+                  "Sequence": 143700484,
+                  "TakerGets": "12495760185",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "234340.1133430221"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 75,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Amount": {
+          "currency": "5377697373546563680000000000000000000000",
+          "issuer": "raq7pGaYrLZRa88v6Py9V5oWMYEqPYr8Tz",
+          "value": "0.7398980323244749"
+        },
+        "DeliverMax": {
+          "currency": "5377697373546563680000000000000000000000",
+          "issuer": "raq7pGaYrLZRa88v6Py9V5oWMYEqPYr8Tz",
+          "value": "0.7398980323244749"
+        },
+        "Destination": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 94084609,
+        "SendMax": {
+          "currency": "OVO",
+          "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+          "value": "1046.540782035757"
+        },
+        "Sequence": 29665811,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TransactionType": "Payment",
+        "TxnSignature": "F122663ED4C18B2054914117A9BACE4F2D34B780A1E7617E20AA3B2F6832205853A5A5B9139C14DE17D97E76CDE47248BD90BA61B1AA4D762D412D62A55B6804",
+        "hash": "B4F866A6615F27437ED0D1B8423D254BC53F390363D16C402243EDCBE8BAF0A7",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-23969.39576384686"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "rEwHAKhGbEA7D3waJxJogEd3meB28BUxQQ",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "raq7pGaYrLZRa88v6Py9V5oWMYEqPYr8Tz",
+                    "value": "0"
+                  },
+                  "LowNode": "9e2"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "68B3AA9DFFCC287696289234F24293A8D24E45B1451FE1E5582EA5E42A713F92",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-23970.13566187918"
+                  }
+                },
+                "PreviousTxnID": "D8D3790D984DE63B306E0968631D3C991FBF007288362337B9837429BC3ECEF8",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "272271.6345399191"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "OVO",
+                    "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+                    "value": "0"
+                  },
+                  "HighNode": "33e",
+                  "LowLimit": {
+                    "currency": "OVO",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "CF7D03A277BB38033EE1039387650B3720EB33056781C1BE75B19A4FC6B999AD",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "273265.8465681891"
+                  }
+                },
+                "PreviousTxnID": "842C902D24727B066525EC681B562AFEFF28B6645C479A41A7748FC865A40B8A",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-32209029.01873399"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "OVO",
+                    "issuer": "rEwHAKhGbEA7D3waJxJogEd3meB28BUxQQ",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "OVO",
+                    "issuer": "r3jQzqfGVagsWNbSxMJpQV8VK7jHHmdv5j",
+                    "value": "0"
+                  },
+                  "LowNode": "346"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D7026D6DDEAF1FEF6E1D38A016474992EAFB7C777102F0B43D1FA14B96D9DD4C",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "OVO",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-32208034.80670572"
+                  }
+                },
+                "PreviousTxnID": "D8D3790D984DE63B306E0968631D3C991FBF007288362337B9837429BC3ECEF8",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "B4F866A6615F27437ED0D1B8423D254BC53F390363D16C402243EDCBE8BAF0A7",
+                  "Balance": "97189514",
+                  "Flags": 0,
+                  "OwnerCount": 404,
+                  "Sequence": 29665812
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "8AA7CCD01D404D192EB7CDD923B7DC54CFCAA0B3DAD406E7DBA09DA4476D3366",
+                  "Balance": "97189524",
+                  "Sequence": 29665811
+                },
+                "PreviousTxnID": "8AA7CCD01D404D192EB7CDD923B7DC54CFCAA0B3DAD406E7DBA09DA4476D3366",
+                "PreviousTxnLgrSeq": 94084605
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.7414391230515426"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "raq7pGaYrLZRa88v6Py9V5oWMYEqPYr8Tz",
+                    "value": "0"
+                  },
+                  "HighNode": "9d4",
+                  "LowLimit": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "EDFD482EE5A971AE673A8B5EB79405006DB3287A0B4B76C7888BAF899FF62FF7",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5377697373546563680000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0015410907270677"
+                  }
+                },
+                "PreviousTxnID": "DC5248296A413031ADBB0518E9827A136A19B157CAC7004862CE1802F3621417",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            }
+          ],
+          "TransactionIndex": 9,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "5377697373546563680000000000000000000000",
+            "issuer": "raq7pGaYrLZRa88v6Py9V5oWMYEqPYr8Tz",
+            "value": "0.7398980323244749"
+          }
+        }
+      },
+      {
+        "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+        "Expiration": 792720015,
+        "Fee": "10",
+        "Flags": 65536,
+        "LastLedgerSequence": 94084626,
+        "OfferSequence": 90961354,
+        "Sequence": 0,
+        "SigningPubKey": "ED4A8371720A1D404927F0B32DD49BDE4F8E2A8177D027482492AEE4F3C5045834",
+        "TakerGets": "3945380900",
+        "TakerPays": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "9593.19366"
+        },
+        "TicketSequence": 90961365,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "E395BC8E3E15ED75D90D9600C730AACBADEEF63EE114A59692EF8F91DD336A82E567655BE06B6D480DD5C14278D804CDAE00E20155446D3AB86093A172868D04",
+        "hash": "B6D1CDD6F4E841DCF81A641B66C3FAABE9A29831D5313461AE5BFD628757394E",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "ae9",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "32D3BEA733A3C7B90A32A6A57DF912F7BE843090DD460A54255F8083E925C2ED",
+                "PreviousTxnID": "41C32E3263D805CA78BD473900F08B59EA64CE8DA5FE2F86D98C29C37643D6F2",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EBD5E35BB6C00",
+                  "BookNode": "0",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "PreviousTxnID": "02B487B97577865E208C1ECC0BFFE01D70A292477D0D03F2F9DA1B0AB58051BF",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "Sequence": 90961354,
+                  "TakerGets": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "4753.645047726341"
+                  },
+                  "TakerPays": "1972221730"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "4F9FBCD1B40F30E74FA8A0C706F5F4CEFEA6F55C4CBA0A396D6A5F815892F0F3"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "aea",
+                  "IndexPrevious": "412",
+                  "Owner": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "RootIndex": "F6ED7E4F8D3EAE3D246D421803B101F4C204AA91046C647121563B6F7DFD9310"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "53E435E1C3E5EBBA12349B35AD36843988423C4C6E64C6D3E92F508C6CEC005D",
+                "PreviousTxnID": "41C32E3263D805CA78BD473900F08B59EA64CE8DA5FE2F86D98C29C37643D6F2",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F08A36FF160E419",
+                "NewFields": {
+                  "ExchangeRate": "4f08a36ff160e419",
+                  "RootIndex": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F08A36FF160E419",
+                  "TakerPaysCurrency": "524C555344000000000000000000000000000000",
+                  "TakerPaysIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Balance": "48203421459",
+                  "Flags": 0,
+                  "OwnerCount": 36,
+                  "Sequence": 90961404,
+                  "TicketCount": 22
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "AB4F967F07A17B276A162D2BE831BB2B4BB7D28C58A71E2B47040114CE4599AE",
+                "PreviousFields": {
+                  "Balance": "48203421469",
+                  "OwnerCount": 37,
+                  "TicketCount": 23
+                },
+                "PreviousTxnID": "41C32E3263D805CA78BD473900F08B59EA64CE8DA5FE2F86D98C29C37643D6F2",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5a0ebd5e35bb6c00",
+                  "Flags": 0,
+                  "PreviousTxnID": "02B487B97577865E208C1ECC0BFFE01D70A292477D0D03F2F9DA1B0AB58051BF",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "RootIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EBD5E35BB6C00",
+                  "TakerGetsCurrency": "524C555344000000000000000000000000000000",
+                  "TakerGetsIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EBD5E35BB6C00"
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "Flags": 0,
+                  "OwnerNode": "ae9",
+                  "PreviousTxnID": "A6F924B090289827515733829A2C4CAF2DABEA5920F6F1B845515F9E243D1D9D",
+                  "PreviousTxnLgrSeq": 94084581,
+                  "TicketSequence": 90961365
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "D3384A09A73FAC8F37658ACD33DB254EB22CDA4352FD226DC79B6B6B72F92775"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "D51D46912D5631316ECA8F8C85546546A9419442B9150E800E5F9BBB0297BB08",
+                "NewFields": {
+                  "Account": "rpiFwLYi6Gb1ESHYorn2QG1WU5vw2u4exQ",
+                  "BookDirectory": "54123B870896F4964184D7042DB75D78913D3E377BFC4ECA4F08A36FF160E419",
+                  "Expiration": 792720015,
+                  "Flags": 65536,
+                  "OwnerNode": "aea",
+                  "Sequence": 90961365,
+                  "TakerGets": "3945379278",
+                  "TakerPays": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "9593.19366"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 20,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rhubarbMVC2nzASf3qSGQcUKtLnAzqcBjp",
+        "Amount": {
+          "currency": "4C41574153000000000000000000000000000000",
+          "issuer": "rfAWYnEAkQGAhbESWAMdNccWJvdcrgugMC",
+          "value": "270324.4695317294"
+        },
+        "DeliverMax": {
+          "currency": "4C41574153000000000000000000000000000000",
+          "issuer": "rfAWYnEAkQGAhbESWAMdNccWJvdcrgugMC",
+          "value": "270324.4695317294"
+        },
+        "Destination": "rhubarbMVC2nzASf3qSGQcUKtLnAzqcBjp",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 94084609,
+        "SendMax": "86718",
+        "Sequence": 94793203,
+        "SigningPubKey": "ED9C7A917E06AE3550AEA072D25D3EAABDBB8D6AC1A1C0AF316866082D10145FF6",
+        "TransactionType": "Payment",
+        "TxnSignature": "AF66CD6A25E5A862B3CC73DABAD8F233C721BCC3C8031DA642992A1FC62F819E7DD046F76E6F80A916CA9221B7E5D4160D14F86CEE12CCE21508E407FE7FFE0C",
+        "hash": "B7F6C0B673059887974E71DD5C50FAA1AE1F6D3A3893B2DA4455F2F6CEA85FCD",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rhubarbMVC2nzASf3qSGQcUKtLnAzqcBjp",
+                  "Balance": "5611216635",
+                  "Flags": 0,
+                  "OwnerCount": 1237,
+                  "Sequence": 94793204
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "7A794B5256B0129A726B10E003DC3EF737C4FB00216A74A2560B0B544D702136",
+                "PreviousFields": {
+                  "Balance": "5611299025",
+                  "Sequence": 94793203
+                },
+                "PreviousTxnID": "DA8E94D41443A9C2FEB64FE20D327D090E09EC99E5E2FF55C986AE0EF6B955DE",
+                "PreviousTxnLgrSeq": 94084601
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "270324.4695317294"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rfAWYnEAkQGAhbESWAMdNccWJvdcrgugMC",
+                    "value": "0"
+                  },
+                  "HighNode": "13",
+                  "LowLimit": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rhubarbMVC2nzASf3qSGQcUKtLnAzqcBjp",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "a3"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "97EE65EC49FBD6A89E785DB49AEC04E11936B0017382C623F0B4266801C41F6C",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  }
+                },
+                "PreviousTxnID": "0F18A7377BEE81BFAB68131DB75C49C9ED3CC337973D4BE06660E82AC6071454",
+                "PreviousTxnLgrSeq": 94084555
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "A352BC92EBEDAB8EF7C02AB7D6E8A8AD0F1CE559459E49D158809F41CC0ED4CA",
+                  "Account": "rf4W6VgoWtJo8KVKMjJEUhT98whxWanXzh",
+                  "Balance": "134540035",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 93002742
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "BDB85A103C0FB55B8EB4E703C89D44DB4118A6B7B53A814852813C5BB28547FB",
+                "PreviousFields": {
+                  "Balance": "134457655"
+                },
+                "PreviousTxnID": "4BE7C3F6049FB7EAF32520C2778DFA49471AD9B6F613544433A32EE4543B8B86",
+                "PreviousTxnLgrSeq": 94084381
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "445671731.2875589"
+                  },
+                  "Flags": 16842752,
+                  "HighLimit": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rfAWYnEAkQGAhbESWAMdNccWJvdcrgugMC",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rf4W6VgoWtJo8KVKMjJEUhT98whxWanXzh",
+                    "value": "0"
+                  },
+                  "LowNode": "0"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "F11C7763D09A46869FA8EFD6FF73E5B5249FF36E5559F8C78976D61F8A8539FA",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "4C41574153000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "445942055.7570906"
+                  }
+                },
+                "PreviousTxnID": "4BE7C3F6049FB7EAF32520C2778DFA49471AD9B6F613544433A32EE4543B8B86",
+                "PreviousTxnLgrSeq": 94084381
+              }
+            }
+          ],
+          "TransactionIndex": 4,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "4C41574153000000000000000000000000000000",
+            "issuer": "rfAWYnEAkQGAhbESWAMdNccWJvdcrgugMC",
+            "value": "270324.4695317294"
+          }
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 123729227,
+        "Sequence": 123729333,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "3045022100CED5B789F3406D9679573B10B390F9598BE34B33D17D7ACC01ED416A5834446602204D231B8F3F54B429CCE4637F24B63224532A6CFFC627303EA9C6430249297D97",
+        "hash": "B83FC54EA93F2FCDDC1B982F784F63422D55FB6EE93258CAB077D473A49557C4",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624F088BCD43232B3E",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "19b13",
+                  "PreviousTxnID": "4B420B3D3E880D1D132EF7A05A0B498BF8539E1C02DBA13B21DA3F3BDF77CD69",
+                  "PreviousTxnLgrSeq": 94084574,
+                  "Sequence": 123729227,
+                  "TakerGets": "29365223570",
+                  "TakerPays": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "70638.44245112776"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "6C429E3A7545CCE0856D5583ADF226921ABB5A4AB4B22DB0002CC65BB24FD435"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "19b14",
+                  "IndexPrevious": "19b12",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "7487E15A9421AEC70D13D44C8BE43B46ACA11BD74638F4D8EEE22D71DE18CE83",
+                "PreviousTxnID": "D97E7B6B54197AF80758623D4C4A818D64E515D4961DB2814F9BCBECBC69B705",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "91960028975",
+                  "Flags": 0,
+                  "OwnerCount": 136,
+                  "Sequence": 123729334
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "91960028985",
+                  "OwnerCount": 137,
+                  "Sequence": 123729333
+                },
+                "PreviousTxnID": "D97E7B6B54197AF80758623D4C4A818D64E515D4961DB2814F9BCBECBC69B705",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f088bcd43232b3e",
+                  "Flags": 0,
+                  "PreviousTxnID": "4B420B3D3E880D1D132EF7A05A0B498BF8539E1C02DBA13B21DA3F3BDF77CD69",
+                  "PreviousTxnLgrSeq": 94084574,
+                  "RootIndex": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624F088BCD43232B3E",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000004555520000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624F088BCD43232B3E"
+              }
+            }
+          ],
+          "TransactionIndex": 50,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "7450534B685770486C633275716147467038494252",
+              "MemoType": "696E7465726E616C6F726465726964"
+            }
+          }
+        ],
+        "OfferSequence": 97505273,
+        "Sequence": 97505281,
+        "SigningPubKey": "034D6788B751D18BBE92CAF1255431512D6D187446D47FAEE20FDB0BFA8144DB1E",
+        "TakerGets": {
+          "currency": "524C555344000000000000000000000000000000",
+          "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+          "value": "9996.4912477595"
+        },
+        "TakerPays": "4136781550",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304502210087DF7A63C88E8FD841DE8B45258CFF076344A5850A2FF84BF6E4E2A8096456F70220306A1957357C5AE48EE64497F54FD5E9B9E800646D952AF8A336020E273D22C3",
+        "hash": "BBEFC10A4F627378921E0AB5D8F2205D1C74FDE4B8714EDABCF175B5C99DC127",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+                  "BookDirectory": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB19DCE1DF200",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "1",
+                  "PreviousTxnID": "ACCE0C697B59D1390490BFD99017D1C1D35FB8BEFFDD1599F3BF8AB15E75BDC2",
+                  "PreviousTxnLgrSeq": 94084607,
+                  "Sequence": 97505273,
+                  "TakerGets": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "9996.46293310277"
+                  },
+                  "TakerPays": "4134478090"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "385E7B214CE6F449151B303DAF38127B8D542D358DA905EE8A8BE306AEF44EE2"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "3B2759738A5C0E5EB5600C93EF43B2033616616F3E603F4EB95410C5BD6769A2",
+                "NewFields": {
+                  "Account": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+                  "BookDirectory": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB3B3AF914400",
+                  "OwnerNode": "1",
+                  "Sequence": 97505281,
+                  "TakerGets": {
+                    "currency": "524C555344000000000000000000000000000000",
+                    "issuer": "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De",
+                    "value": "9996.490169478092"
+                  },
+                  "TakerPays": "4136781550"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+                  "Balance": "60817108113",
+                  "Flags": 0,
+                  "OwnerCount": 34,
+                  "Sequence": 97505282
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "6BC9286C5146B76D0D140873B509D72581AABEB79037BF1D9849830FBF5A9FE6",
+                "PreviousFields": {
+                  "Balance": "60817108128",
+                  "Sequence": 97505281
+                },
+                "PreviousTxnID": "60E05E95317698F61A0737910912AED820EB0E49DF590A7FC878ABCE02547263",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5a0eb19dce1df200",
+                  "Flags": 0,
+                  "PreviousTxnID": "ACCE0C697B59D1390490BFD99017D1C1D35FB8BEFFDD1599F3BF8AB15E75BDC2",
+                  "PreviousTxnLgrSeq": 94084607,
+                  "RootIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB19DCE1DF200",
+                  "TakerGetsCurrency": "524C555344000000000000000000000000000000",
+                  "TakerGetsIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB19DCE1DF200"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB3B3AF914400",
+                "NewFields": {
+                  "ExchangeRate": "5a0eb3b3af914400",
+                  "RootIndex": "CFEC8953D22B1B50F20F46ECBCD51990A26BDB71951ED8265A0EB3B3AF914400",
+                  "TakerGetsCurrency": "524C555344000000000000000000000000000000",
+                  "TakerGetsIssuer": "E5E961C6A025C9404AA7B662DD1DF975BE75D13E"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rfmdBKhtJw2J22rw1JxQcchQTM68qzE4N2",
+                  "RootIndex": "49B537464A9659478275132402EB6D5E8723F42ED20DB3CF4A4527A9A3F1589A"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "E06052755A83D52A63C3392B87634326BE0E4E68ECB59B7DF3A2B1851229208D",
+                "PreviousTxnID": "60E05E95317698F61A0737910912AED820EB0E49DF590A7FC878ABCE02547263",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            }
+          ],
+          "TransactionIndex": 45,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rBB5X3CxT8LGbwKqUszz9bx1DMshqK2Z7g",
+        "Fee": "12",
+        "Flags": 2228224,
+        "LastLedgerSequence": 94084626,
+        "LimitAmount": {
+          "currency": "5748590000000000000000000000000000000000",
+          "issuer": "rUikrq6kQdeuQAmowgRtazfi46qvQHzEBD",
+          "value": "0"
+        },
+        "Sequence": 92796532,
+        "SigningPubKey": "EDF5F8831C5D41BC9F51E71499A16381B6C7E7BCCCE2B52F12489192904CE60C66",
+        "TransactionType": "TrustSet",
+        "TxnSignature": "1751679A4B73BD767DBC376DD6EB6E6E3E36688918E31992A9CEFD38864B160E8F4CE6CD9C31EB0DC56C2E70961FFDB0E154AAAF37E9C2D852FFA29F7F91CE0C",
+        "hash": "BDCDEAF11F3612816EF695496D670D965B61C5245D0DBBB265896A94B2D237F7",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rBB5X3CxT8LGbwKqUszz9bx1DMshqK2Z7g",
+                  "Balance": "29989867",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 92796533,
+                  "TicketCount": 5
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "8F39B8C6355F4E9DF1EDCD03013270D902DFB5E550D78092EAEC81F35F93C8CE",
+                "PreviousFields": {
+                  "Balance": "29989879",
+                  "Sequence": 92796532
+                },
+                "PreviousTxnID": "AC8DDDA3878D1CA18AF82EFD2B1E3C0E3C4E487C08FE6B90DB5F21C3D58AE0D9",
+                "PreviousTxnLgrSeq": 94080355
+              }
+            }
+          ],
+          "TransactionIndex": 33,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rQEGtFudk3FPi4CuSDdDyvqSgQjZeALySy",
+        "Fee": "12",
+        "Flags": 2228224,
+        "LastLedgerSequence": 94084626,
+        "LimitAmount": {
+          "currency": "5748590000000000000000000000000000000000",
+          "issuer": "rUikrq6kQdeuQAmowgRtazfi46qvQHzEBD",
+          "value": "0"
+        },
+        "Sequence": 92796241,
+        "SigningPubKey": "EDA8C92DC4159A7CBC2DB590C690DEED3E7103BEEF73201391AFF4E7DA3946AF70",
+        "TransactionType": "TrustSet",
+        "TxnSignature": "B27B18AE82E7BE59CB0A1D782CC980DBEFFBE5FA4B9F3CC344677A33E0F7F91AEB0C888EC6C7B93CD921A3E81204867B4883C8CB396BDB0F3CBA3F9B497F380F",
+        "hash": "BFDCBE69E62B19CCCCF9762354BDD65465222F4E2723F8E15DF62763FDE4624F",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rQEGtFudk3FPi4CuSDdDyvqSgQjZeALySy",
+                  "Balance": "29692527",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 92796242,
+                  "TicketCount": 5
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "46D0961B6A6C965D6A825C17348660DBA43D058F0FC600C35094DEC6C1519845",
+                "PreviousFields": {
+                  "Balance": "29692539",
+                  "Sequence": 92796241
+                },
+                "PreviousTxnID": "171CFD345FCD799E629B2CB4E7FE7868DF718E5F925DF15B4E7663A4BB6C91C3",
+                "PreviousTxnLgrSeq": 94080355
+              }
+            }
+          ],
+          "TransactionIndex": 79,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rsciveSyY95Vn9ba1nSGiBcTdhQdZWkrBv",
+        "Fee": "12",
+        "Flags": 2228224,
+        "LastLedgerSequence": 94084626,
+        "LimitAmount": {
+          "currency": "5748590000000000000000000000000000000000",
+          "issuer": "rUikrq6kQdeuQAmowgRtazfi46qvQHzEBD",
+          "value": "0"
+        },
+        "Sequence": 92794453,
+        "SigningPubKey": "EDB5373B48D053FC87BCBB677B3B9D1984EE804C7251551F98712D367BFB8F6C8A",
+        "TransactionType": "TrustSet",
+        "TxnSignature": "906BF6C042AFE9A6C43A7CE80A464C76F168510CB9D2E4077539CDD129EF1A3C240D50F3916A099B1798430FBD534646B328F158E30B699059CC76178025400B",
+        "hash": "BFE0B3D5EDB8A7E3A41F203EA06A93558B0375D21F59FFF5D9C321C1ABB8D486",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rsciveSyY95Vn9ba1nSGiBcTdhQdZWkrBv",
+                  "Balance": "29682734",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 92794454,
+                  "TicketCount": 5
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "3885EAEAAE48A3E0C0BE1260872CD0C02E719A7D546D2C393D334305A13993FC",
+                "PreviousFields": {
+                  "Balance": "29682746",
+                  "Sequence": 92794453
+                },
+                "PreviousTxnID": "B7E1CC08EC15F1364901C6AB3246F53911A60B65E697721301EF772B76A000DA",
+                "PreviousTxnLgrSeq": 94080355
+              }
+            }
+          ],
+          "TransactionIndex": 28,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Amount": {
+          "currency": "5341564500000000000000000000000000000000",
+          "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+          "value": "0.0002836601528397933"
+        },
+        "DeliverMax": {
+          "currency": "5341564500000000000000000000000000000000",
+          "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+          "value": "0.0002836601528397933"
+        },
+        "Destination": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 94084609,
+        "SendMax": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.01022059659998695"
+        },
+        "Sequence": 29665814,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TransactionType": "Payment",
+        "TxnSignature": "377DD518A9FC3A677DFEE534D6EC650F8B6D2CE35DC7F96FFA8E1A48CECE02978C01077A9E5F85F8CC9E0645F0E4DF91D3A6B1B5C7FC707D65AB7B014EC1460A",
+        "hash": "C6CCF1D66193D6ACA31590E5452927E415C4E7E635301DE5198D03415927EEF8",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0002836618851887548"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+                    "value": "0"
+                  },
+                  "HighNode": "257",
+                  "LowLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "27"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "5F1CF805D1229FC7954D8E8D5B5CC87B90D02A82BFE8475E1A768AAC1E99775A",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.0000000017323489615"
+                  }
+                },
+                "PreviousTxnID": "A4784B507419D46CE2FAD83EC4305BE86E9E6CD109AC07986E467F3E9F2A3A18",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-2.582410001205142"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "r3o25dZscweKkkh1WxjXLZ1yUW4itQ5E6r",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+                    "value": "0"
+                  },
+                  "LowNode": "254"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "BD923737FA1FA0BCC2C07C6A72681C675E1A5054BA22875105619B5EEAE82295",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "5341564500000000000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-2.582693661357982"
+                  }
+                },
+                "PreviousTxnID": "542A160F911E55FD6D59376A85FC69B2AA4495F7A6C863F94383A3D7005304D2",
+                "PreviousTxnLgrSeq": 94084545
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000001749818101029"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "HighNode": "bfa",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "CE8BC6520C7A30953A4AC6733394E6924DAA4C3CB16CFB9EAC02EA7494417D59",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.009711236922062219"
+                  }
+                },
+                "PreviousTxnID": "DADC4E8966CB4A1023558E74EF0C15BC886903795B06459D84507002574A0216",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-88.00659159830168"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "r3o25dZscweKkkh1WxjXLZ1yUW4itQ5E6r",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "be6"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "D76538A732D9E3D87753D16FF280F7836AF5B796D263A9D038705BA95E6A8BF8",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-87.99689665361475"
+                  }
+                },
+                "PreviousTxnID": "542A160F911E55FD6D59376A85FC69B2AA4495F7A6C863F94383A3D7005304D2",
+                "PreviousTxnLgrSeq": 94084545
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "C6CCF1D66193D6ACA31590E5452927E415C4E7E635301DE5198D03415927EEF8",
+                  "Balance": "97189484",
+                  "Flags": 0,
+                  "OwnerCount": 404,
+                  "Sequence": 29665815
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "DADC4E8966CB4A1023558E74EF0C15BC886903795B06459D84507002574A0216",
+                  "Balance": "97189494",
+                  "Sequence": 29665814
+                },
+                "PreviousTxnID": "DADC4E8966CB4A1023558E74EF0C15BC886903795B06459D84507002574A0216",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            }
+          ],
+          "TransactionIndex": 12,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "5341564500000000000000000000000000000000",
+            "issuer": "rfAJaM2jr8frHwcXY52gLeqDEUmAFmzqFT",
+            "value": "0.0002836601528397933"
+          }
+        }
+      },
+      {
+        "Account": "rhubarbMVC2nzASf3qSGQcUKtLnAzqcBjp",
+        "Amount": "120120",
+        "DeliverMax": "120120",
+        "Destination": "rhubarbMVC2nzASf3qSGQcUKtLnAzqcBjp",
+        "Fee": "10",
+        "Flags": 131072,
+        "LastLedgerSequence": 94084609,
+        "SendMax": {
+          "currency": "58525061794E6574000000000000000000000000",
+          "issuer": "r9rRLst96Ue4YTDQkWWkX1ePB6p6Ye4FkA",
+          "value": "2445.972331050167"
+        },
+        "Sequence": 94793205,
+        "SigningPubKey": "ED9C7A917E06AE3550AEA072D25D3EAABDBB8D6AC1A1C0AF316866082D10145FF6",
+        "TransactionType": "Payment",
+        "TxnSignature": "8507AB126DAF12E275B9EEED9969CF53FA846298055432954E554386A2D70909DD1CDFB48BD729E8B1996EF690C6BE7B45CCF1DA903BDBADB5912E9DF9FA0804",
+        "hash": "C712C85CB03443D87FB3D6892620F895B298E91A6FFE706B2B323B71CD73B340",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-44878963.17464885"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "rNiL5mNNoMMQJrFJH9Ku9YePUZDXMci2VM",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "r9rRLst96Ue4YTDQkWWkX1ePB6p6Ye4FkA",
+                    "value": "0"
+                  },
+                  "LowNode": "311"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "1FF5CD8341A3AEE851417398E6E4834B7DDA1B23035405B66810965DC0094C0E",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-44877348.56538383"
+                  }
+                },
+                "PreviousTxnID": "48C4D986E46EC5E23865917460D0B39A5BEC14D90AD2269CFE6C255B789D9834",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rhubarbMVC2nzASf3qSGQcUKtLnAzqcBjp",
+                  "Balance": "5611300080",
+                  "Flags": 0,
+                  "OwnerCount": 1237,
+                  "Sequence": 94793206
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "7A794B5256B0129A726B10E003DC3EF737C4FB00216A74A2560B0B544D702136",
+                "PreviousFields": {
+                  "Balance": "5611216625",
+                  "Sequence": 94793205
+                },
+                "PreviousTxnID": "7D3D5A6EABDE581B58CEC2CD03354BB4C0CCF37DDEABFBEE130F6CBC78BEE2C2",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "r9rRLst96Ue4YTDQkWWkX1ePB6p6Ye4FkA",
+                    "value": "0"
+                  },
+                  "HighNode": "336",
+                  "LowLimit": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "rhubarbMVC2nzASf3qSGQcUKtLnAzqcBjp",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "95"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "BDDB87931825E4185EA1FD9EAF134270EBC1F74BBDFA967F67C511B5FC8034F4",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "58525061794E6574000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "1614.6092650151"
+                  }
+                },
+                "PreviousTxnID": "7D3D5A6EABDE581B58CEC2CD03354BB4C0CCF37DDEABFBEE130F6CBC78BEE2C2",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "BC5D2834CE4875A98BE1FD9F3EDBE9EB5B81481CB064E8FF333DFADE1371664E",
+                  "Account": "rNiL5mNNoMMQJrFJH9Ku9YePUZDXMci2VM",
+                  "Balance": "2342732937",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 86796106
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "CA0D6B4B8399F382BC16C74362E685717A6A0601FCBC2EAAFD9475680DBFFF99",
+                "PreviousFields": {
+                  "Balance": "2342816402"
+                },
+                "PreviousTxnID": "48C4D986E46EC5E23865917460D0B39A5BEC14D90AD2269CFE6C255B789D9834",
+                "PreviousTxnLgrSeq": 94084597
+              }
+            }
+          ],
+          "DeliveredAmount": "83465",
+          "TransactionIndex": 6,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "83465"
+        }
+      },
+      {
+        "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 143700480,
+        "Sequence": 143700486,
+        "SigningPubKey": "039451ECAC6D4EB75E3C926E7DC7BA7721719A1521502F99EC7EB2FE87CEE9E824",
+        "TakerGets": "2998720770",
+        "TakerPays": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "75577.50924815325"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100F77C7DA67DC8864CC2D383898F3E83689BAF816621072C6701441EA6C5490A240220402B6A5781A42573CC327F36C96AADBF3C4CC603EDC3884ABFFD25F05AFA7A32",
+        "hash": "CD5F359A7BB3BA488F8742EC99D8918A60C2E1976954BBC6889F96F8B4CE8CBC",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "RootIndex": "07CE63F6E62E095CAF97BC77572A203D75ECB68219F97505AC5DF2DB061C9D96"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "07CE63F6E62E095CAF97BC77572A203D75ECB68219F97505AC5DF2DB061C9D96",
+                "PreviousTxnID": "92631532977C634CA40221035BAA3E4FFDE6EB2B3B229AE36DE7465600ABDF0E",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475006AA8B454E412A",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "22C661D131720C292108308DE522BCEE19BB067DF86EDE574FC319E9DB28CE1B",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "Sequence": 143700480,
+                  "TakerGets": "6209023302",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "116503.9400927664"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "3F44E10C852583F23DF58A445F93D8100F58274AF9BA10F087C37F060A03E9CD"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "Balance": "1000571154",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 143700487
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "47FE64F9223D604034486F4DA7A175D5DA7F8A096952261CF8F3D77B74DC4AFA",
+                "PreviousFields": {
+                  "Balance": "1000571169",
+                  "Sequence": 143700486
+                },
+                "PreviousTxnID": "92631532977C634CA40221035BAA3E4FFDE6EB2B3B229AE36DE7465600ABDF0E",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "5D662638B65DA1B17579962C131AC80754E006BA72326D93CEE01A86335210A8",
+                "NewFields": {
+                  "Account": "rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475008F438E458C909",
+                  "Sequence": 143700486,
+                  "TakerGets": "2998720770",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "75577.50924815325"
+                  }
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5006aa8b454e412a",
+                  "Flags": 0,
+                  "PreviousTxnID": "22C661D131720C292108308DE522BCEE19BB067DF86EDE574FC319E9DB28CE1B",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475006AA8B454E412A",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475006AA8B454E412A"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475008F438E458C909",
+                "NewFields": {
+                  "ExchangeRate": "5008f438e458c909",
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475008F438E458C909",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 77,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 123729274,
+        "Sequence": 123729330,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "3045022100EE6AB28827BEEE365EA4F511D8637F4CC08748328711FAB74108C874ABDB78BD0220140555EDA88DC1EDFDB1DE53A6C885712735D868217CF21BF7E6C90EBDD6A363",
+        "hash": "D3CAD77DA369288D6E9F3D828977F1B8BCDD59C622892D7D77E1C64D3008A947",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "CEA664F2B7C3F3A31B6DE8E3F179E3AE5E2C471FCD6039E7570494A95AC3AE00",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "19b14",
+                  "PreviousTxnID": "18CB4A6DC8D64CF6A5E7E32AC992F628CBC0C1E694B184416D49F172CCE22FF8",
+                  "PreviousTxnLgrSeq": 94084588,
+                  "Sequence": 123729274,
+                  "TakerGets": {
+                    "currency": "LTC",
+                    "issuer": "rcRzGWq6Ng3jeYhqnmM4zcWcUh69hrQ8V",
+                    "value": "19.2650587000909"
+                  },
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "2483.94997602557"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "495EB181702D5485E87F7E9B651EF5BB90BC8D870807B0011AEF4B10A6A22CFB"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "91960029005",
+                  "Flags": 0,
+                  "OwnerCount": 139,
+                  "Sequence": 123729331
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "91960029015",
+                  "OwnerCount": 140,
+                  "Sequence": 123729330
+                },
+                "PreviousTxnID": "8875B2DBC3122739C9084140C33525B198E6FED0B2DC63CB8623485AC056D6A1",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "570494a95ac3ae00",
+                  "Flags": 0,
+                  "RootIndex": "CEA664F2B7C3F3A31B6DE8E3F179E3AE5E2C471FCD6039E7570494A95AC3AE00",
+                  "TakerGetsCurrency": "0000000000000000000000004C54430000000000",
+                  "TakerGetsIssuer": "06B36AC50AC7331069070C6350B202EAF2125C7C",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CEA664F2B7C3F3A31B6DE8E3F179E3AE5E2C471FCD6039E7570494A95AC3AE00",
+                "PreviousTxnID": "BF6F729EE2D6C941EB84ADE4E14C0E0A2631CD2568AD83A426F087975CDB37FE",
+                "PreviousTxnLgrSeq": 94084588
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "19b15",
+                  "IndexPrevious": "19b13",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "DF3339FE796ED3E629118B760BB5CDB86E3D496F8FCDAC784A7AEA7B40C68BEA",
+                "PreviousTxnID": "8811AC23838EF6BB3216574569DB0127F8F87580B4C4330969900196FF1A2A3F",
+                "PreviousTxnLgrSeq": 94084599
+              }
+            }
+          ],
+          "TransactionIndex": 47,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rHrsM2gD2EqiziogUgDT4DunwjwJLxi3ZZ",
+        "Amount": "90000",
+        "DeliverMax": "90000",
+        "Destination": "ryouhapPYV5KNHmFUKrjNqsjxhnxvQiVt",
+        "Fee": "12",
+        "InvoiceID": "4D0ECFCDD6CAFC206878C65CF487544AC90AE7B5462B9448E96A4D24624AFE54",
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "58616D616E205365727669636520466565"
+            }
+          }
+        ],
+        "Sequence": 91258094,
+        "SigningPubKey": "037581370D8E98ABBEBB7BC7BA036712EFCB0A3D9ABF291C8BA43154DFF0FEE6E2",
+        "TransactionType": "Payment",
+        "TxnSignature": "3045022100B623AD106B374824867B42065292388D49C64029E641001498B2D1BCCB17121002202411655B396E1CD9A94A6F047D8A13EDCAAE0596939F7EBC4D182A65A90F7BC2",
+        "hash": "D826B845D98ADCF10EC411CD59415B83D674C2DE6AFDD9CEB086BCBD5C924F38",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rHrsM2gD2EqiziogUgDT4DunwjwJLxi3ZZ",
+                  "Balance": "7680156",
+                  "Flags": 0,
+                  "OwnerCount": 10,
+                  "Sequence": 91258095
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "101D1333DD46D0AB177FB7B1EDE3911485A83A9C136F420F19D1B1F242256332",
+                "PreviousFields": {
+                  "Balance": "7770168",
+                  "Sequence": 91258094
+                },
+                "PreviousTxnID": "4D0ECFCDD6CAFC206878C65CF487544AC90AE7B5462B9448E96A4D24624AFE54",
+                "PreviousTxnLgrSeq": 94084606
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "ryouhapPYV5KNHmFUKrjNqsjxhnxvQiVt",
+                  "Balance": "2809043054",
+                  "EmailHash": "5B0F31F3678A837376CD437DAA2FCC77",
+                  "Flags": 1048576,
+                  "OwnerCount": 167,
+                  "RegularKey": "r33MBTjz1hzaZSsyvRwHRmaMn9S5xpp9w6",
+                  "Sequence": 80608752,
+                  "TicketCount": 167
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "9185B96A67C38FC7BBA39BC44BB6CC9C19DBAE20778A2E3BBB0EBB60BE5F7E0E",
+                "PreviousFields": {
+                  "Balance": "2808953054"
+                },
+                "PreviousTxnID": "C99F1C3C91BC4AB5C73F16B4A6578B783FA3DD45CE0E2484E770C01EC00F4540",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            }
+          ],
+          "TransactionIndex": 61,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "90000"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 123729226,
+        "Sequence": 123729332,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TransactionType": "OfferCancel",
+        "TxnSignature": "304402202FD0C40492F27F5D19C6DA8C6884F0A713EC36CB5ED94E4D908E082A22BC4EC80220719C52E161E01EA64CB1C1C2A443EF8B3306470128E6ED4EEE3B142447AA0FF5",
+        "hash": "D97E7B6B54197AF80758623D4C4A818D64E515D4961DB2814F9BCBECBC69B705",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "19b14",
+                  "IndexPrevious": "19b12",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "7487E15A9421AEC70D13D44C8BE43B46ACA11BD74638F4D8EEE22D71DE18CE83",
+                "PreviousTxnID": "CE309BF9153A0DF26471243A0299D1C0A6BB2213AF81038471D2BB86FAC3C600",
+                "PreviousTxnLgrSeq": 94084600
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624F088BCD432421BA",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "19b13",
+                  "PreviousTxnID": "7034239EDFE2139FC9225059B0AF7A2E6B47BC2877DB98BE65177741A576A2E6",
+                  "PreviousTxnLgrSeq": 94084574,
+                  "Sequence": 123729226,
+                  "TakerGets": "20892417445",
+                  "TakerPays": {
+                    "currency": "EUR",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "50256.99272727461"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "A3ED2233C6A005C6D4450FD897B1A67F4990775FC28E7E38603E7EE757A74EE4"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "91960028985",
+                  "Flags": 0,
+                  "OwnerCount": 137,
+                  "Sequence": 123729333
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "91960028995",
+                  "OwnerCount": 138,
+                  "Sequence": 123729332
+                },
+                "PreviousTxnID": "86EBE66B7D01F69A5B34C79DEC0F7B8621D4F485FB891E424F4CF4DBC6F2D11E",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "4f088bcd432421ba",
+                  "Flags": 0,
+                  "PreviousTxnID": "7034239EDFE2139FC9225059B0AF7A2E6B47BC2877DB98BE65177741A576A2E6",
+                  "PreviousTxnLgrSeq": 94084574,
+                  "RootIndex": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624F088BCD432421BA",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "0000000000000000000000004555520000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624F088BCD432421BA"
+              }
+            }
+          ],
+          "TransactionIndex": 49,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+        "Fee": "10",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "Sequence": 123729335,
+        "SigningPubKey": "03C48299E57F5AE7C2BE1391B581D313F1967EA2301628C07AC412092FDC15BA22",
+        "TakerGets": {
+          "currency": "LTC",
+          "issuer": "rcRzGWq6Ng3jeYhqnmM4zcWcUh69hrQ8V",
+          "value": "27.06422102607383"
+        },
+        "TakerPays": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "3489.538870107342"
+        },
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "304402207539F928F59E78ED67B5A900BDE6F704B56BAEC76BAF1EF1D5F195184F9FFC7702202CC39002DDD4B990D2EE7EE8B7942E30BD88B8AF31F3202CBCC83253B50EA5F7",
+        "hash": "D9B2B0AEA084E8C1DBA6024BFDF9B77AB1F701ED45F1B746F7E8E6F0AA3E0471",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "506F0910A803628DAEF1DD559E936AC9B5D009B27EE7FD66D2013E517C95EAAF",
+                "NewFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "BookDirectory": "CEA664F2B7C3F3A31B6DE8E3F179E3AE5E2C471FCD6039E7570494A95AC3AE00",
+                  "OwnerNode": "19b15",
+                  "Sequence": 123729335,
+                  "TakerGets": {
+                    "currency": "LTC",
+                    "issuer": "rcRzGWq6Ng3jeYhqnmM4zcWcUh69hrQ8V",
+                    "value": "27.06422102607383"
+                  },
+                  "TakerPays": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "3489.538870107342"
+                  }
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "19b14",
+                  "Owner": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "RootIndex": "FDE0DCA95589B07340A7D5BE2FD72AA8EEAC878664CC9B707308B4419333E551"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "9DBB7ADE16C6B4D763193B6D41161ACF6E93F22C6F4401FFC89B89ADCC378328",
+                "PreviousTxnID": "7C921B51A7FDB340DEEA210162FAD24366FC869904EB42CED6E9D6E682F6A309",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "r3rhWeE31Jt5sWmi4QiGLMZnY3ENgqw96W",
+                  "Balance": "91960028955",
+                  "Flags": 0,
+                  "OwnerCount": 138,
+                  "Sequence": 123729336
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B1B9AAC12B56B1CFC93DDC8AF6958B50E89509F377ED4825A3D970F249892CE3",
+                "PreviousFields": {
+                  "Balance": "91960028965",
+                  "OwnerCount": 137,
+                  "Sequence": 123729335
+                },
+                "PreviousTxnID": "7C921B51A7FDB340DEEA210162FAD24366FC869904EB42CED6E9D6E682F6A309",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "570494a95ac3ae00",
+                  "Flags": 0,
+                  "RootIndex": "CEA664F2B7C3F3A31B6DE8E3F179E3AE5E2C471FCD6039E7570494A95AC3AE00",
+                  "TakerGetsCurrency": "0000000000000000000000004C54430000000000",
+                  "TakerGetsIssuer": "06B36AC50AC7331069070C6350B202EAF2125C7C",
+                  "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+                  "TakerPaysIssuer": "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "CEA664F2B7C3F3A31B6DE8E3F179E3AE5E2C471FCD6039E7570494A95AC3AE00",
+                "PreviousTxnID": "7C921B51A7FDB340DEEA210162FAD24366FC869904EB42CED6E9D6E682F6A309",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            }
+          ],
+          "TransactionIndex": 52,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Amount": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.01022059659998695"
+        },
+        "DeliverMax": {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "value": "0.01022059659998695"
+        },
+        "Destination": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+        "Fee": "10",
+        "Flags": 196608,
+        "LastLedgerSequence": 94084609,
+        "Paths": [
+          [
+            {
+              "account": "rB8KKJ16JAuhT4ZmBsai1zNpq6DP6Yrrmh",
+              "type": 1
+            }
+          ]
+        ],
+        "SendMax": {
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "value": "0.01025652520778983"
+        },
+        "Sequence": 29665813,
+        "SigningPubKey": "ED3DC1A8262390DBA0E9926050A7BE377DFCC7937CC94C5F5F24E6BD97D677BA6C",
+        "TransactionType": "Payment",
+        "TxnSignature": "B5EC3604526B0294573ECEB22732C94C4710581EC330A57B8EF680202634AB9CF5A906EA32A273FFD994C28E96C62FADEB80A45C476B07063DA6C3D6BFD48807",
+        "hash": "DADC4E8966CB4A1023558E74EF0C15BC886903795B06459D84507002574A0216",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-358.2743625685351"
+                  },
+                  "Flags": 131072,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rB8KKJ16JAuhT4ZmBsai1zNpq6DP6Yrrmh",
+                    "value": "1000000000"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "LowNode": "312"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "0E143A3E899812A04E169062D5E9F982575A56CB2193F9F11C5B50646041C8C8",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-358.2840868189816"
+                  }
+                },
+                "PreviousTxnID": "5DDFB6E819730F37B7B1CD7101BA5D76ACC4166EDFF9D45AA6AD6A8251277FE5",
+                "PreviousTxnLgrSeq": 94084545
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "0"
+                  },
+                  "HighNode": "237c",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "197E542413061266DC6995ADD18728149974484D717A415649AE12E89E297DA5",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.009743698947400346"
+                  }
+                },
+                "PreviousTxnID": "88D2EFCC697A12E2E40B7494897953BC58ECB7F293381437C0B07983B1877075",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-538.0489594183084"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rB8KKJ16JAuhT4ZmBsai1zNpq6DP6Yrrmh",
+                    "value": "1000000000"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value": "0"
+                  },
+                  "LowNode": "ad7"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "6984330E24A19B262652E03718CCF311E06F3B12882CC13D9C9F06E3ABD6D490",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-538.0392351678619"
+                  }
+                },
+                "PreviousTxnID": "5DDFB6E819730F37B7B1CD7101BA5D76ACC4166EDFF9D45AA6AD6A8251277FE5",
+                "PreviousTxnLgrSeq": 94084545
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.009711236922062219"
+                  },
+                  "Flags": 1114112,
+                  "HighLimit": {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "value": "0"
+                  },
+                  "HighNode": "bfa",
+                  "LowLimit": {
+                    "currency": "USD",
+                    "issuer": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                    "value": "9999999999999999e80"
+                  },
+                  "LowNode": "8"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "CE8BC6520C7A30953A4AC6733394E6924DAA4C3CB16CFB9EAC02EA7494417D59",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "USD",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0.000001551004431334"
+                  }
+                },
+                "PreviousTxnID": "542A160F911E55FD6D59376A85FC69B2AA4495F7A6C863F94383A3D7005304D2",
+                "PreviousTxnLgrSeq": 94084545
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rogue5HnPRSszD9CWGSUz8UGHMVwSSKF6",
+                  "AccountTxnID": "DADC4E8966CB4A1023558E74EF0C15BC886903795B06459D84507002574A0216",
+                  "Balance": "97189494",
+                  "Flags": 0,
+                  "OwnerCount": 404,
+                  "Sequence": 29665814
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E7C799A822859C2DC1CA293CB3136B6590628B19F81D5C7BA8752B49BB422E84",
+                "PreviousFields": {
+                  "AccountTxnID": "88D2EFCC697A12E2E40B7494897953BC58ECB7F293381437C0B07983B1877075",
+                  "Balance": "97189504",
+                  "Sequence": 29665813
+                },
+                "PreviousTxnID": "88D2EFCC697A12E2E40B7494897953BC58ECB7F293381437C0B07983B1877075",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            }
+          ],
+          "DeliveredAmount": {
+            "currency": "USD",
+            "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "value": "0.009709685917630885"
+          },
+          "TransactionIndex": 11,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": {
+            "currency": "USD",
+            "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "value": "0.009709685917630885"
+          }
+        }
+      },
+      {
+        "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 30424030,
+        "Sequence": 30424035,
+        "SigningPubKey": "037E9B02A63FFC298C82B66D250932A5DCF89361122925CB42339E3C769245084C",
+        "TakerGets": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "41161.31084509362"
+        },
+        "TakerPays": "3035042777",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100C2B840A8552BE8BD3234AA562850BA50BF3B1216830FB1977ADE414C0516B69F02205792F6079A49ED318DD583BDFB7AF926DB4B8BFECCAB0D177B87B89A673AEEAA",
+        "hash": "DFE5582189D6192497C1199E17AA699F8D7F6226FCB8AA96F7BE4511BD2F3059",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "591691a5b40854a9",
+                  "Flags": 0,
+                  "PreviousTxnID": "A6B3493F81327D1A5F6F78C9DD9DCFA4BBCAD2E22545597B16AD81BA56E65DCD",
+                  "PreviousTxnLgrSeq": 94084600,
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591691A5B40854A9",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591691A5B40854A9"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591A3230665067F6",
+                "NewFields": {
+                  "ExchangeRate": "591a3230665067f6",
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591A3230665067F6",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591691A5B40854A9",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "A6B3493F81327D1A5F6F78C9DD9DCFA4BBCAD2E22545597B16AD81BA56E65DCD",
+                  "PreviousTxnLgrSeq": 94084600,
+                  "Sequence": 30424030,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "302095.7419296014"
+                  },
+                  "TakerPays": "19190904991"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "72F32146B93FA56DAD6794D156FC7541D78E8814D75504C1FAB23F5F0D4E3D59"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "99F5EC5259969673B1FE47D0A2DCEF3E198C2CFE5245CF211317E99637D66B55",
+                "NewFields": {
+                  "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591A3230665067F6",
+                  "Sequence": 30424035,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "41161.31084509362"
+                  },
+                  "TakerPays": "3035042777"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "Balance": "100882749",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 30424036
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C84DB7EC299936754ADF7B0342A2E3B441F5076DAD476769D5021BA104BF9A7E",
+                "PreviousFields": {
+                  "Balance": "100882764",
+                  "Sequence": 30424035
+                },
+                "PreviousTxnID": "EA35FA390DF2C87A74B947B2D099E616AF799119F497F98E6EBF99A347F8D091",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "RootIndex": "D2932301FC455041F84607F18EEFB3E24C9B4B9269DAB4B79DEEBA3A96FED70E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "D2932301FC455041F84607F18EEFB3E24C9B4B9269DAB4B79DEEBA3A96FED70E",
+                "PreviousTxnID": "EA35FA390DF2C87A74B947B2D099E616AF799119F497F98E6EBF99A347F8D091",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            }
+          ],
+          "TransactionIndex": 30,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rEoYG7nQQyfuAiTL1FViY7dGUYdixC6PTy",
+        "Amount": "757530",
+        "DeliverMax": "757530",
+        "Destination": "rJGb4etn9GSwNHYVu7dNMbdiVgzqxaTSUG",
+        "Fee": "12",
+        "LastLedgerSequence": 94085605,
+        "Memos": [
+          {
+            "Memo": {
+              "MemoData": "4669727374204C6564676572207472616E73616374696F6E20666565"
+            }
+          }
+        ],
+        "Sequence": 91643959,
+        "SigningPubKey": "034232653656DED23A25C5C292F05E12162C78567435BA25E2F8A47DF9E6023EE9",
+        "SourceTag": 74920348,
+        "TransactionType": "Payment",
+        "TxnSignature": "304402202E014C5F68C23267A581922E9102340CC3353859D1370F6E439CB829CFCC97E902203A2831FD6F0A55B20E8E048A62AD8B494B8BA804C993B8CF47C1EDF24CABB343",
+        "hash": "E342C7D4343D8347406B191AEAFA0921766C3D9CC014180102F25C0A73252E6F",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rJGb4etn9GSwNHYVu7dNMbdiVgzqxaTSUG",
+                  "Balance": "1504252465243",
+                  "Flags": 0,
+                  "OwnerCount": 0,
+                  "Sequence": 86622343
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "8EB322D489D5899DE90DD1F9A1F5CC541D3261B4BE25279F6F018FDF6D5C20C8",
+                "PreviousFields": {
+                  "Balance": "1504251707713"
+                },
+                "PreviousTxnID": "897E7DD85A7DFD20AF2C2C811F91827707123B007F5F2D4A165B70B643600268",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rEoYG7nQQyfuAiTL1FViY7dGUYdixC6PTy",
+                  "Balance": "90186191",
+                  "Flags": 0,
+                  "OwnerCount": 67,
+                  "Sequence": 91643960
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "B0D2869D98E570129FED85A9F5D6F0BA19358606B12676495BF830FD50CFF48A",
+                "PreviousFields": {
+                  "Balance": "90943733",
+                  "Sequence": 91643959
+                },
+                "PreviousTxnID": "D09B1F84AC7773F54126498ED151AC74526922EE41732A934049CEB526AAB978",
+                "PreviousTxnLgrSeq": 94084607
+              }
+            }
+          ],
+          "TransactionIndex": 58,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "757530"
+        }
+      },
+      {
+        "Account": "rL4H3dcrK3uzoa58ejQ2YXc8iGdrDQFEoS",
+        "Amount": "11686883",
+        "DeliverMax": "11686883",
+        "DeliverMin": "11453145",
+        "Destination": "rL4H3dcrK3uzoa58ejQ2YXc8iGdrDQFEoS",
+        "Fee": "12",
+        "Flags": 131072,
+        "LastLedgerSequence": 94084626,
+        "SendMax": {
+          "currency": "416D657269636100000000000000000000000000",
+          "issuer": "rpVajoWTXFkKWY7gtWSwcpEcpLDUjtktCA",
+          "value": "5492183.139748964"
+        },
+        "Sequence": 93505190,
+        "SigningPubKey": "ED1C743268B2BC9E87549B84D90BC6B4BEAF6ABAEFA7049CB2214CA567D3DE2F11",
+        "TransactionType": "Payment",
+        "TxnSignature": "4BCC6A702CE7202F38C12F56A3494984011802ECC31BDEC38D15763E47508F6D0AF3C9BB6513D28DDEBAA1F59C36397C51AFBFF3CCE255C7ADF2224E1C84F403",
+        "hash": "E72A6831AA130B44828A67B742757F6B8388E46C7E5C46652C215FBEAD1FC35B",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1959914887.440993"
+                  },
+                  "Flags": 16908288,
+                  "HighLimit": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rDwJrWbmBd2eGMmpGhA1NJLXYXhUHhv8sh",
+                    "value": "0"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rpVajoWTXFkKWY7gtWSwcpEcpLDUjtktCA",
+                    "value": "0"
+                  },
+                  "LowNode": "1"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "7C3D48ED20980D68B8C3FDA328F5AE2A87F5137BD29EB402C8BF94A07A9399C2",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-1954422704.301244"
+                  }
+                },
+                "PreviousTxnID": "29B38C33CCF2D500600D746F109A7A985203A45EA78F5A6D677A916884BE9249",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "AMMID": "ED4CBF1A89198D096EAB02EEE41B5E1D2B895D9CEE0F27E9EFE509EA3C23A1C7",
+                  "Account": "rDwJrWbmBd2eGMmpGhA1NJLXYXhUHhv8sh",
+                  "Balance": "4124130383",
+                  "Flags": 26214400,
+                  "OwnerCount": 1,
+                  "Sequence": 92443065
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "7D917B911BF3B3F3E052B85D540C4B26B33E4C9247FA7F03CEEF59F82877D30A",
+                "PreviousFields": {
+                  "Balance": "4135718801"
+                },
+                "PreviousTxnID": "29B38C33CCF2D500600D746F109A7A985203A45EA78F5A6D677A916884BE9249",
+                "PreviousTxnLgrSeq": 94084608
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rL4H3dcrK3uzoa58ejQ2YXc8iGdrDQFEoS",
+                  "Balance": "20146020",
+                  "Flags": 0,
+                  "OwnerCount": 1,
+                  "Sequence": 93505191
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C3545380C989F54ED39123AAD3BB8209FCEE7DA86A4E51D1C5A58BEA7F02E10D",
+                "PreviousFields": {
+                  "Balance": "8557614",
+                  "Sequence": 93505190
+                },
+                "PreviousTxnID": "F61DEF202287073382AB851AC6F79F425939A430B4B0A34536529793F3747B77",
+                "PreviousTxnLgrSeq": 94084606
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Balance": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "0"
+                  },
+                  "Flags": 2228224,
+                  "HighLimit": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rL4H3dcrK3uzoa58ejQ2YXc8iGdrDQFEoS",
+                    "value": "1000000000000000e-2"
+                  },
+                  "HighNode": "0",
+                  "LowLimit": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rpVajoWTXFkKWY7gtWSwcpEcpLDUjtktCA",
+                    "value": "0"
+                  },
+                  "LowNode": "23"
+                },
+                "LedgerEntryType": "RippleState",
+                "LedgerIndex": "FCFDEB5FB09419E2A92AEFD99E2752841053057CD751D85AD72D6574900CE16B",
+                "PreviousFields": {
+                  "Balance": {
+                    "currency": "416D657269636100000000000000000000000000",
+                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                    "value": "-5492183.139748964"
+                  }
+                },
+                "PreviousTxnID": "F61DEF202287073382AB851AC6F79F425939A430B4B0A34536529793F3747B77",
+                "PreviousTxnLgrSeq": 94084606
+              }
+            }
+          ],
+          "DeliveredAmount": "11588418",
+          "TransactionIndex": 82,
+          "TransactionResult": "tesSUCCESS",
+          "delivered_amount": "11588418"
+        }
+      },
+      {
+        "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 30424031,
+        "Sequence": 30424034,
+        "SigningPubKey": "037E9B02A63FFC298C82B66D250932A5DCF89361122925CB42339E3C769245084C",
+        "TakerGets": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "177730.1505367868"
+        },
+        "TakerPays": "11304471889",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100A00E88FA111B687162F29AA7119DA7E2C19B14565DC602D3FA2970C2598C95DE0220091FECDEC99E41BAA4B3276F5AFC051CC929F442BDF96F9913ED54C52AA52613",
+        "hash": "EA35FA390DF2C87A74B947B2D099E616AF799119F497F98E6EBF99A347F8D091",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591698D030DA59F4",
+                "NewFields": {
+                  "ExchangeRate": "591698d030da59f4",
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591698D030DA59F4",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "591a29e091e1e529",
+                  "Flags": 0,
+                  "PreviousTxnID": "40ECC08AB895DB2187DA7DA86612AC35E1379AFA40A5689AC3EC2DE70D693A79",
+                  "PreviousTxnLgrSeq": 94084600,
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591A29E091E1E529",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591A29E091E1E529"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "1D64EBD8301DF5C786FD05BF61E6C17CF8372D2E81FAEF24839520849D5A199E",
+                "NewFields": {
+                  "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591698D030DA59F4",
+                  "Sequence": 30424034,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "177730.1505367868"
+                  },
+                  "TakerPays": "11304471889"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB7097591A29E091E1E529",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "40ECC08AB895DB2187DA7DA86612AC35E1379AFA40A5689AC3EC2DE70D693A79",
+                  "PreviousTxnLgrSeq": 94084600,
+                  "Sequence": 30424031,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "36753.90949911346"
+                  },
+                  "TakerPays": "2706702666"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "6125183478D86B7DF9229647B8379A8EA370A5E8630BD59F36E021E227391D2B"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "Balance": "100882764",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 30424035
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "C84DB7EC299936754ADF7B0342A2E3B441F5076DAD476769D5021BA104BF9A7E",
+                "PreviousFields": {
+                  "Balance": "100882779",
+                  "Sequence": 30424034
+                },
+                "PreviousTxnID": "63528D19791CB93D762CEEDB1C5AEBF08538C8C75F2F51A340E52E6981272F32",
+                "PreviousTxnLgrSeq": 94084600
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "Owner": "rwchA2b36zu2r6CJfEMzPLQ1cmciKFcw9t",
+                  "RootIndex": "D2932301FC455041F84607F18EEFB3E24C9B4B9269DAB4B79DEEBA3A96FED70E"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "D2932301FC455041F84607F18EEFB3E24C9B4B9269DAB4B79DEEBA3A96FED70E",
+                "PreviousTxnID": "63528D19791CB93D762CEEDB1C5AEBF08538C8C75F2F51A340E52E6981272F32",
+                "PreviousTxnLgrSeq": 94084600
+              }
+            }
+          ],
+          "TransactionIndex": 29,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rDrvRfz24oqMZFoH8a45CE1qEo8U8m1EAX",
+        "Fee": "12",
+        "Flags": 0,
+        "LastLedgerSequence": 94084621,
+        "OfferSequence": 88619454,
+        "Sequence": 0,
+        "SigningPubKey": "EDBCC48EBFB7A77F0318265D45D93F860C9295E28FF89A57C7FDE6D2501441E750",
+        "TakerGets": "10480980",
+        "TakerPays": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "221.344110543449"
+        },
+        "TicketSequence": 88619453,
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "A480FB2AB78B4FF7A973BC63697EC29F0E96E00BC5D196E21511193143F7A78E736D5D2D4B22C176EEF3610DF0751861C1CF4E082B06E46E4948C9879899B30B",
+        "hash": "FB8EAF3BA6D534D9CF5072ADA03DEA1512D1EB2DADD19F0308B765DF313F2A97",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rDrvRfz24oqMZFoH8a45CE1qEo8U8m1EAX",
+                  "Flags": 0,
+                  "OwnerNode": "9f6a",
+                  "PreviousTxnID": "E2C589482CFCB38CEF393F3FD4AC7060CFBB09B6F9F79CA3AD7B8DCD690AA56D",
+                  "PreviousTxnLgrSeq": 94084513,
+                  "TicketSequence": 88619453
+                },
+                "LedgerEntryType": "Ticket",
+                "LedgerIndex": "14B67DC029703B52D08B48191081BE0689B41D04B0A11C9C4074FF84E7AE2CA4"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rDrvRfz24oqMZFoH8a45CE1qEo8U8m1EAX",
+                  "Balance": "861688504",
+                  "Flags": 0,
+                  "OwnerCount": 172,
+                  "Sequence": 88619466,
+                  "TicketCount": 14
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "5681BA06B7D08AD12A85CBCFD767A2E61D3D9BD590BBB5DDCBB35F22BAADA70F",
+                "PreviousFields": {
+                  "Balance": "861688516",
+                  "OwnerCount": 173,
+                  "TicketCount": 15
+                },
+                "PreviousTxnID": "4E7709B99AE33172137E754F9B3C83B295F98827DF04CA3ED06F5BE70590416A",
+                "PreviousTxnLgrSeq": 94084605
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rDrvRfz24oqMZFoH8a45CE1qEo8U8m1EAX",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475007810BD45B0062",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "9f6a",
+                  "PreviousTxnID": "3B292058C341CD13EB4F3DA3897296DD01E2EE7E366645D33B207540CF8E1E22",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "Sequence": 88619454,
+                  "TakerGets": "10480980",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "221.380584809868"
+                  }
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "61EC7BC572FAFB0E6C3A3B04062C27D2533A06A02CFBED3243DD267FD3DA986D"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500780BACDAE049A",
+                "NewFields": {
+                  "ExchangeRate": "500780bacdae049a",
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500780BACDAE049A",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5007810bd45b0062",
+                  "Flags": 0,
+                  "PreviousTxnID": "3B292058C341CD13EB4F3DA3897296DD01E2EE7E366645D33B207540CF8E1E22",
+                  "PreviousTxnLgrSeq": 94084605,
+                  "RootIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475007810BD45B0062",
+                  "TakerGetsCurrency": "0000000000000000000000000000000000000000",
+                  "TakerGetsIssuer": "0000000000000000000000000000000000000000",
+                  "TakerPaysCurrency": "000000000000000000000000434E590000000000",
+                  "TakerPaysIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE100799475007810BD45B0062"
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexPrevious": "9f60",
+                  "Owner": "rDrvRfz24oqMZFoH8a45CE1qEo8U8m1EAX",
+                  "RootIndex": "803D7CD7108997F42FA4DF5C63A16BCA2FF1232D2879FF9F357BCFC04C2CFF4C"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "B3A97CB20739AFA0535FABDC2B08CD14A2FF05E2518F744BE24368F35DC1AA12",
+                "PreviousTxnID": "4E7709B99AE33172137E754F9B3C83B295F98827DF04CA3ED06F5BE70590416A",
+                "PreviousTxnLgrSeq": 94084605
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "C039A0E2F48244D1F3BB0C8A6A95E7E6F309DDAB69FC1A15E95DCDF7A044C0D1",
+                "NewFields": {
+                  "Account": "rDrvRfz24oqMZFoH8a45CE1qEo8U8m1EAX",
+                  "BookDirectory": "623C4C4AD65873DA787AC85A0A1385FE6233B6DE10079947500780BACDAE049A",
+                  "OwnerNode": "9f6a",
+                  "Sequence": 88619453,
+                  "TakerGets": "10480980",
+                  "TakerPays": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "221.344110543449"
+                  }
+                }
+              }
+            }
+          ],
+          "TransactionIndex": 64,
+          "TransactionResult": "tesSUCCESS"
+        }
+      },
+      {
+        "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+        "Fee": "15",
+        "Flags": 0,
+        "LastLedgerSequence": 94084610,
+        "OfferSequence": 144101817,
+        "Sequence": 144101821,
+        "SigningPubKey": "022D40673B44C82DEE1DDB8B9BB53DCCE4F97B27404DB850F068DD91D685E337EA",
+        "TakerGets": {
+          "currency": "CNY",
+          "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+          "value": "164908.4438172974"
+        },
+        "TakerPays": "9883984139",
+        "TransactionType": "OfferCreate",
+        "TxnSignature": "3045022100B09658CD68F45FEB087B60908BE429330A2B177C476E0AACAC89F97519F4362B02207256A1B8AB1D00C9003320F555EFA66D47D11A213F2B3A63A23FBFC1099A40AB",
+        "hash": "FE286600AC66A0438D0E01B5BA59E1EEAA0106A979248330E52D15C23F2416A2",
+        "metaData": {
+          "AffectedNodes": [
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "ExchangeRate": "5915483c5bea2592",
+                  "Flags": 0,
+                  "PreviousTxnID": "AF4E9CE2CA6C2F23FD5EDEA9DCA88B657D5F41640DB2419698E37C08CF1E6F3B",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975915483C5BEA2592",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0",
+                  "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+                  "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975915483C5BEA2592"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB709759154B2A36E63573",
+                "NewFields": {
+                  "ExchangeRate": "59154b2a36e63573",
+                  "RootIndex": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB709759154B2A36E63573",
+                  "TakerGetsCurrency": "000000000000000000000000434E590000000000",
+                  "TakerGetsIssuer": "0360E3E0751BD9A566CD03FA6CAFC78118B82BA0"
+                }
+              }
+            },
+            {
+              "DeletedNode": {
+                "FinalFields": {
+                  "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB70975915483C5BEA2592",
+                  "BookNode": "0",
+                  "Flags": 0,
+                  "OwnerNode": "0",
+                  "PreviousTxnID": "AF4E9CE2CA6C2F23FD5EDEA9DCA88B657D5F41640DB2419698E37C08CF1E6F3B",
+                  "PreviousTxnLgrSeq": 94084606,
+                  "Sequence": 144101817,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "94156.63673998775"
+                  },
+                  "TakerPays": "5640357838"
+                },
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "44E899A41D84E281061E72D74C18A578A35A7D9C09FB5ACF6EDB56322E0603E8"
+              }
+            },
+            {
+              "CreatedNode": {
+                "LedgerEntryType": "Offer",
+                "LedgerIndex": "5100AC12E9E9AB9CD47BC8EA802B959A38B5AD22DE918E8748E9987753B59F2E",
+                "NewFields": {
+                  "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "BookDirectory": "1AC09600F4B502C8F7F830F80B616DCB6F3970CB79AB709759154B2A36E63573",
+                  "Sequence": 144101821,
+                  "TakerGets": {
+                    "currency": "CNY",
+                    "issuer": "rJ1adrpGS3xsnQMb9Cw54tWJVFPuSdZHK",
+                    "value": "164908.4438172974"
+                  },
+                  "TakerPays": "9883984139"
+                }
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Flags": 0,
+                  "IndexNext": "0",
+                  "IndexPrevious": "0",
+                  "Owner": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "RootIndex": "AEA3074F10FE15DAC592F8A0405C61FB7D4C98F588C2D55C84718FAFBBD2604A"
+                },
+                "LedgerEntryType": "DirectoryNode",
+                "LedgerIndex": "AEA3074F10FE15DAC592F8A0405C61FB7D4C98F588C2D55C84718FAFBBD2604A",
+                "PreviousTxnID": "3A4F2024CF352C9C11259889E81514EBBA2C7C2BF70C9FF0B38539B31F57219E",
+                "PreviousTxnLgrSeq": 94084606
+              }
+            },
+            {
+              "ModifiedNode": {
+                "FinalFields": {
+                  "Account": "rh3VLyj1GbQjX7eA15BwUagEhSrPHmLkSR",
+                  "Balance": "100345352",
+                  "Flags": 0,
+                  "OwnerCount": 5,
+                  "Sequence": 144101822
+                },
+                "LedgerEntryType": "AccountRoot",
+                "LedgerIndex": "E0311EB450B6177F969B94DBDDA83E99B7A0576ACD9079573876F16C0C004F06",
+                "PreviousFields": {
+                  "Balance": "100345367",
+                  "Sequence": 144101821
+                },
+                "PreviousTxnID": "3A4F2024CF352C9C11259889E81514EBBA2C7C2BF70C9FF0B38539B31F57219E",
+                "PreviousTxnLgrSeq": 94084606
+              }
+            }
+          ],
+          "TransactionIndex": 0,
+          "TransactionResult": "tesSUCCESS"
+        }
+      }
+    ]
+  },
+  "ledger_hash": "576A59C1EA928637915556DBF2BF9F6CC7ADAC942EAA6706BA91BB35751140A5",
+  "ledger_index": 94084608,
+  "validated": true
+}


### PR DESCRIPTION
Fixes #590 by removing the `Account` property from any incoming `UnlModify` JSON about to be deserialized. This fixes #590 because the JSON returned by the rippled/clio API v1 has a bug where the account value in `UnlModify` transactions is an empty string, when serialized throws an exception because empty string is not a valid Address. By removing the property from incoming JSON, the Java value for the `Account` property is always set to ACCOUNT_ZERO via a default method. Without this fix, the `Account` will also errantly end up in the `unknownFields map of the ultimate Java object, which is incorrect.

(Note the large line-count of this PR is due to the addition of a Livenet ledger JSON file used to validate this fix against real data)