### PR TITLE
Draft: Add support for AMM Clawback

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtils.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtils.java
@@ -608,7 +608,7 @@ public class SignatureUtils {
         .signers(signers)
         .build();
     } else if (AmmClawback.class.isAssignableFrom(transaction.getClass())) {
-      transactionWithSignatures = OracleDelete.builder().from((AmmClawback) transaction)
+      transactionWithSignatures = AmmClawback.builder().from((AmmClawback) transaction)
           .signers(signers)
           .build();
     } else {

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtils.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtils.java
@@ -34,6 +34,7 @@ import org.xrpl.xrpl4j.model.transactions.AccountDelete;
 import org.xrpl.xrpl4j.model.transactions.AccountSet;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.AmmBid;
+import org.xrpl.xrpl4j.model.transactions.AmmClawback;
 import org.xrpl.xrpl4j.model.transactions.AmmCreate;
 import org.xrpl.xrpl4j.model.transactions.AmmDelete;
 import org.xrpl.xrpl4j.model.transactions.AmmDeposit;
@@ -391,6 +392,10 @@ public class SignatureUtils {
       transactionWithSignature = OracleDelete.builder().from((OracleDelete) transaction)
         .transactionSignature(signature)
         .build();
+    } else if (AmmClawback.class.isAssignableFrom(transaction.getClass())) {
+      transactionWithSignature = AmmClawback.builder().from((AmmClawback) transaction)
+          .transactionSignature(signature)
+          .build();
     } else {
       // Should never happen, but will in a unit test if we miss one.
       throw new IllegalArgumentException("Signing fields could not be added to the transaction.");
@@ -602,6 +607,10 @@ public class SignatureUtils {
       transactionWithSignatures = OracleDelete.builder().from((OracleDelete) transaction)
         .signers(signers)
         .build();
+    } else if (AmmClawback.class.isAssignableFrom(transaction.getClass())) {
+      transactionWithSignatures = OracleDelete.builder().from((AmmClawback) transaction)
+          .signers(signers)
+          .build();
     } else {
       // Should never happen, but will in a unit test if we miss one.
       throw new IllegalArgumentException("Signing fields could not be added to the transaction.");

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/flags/AmmClawbackTransactionFlags.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/flags/AmmClawbackTransactionFlags.java
@@ -1,0 +1,113 @@
+package org.xrpl.xrpl4j.model.flags;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: core
+ * %%
+ * Copyright (C) 2020 - 2023 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import org.xrpl.xrpl4j.model.transactions.AmmClawback;
+
+/**
+ * {@link TransactionFlags} for {@link AmmClawback} transactions.
+ */
+public class AmmClawbackTransactionFlags extends TransactionFlags {
+  /**
+   * Constant for an unset flag.
+   */
+  protected static final AmmClawbackTransactionFlags UNSET = new AmmClawbackTransactionFlags(0);
+
+  /**
+   * Constant for the {@code tfClawTwoAssets} flag.
+   */
+  protected static final AmmClawbackTransactionFlags CLAW_TWO_ASSETS = new AmmClawbackTransactionFlags(0x00000001);
+
+  private AmmClawbackTransactionFlags(long value) {
+    super(value);
+  }
+
+  private AmmClawbackTransactionFlags() {
+  }
+
+  /**
+   * Construct {@link AmmClawbackTransactionFlags} with a given value.
+   *
+   * @param tfFullyCanonicalSig The long-number encoded flags value of this {@link AmmClawbackTransactionFlags}.
+   *
+   * @return New {@link AmmClawbackTransactionFlags}.
+   */
+  public static AmmClawbackTransactionFlags of(boolean tfFullyCanonicalSig) {
+    return new AmmClawbackTransactionFlags(
+        Flags.of(
+            tfFullyCanonicalSig ? CLAW_TWO_ASSETS : UNSET
+        ).getValue()
+    );
+  }
+
+  /**
+   * Construct an empty instance of {@link AmmClawbackTransactionFlags}.
+   *
+   * @return An empty {@link AmmClawbackTransactionFlags}.
+   */
+  public static AmmClawbackTransactionFlags empty() {
+    return new AmmClawbackTransactionFlags();
+  }
+
+  /**
+   * Create a new {@link Builder}.
+   *
+   * @return A new {@link Builder}.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Whether or not the {@code tfClawTwoAssets} flag is set.
+   *
+   * @return {@code true} if {@code tfClawTwoAssets} is set, otherwise {@code false}.
+   */
+  public boolean tfClawTwoAssets() {
+    return this.isSet(CLAW_TWO_ASSETS);
+  }
+
+  /**
+   * A builder class for {@link AmmClawbackTransactionFlags}.
+   */
+  public static class Builder {
+    private boolean tfClawTwoAssets = false;
+
+    /**
+     * Set {@code tfClawTwoAssets} to the given value.
+     *
+     * @return The same {@link Builder}.
+     */
+    public Builder tfClawTwoAssets() {
+      this.tfClawTwoAssets = true;
+      return this;
+    }
+
+    /**
+     * Build a new {@link AmmClawbackTransactionFlags} from the current boolean values.
+     *
+     * @return A new {@link AmmClawbackTransactionFlags}.
+     */
+    public AmmClawbackTransactionFlags build() {
+      return AmmClawbackTransactionFlags.of(tfClawTwoAssets);
+    }
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/AmmClawback.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/AmmClawback.java
@@ -3,16 +3,16 @@ package org.xrpl.xrpl4j.model.transactions;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.annotations.Beta;
 import org.immutables.value.Value;
+import org.xrpl.xrpl4j.model.flags.TransactionFlags;
 import org.xrpl.xrpl4j.model.ledger.Issue;
 
 /**
  * Object mapping for the {@code AMMClawback} transaction.
  */
 @Value.Immutable
-// @JsonSerialize(as = ImmutableDidSet.class)
-// @JsonDeserialize(as = ImmutableDidSet.class)
+@JsonSerialize(as = ImmutableAmmClawback.class)
+@JsonDeserialize(as = ImmutableAmmClawback.class)
 public interface AmmClawback extends Transaction {
   @JsonProperty("Account")
   Address account();
@@ -25,4 +25,17 @@ public interface AmmClawback extends Transaction {
 
   @JsonProperty("Amount")
   CurrencyAmount amount();
+
+  @JsonProperty("Holder")
+  Address holder();
+
+  @JsonProperty("Flags")
+  @Value.Default
+  default TransactionFlags flags() {
+    return TransactionFlags.EMPTY;
+  }
+
+  static ImmutableAmmClawback.Builder builder() {
+    return ImmutableAmmClawback.builder();
+  }
 }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/AmmClawback.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/AmmClawback.java
@@ -3,9 +3,12 @@ package org.xrpl.xrpl4j.model.transactions;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.annotations.Beta;
 import org.immutables.value.Value;
 import org.xrpl.xrpl4j.model.flags.TransactionFlags;
 import org.xrpl.xrpl4j.model.ledger.Issue;
+
+import java.util.Optional;
 
 /**
  * Object mapping for the {@code AMMClawback} transaction.
@@ -13,9 +16,11 @@ import org.xrpl.xrpl4j.model.ledger.Issue;
 @Value.Immutable
 @JsonSerialize(as = ImmutableAmmClawback.class)
 @JsonDeserialize(as = ImmutableAmmClawback.class)
+@Beta
 public interface AmmClawback extends Transaction {
-  @JsonProperty("Account")
-  Address account();
+
+  @JsonProperty("Holder")
+  Address holder();
 
   @JsonProperty("Asset")
   Issue asset();
@@ -24,16 +29,7 @@ public interface AmmClawback extends Transaction {
   Issue asset2();
 
   @JsonProperty("Amount")
-  CurrencyAmount amount();
-
-  @JsonProperty("Holder")
-  Address holder();
-
-  @JsonProperty("Flags")
-  @Value.Default
-  default TransactionFlags flags() {
-    return TransactionFlags.EMPTY;
-  }
+  Optional<CurrencyAmount> amount();
 
   static ImmutableAmmClawback.Builder builder() {
     return ImmutableAmmClawback.builder();

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/AmmClawback.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/AmmClawback.java
@@ -1,0 +1,28 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.annotations.Beta;
+import org.immutables.value.Value;
+import org.xrpl.xrpl4j.model.ledger.Issue;
+
+/**
+ * Object mapping for the {@code AMMClawback} transaction.
+ */
+@Value.Immutable
+// @JsonSerialize(as = ImmutableDidSet.class)
+// @JsonDeserialize(as = ImmutableDidSet.class)
+public interface AmmClawback extends Transaction {
+  @JsonProperty("Account")
+  Address account();
+
+  @JsonProperty("Asset")
+  Issue asset();
+
+  @JsonProperty("Asset2")
+  Issue asset2();
+
+  @JsonProperty("Amount")
+  CurrencyAmount amount();
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Transaction.java
@@ -90,6 +90,7 @@ public interface Transaction {
       .put(ImmutableDidDelete.class, TransactionType.DID_DELETE)
       .put(ImmutableOracleSet.class, TransactionType.ORACLE_SET)
       .put(ImmutableOracleDelete.class, TransactionType.ORACLE_DELETE)
+      .put(ImmutableAmmClawback.class, TransactionType.AMM_CLAWBACK)
       .build();
 
   /**

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/TransactionType.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/TransactionType.java
@@ -336,7 +336,9 @@ public enum TransactionType {
    * is subject to change.</p>
    */
   @Beta
-  ORACLE_DELETE("OracleDelete");
+  ORACLE_DELETE("OracleDelete"),
+
+  AMM_CLAWBACK("AMMClawback");
 
   private final String value;
 

--- a/xrpl4j-core/src/main/resources/definitions.json
+++ b/xrpl4j-core/src/main/resources/definitions.json
@@ -1,2775 +1,3041 @@
 {
-  "TYPES": {
-    "Done": -1,
-    "Unknown": -2,
-    "NotPresent": 0,
-    "UInt16": 1,
-    "UInt32": 2,
-    "UInt64": 3,
-    "Hash128": 4,
-    "Hash256": 5,
-    "Amount": 6,
-    "Blob": 7,
-    "AccountID": 8,
-    "STObject": 14,
-    "STArray": 15,
-    "UInt8": 16,
-    "Hash160": 17,
-    "PathSet": 18,
-    "Vector256": 19,
-    "UInt96": 20,
-    "UInt192": 21,
-    "UInt384": 22,
-    "UInt512": 23,
-    "Issue": 24,
-    "XChainBridge": 25,
-    "Currency": 26,
-    "Transaction": 10001,
-    "LedgerEntry": 10002,
-    "Validation": 10003,
-    "Metadata": 10004
-  },
-  "LEDGER_ENTRY_TYPES": {
-    "Invalid": -1,
-    "AccountRoot": 97,
-    "DirectoryNode": 100,
-    "RippleState": 114,
-    "Ticket": 84,
-    "SignerList": 83,
-    "Offer": 111,
-    "Bridge": 105,
-    "LedgerHashes": 104,
-    "Amendments": 102,
-    "XChainOwnedClaimID": 113,
-    "XChainOwnedCreateAccountClaimID": 116,
-    "FeeSettings": 115,
-    "Escrow": 117,
-    "PayChannel": 120,
-    "Check": 67,
-    "DepositPreauth": 112,
-    "NegativeUNL": 78,
-    "NFTokenPage": 80,
-    "NFTokenOffer": 55,
-    "AMM": 121,
-    "DID": 73,
-    "Oracle": 128,
-    "Any": -3,
-    "Child": -2,
-    "Nickname": 110,
-    "Contract": 99,
-    "GeneratorMap": 103
-  },
   "FIELDS": [
     [
       "Generic",
       {
-        "nth": 0,
-        "isVLEncoded": false,
         "isSerialized": false,
         "isSigningField": false,
+        "isVLEncoded": false,
+        "nth": 0,
         "type": "Unknown"
       }
     ],
     [
       "Invalid",
       {
-        "nth": -1,
-        "isVLEncoded": false,
         "isSerialized": false,
         "isSigningField": false,
+        "isVLEncoded": false,
+        "nth": -1,
         "type": "Unknown"
       }
     ],
     [
       "ObjectEndMarker",
       {
-        "nth": 1,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
         "type": "STObject"
       }
     ],
     [
       "ArrayEndMarker",
       {
-        "nth": 1,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
         "type": "STArray"
-      }
-    ],
-    [
-      "hash",
-      {
-        "nth": 257,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
-        "type": "Hash256"
-      }
-    ],
-    [
-      "index",
-      {
-        "nth": 258,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
-        "type": "Hash256"
       }
     ],
     [
       "taker_gets_funded",
       {
-        "nth": 258,
-        "isVLEncoded": false,
         "isSerialized": false,
         "isSigningField": false,
+        "isVLEncoded": false,
+        "nth": 258,
         "type": "Amount"
       }
     ],
     [
       "taker_pays_funded",
       {
+        "isSerialized": false,
+        "isSigningField": false,
+        "isVLEncoded": false,
         "nth": 259,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
         "type": "Amount"
-      }
-    ],
-    [
-      "LedgerEntry",
-      {
-        "nth": 257,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
-        "type": "LedgerEntry"
-      }
-    ],
-    [
-      "Transaction",
-      {
-        "nth": 257,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
-        "type": "Transaction"
-      }
-    ],
-    [
-      "Validation",
-      {
-        "nth": 257,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
-        "type": "Validation"
-      }
-    ],
-    [
-      "Metadata",
-      {
-        "nth": 257,
-        "isVLEncoded": false,
-        "isSerialized": false,
-        "isSigningField": false,
-        "type": "Metadata"
-      }
-    ],
-    [
-      "CloseResolution",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt8"
-      }
-    ],
-    [
-      "Method",
-      {
-        "nth": 2,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt8"
-      }
-    ],
-    [
-      "TransactionResult",
-      {
-        "nth": 3,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt8"
-      }
-    ],
-    [
-      "Scale",
-      {
-        "nth": 4,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt8"
-      }
-    ],
-    [
-      "TickSize",
-      {
-        "nth": 16,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt8"
-      }
-    ],
-    [
-      "UNLModifyDisabling",
-      {
-        "nth": 17,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt8"
-      }
-    ],
-    [
-      "HookResult",
-      {
-        "nth": 18,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt8"
-      }
-    ],
-    [
-      "WasLockingChainSend",
-      {
-        "nth": 19,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "UInt8"
       }
     ],
     [
       "LedgerEntryType",
       {
-        "nth": 1,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
         "type": "UInt16"
       }
     ],
     [
       "TransactionType",
       {
-        "nth": 2,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
         "type": "UInt16"
       }
     ],
     [
       "SignerWeight",
       {
-        "nth": 3,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 3,
         "type": "UInt16"
       }
     ],
     [
       "TransferFee",
       {
-        "nth": 4,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 4,
         "type": "UInt16"
       }
     ],
     [
       "TradingFee",
       {
-        "nth": 5,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 5,
         "type": "UInt16"
       }
     ],
     [
       "DiscountedFee",
       {
-        "nth": 6,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 6,
         "type": "UInt16"
       }
     ],
     [
       "Version",
       {
-        "nth": 16,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 16,
         "type": "UInt16"
       }
     ],
     [
       "HookStateChangeCount",
       {
-        "nth": 17,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 17,
         "type": "UInt16"
       }
     ],
     [
       "HookEmitCount",
       {
-        "nth": 18,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 18,
         "type": "UInt16"
       }
     ],
     [
       "HookExecutionIndex",
       {
-        "nth": 19,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 19,
         "type": "UInt16"
       }
     ],
     [
       "HookApiVersion",
       {
-        "nth": 20,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 20,
+        "type": "UInt16"
+      }
+    ],
+    [
+      "LedgerFixType",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 21,
         "type": "UInt16"
       }
     ],
     [
       "NetworkID",
       {
-        "nth": 1,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
         "type": "UInt32"
       }
     ],
     [
       "Flags",
       {
-        "nth": 2,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
         "type": "UInt32"
       }
     ],
     [
       "SourceTag",
       {
-        "nth": 3,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 3,
         "type": "UInt32"
       }
     ],
     [
       "Sequence",
       {
-        "nth": 4,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 4,
         "type": "UInt32"
       }
     ],
     [
       "PreviousTxnLgrSeq",
       {
-        "nth": 5,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 5,
         "type": "UInt32"
       }
     ],
     [
       "LedgerSequence",
       {
-        "nth": 6,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 6,
         "type": "UInt32"
       }
     ],
     [
       "CloseTime",
       {
-        "nth": 7,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 7,
         "type": "UInt32"
       }
     ],
     [
       "ParentCloseTime",
       {
-        "nth": 8,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 8,
         "type": "UInt32"
       }
     ],
     [
       "SigningTime",
       {
-        "nth": 9,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 9,
         "type": "UInt32"
       }
     ],
     [
       "Expiration",
       {
-        "nth": 10,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 10,
         "type": "UInt32"
       }
     ],
     [
       "TransferRate",
       {
-        "nth": 11,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 11,
         "type": "UInt32"
       }
     ],
     [
       "WalletSize",
       {
-        "nth": 12,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 12,
         "type": "UInt32"
       }
     ],
     [
       "OwnerCount",
       {
-        "nth": 13,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 13,
         "type": "UInt32"
       }
     ],
     [
       "DestinationTag",
       {
-        "nth": 14,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 14,
         "type": "UInt32"
       }
     ],
     [
       "LastUpdateTime",
       {
-        "nth": 15,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 15,
         "type": "UInt32"
       }
     ],
     [
       "HighQualityIn",
       {
-        "nth": 16,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 16,
         "type": "UInt32"
       }
     ],
     [
       "HighQualityOut",
       {
-        "nth": 17,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 17,
         "type": "UInt32"
       }
     ],
     [
       "LowQualityIn",
       {
-        "nth": 18,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 18,
         "type": "UInt32"
       }
     ],
     [
       "LowQualityOut",
       {
-        "nth": 19,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 19,
         "type": "UInt32"
       }
     ],
     [
       "QualityIn",
       {
-        "nth": 20,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 20,
         "type": "UInt32"
       }
     ],
     [
       "QualityOut",
       {
-        "nth": 21,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 21,
         "type": "UInt32"
       }
     ],
     [
       "StampEscrow",
       {
-        "nth": 22,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 22,
         "type": "UInt32"
       }
     ],
     [
       "BondAmount",
       {
-        "nth": 23,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 23,
         "type": "UInt32"
       }
     ],
     [
       "LoadFee",
       {
-        "nth": 24,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 24,
         "type": "UInt32"
       }
     ],
     [
       "OfferSequence",
       {
-        "nth": 25,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 25,
         "type": "UInt32"
       }
     ],
     [
       "FirstLedgerSequence",
       {
-        "nth": 26,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 26,
         "type": "UInt32"
       }
     ],
     [
       "LastLedgerSequence",
       {
-        "nth": 27,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 27,
         "type": "UInt32"
       }
     ],
     [
       "TransactionIndex",
       {
-        "nth": 28,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 28,
         "type": "UInt32"
       }
     ],
     [
       "OperationLimit",
       {
-        "nth": 29,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 29,
         "type": "UInt32"
       }
     ],
     [
       "ReferenceFeeUnits",
       {
-        "nth": 30,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 30,
         "type": "UInt32"
       }
     ],
     [
       "ReserveBase",
       {
-        "nth": 31,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 31,
         "type": "UInt32"
       }
     ],
     [
       "ReserveIncrement",
       {
-        "nth": 32,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 32,
         "type": "UInt32"
       }
     ],
     [
       "SetFlag",
       {
-        "nth": 33,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 33,
         "type": "UInt32"
       }
     ],
     [
       "ClearFlag",
       {
-        "nth": 34,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 34,
         "type": "UInt32"
       }
     ],
     [
       "SignerQuorum",
       {
-        "nth": 35,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 35,
         "type": "UInt32"
       }
     ],
     [
       "CancelAfter",
       {
-        "nth": 36,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 36,
         "type": "UInt32"
       }
     ],
     [
       "FinishAfter",
       {
-        "nth": 37,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 37,
         "type": "UInt32"
       }
     ],
     [
       "SignerListID",
       {
-        "nth": 38,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 38,
         "type": "UInt32"
       }
     ],
     [
       "SettleDelay",
       {
-        "nth": 39,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 39,
         "type": "UInt32"
       }
     ],
     [
       "TicketCount",
       {
-        "nth": 40,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 40,
         "type": "UInt32"
       }
     ],
     [
       "TicketSequence",
       {
-        "nth": 41,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 41,
         "type": "UInt32"
       }
     ],
     [
       "NFTokenTaxon",
       {
-        "nth": 42,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 42,
         "type": "UInt32"
       }
     ],
     [
       "MintedNFTokens",
       {
-        "nth": 43,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 43,
         "type": "UInt32"
       }
     ],
     [
       "BurnedNFTokens",
       {
-        "nth": 44,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 44,
         "type": "UInt32"
       }
     ],
     [
       "HookStateCount",
       {
-        "nth": 45,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 45,
         "type": "UInt32"
       }
     ],
     [
       "EmitGeneration",
       {
-        "nth": 46,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 46,
         "type": "UInt32"
       }
     ],
     [
       "VoteWeight",
       {
-        "nth": 48,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 48,
         "type": "UInt32"
       }
     ],
     [
       "FirstNFTokenSequence",
       {
-        "nth": 50,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 50,
         "type": "UInt32"
       }
     ],
     [
       "OracleDocumentID",
       {
-        "nth": 51,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 51,
         "type": "UInt32"
       }
     ],
     [
       "IndexNext",
       {
-        "nth": 1,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
         "type": "UInt64"
       }
     ],
     [
       "IndexPrevious",
       {
-        "nth": 2,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
         "type": "UInt64"
       }
     ],
     [
       "BookNode",
       {
-        "nth": 3,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 3,
         "type": "UInt64"
       }
     ],
     [
       "OwnerNode",
       {
-        "nth": 4,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 4,
         "type": "UInt64"
       }
     ],
     [
       "BaseFee",
       {
-        "nth": 5,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 5,
         "type": "UInt64"
       }
     ],
     [
       "ExchangeRate",
       {
-        "nth": 6,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 6,
         "type": "UInt64"
       }
     ],
     [
       "LowNode",
       {
-        "nth": 7,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 7,
         "type": "UInt64"
       }
     ],
     [
       "HighNode",
       {
-        "nth": 8,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 8,
         "type": "UInt64"
       }
     ],
     [
       "DestinationNode",
       {
-        "nth": 9,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 9,
         "type": "UInt64"
       }
     ],
     [
       "Cookie",
       {
-        "nth": 10,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 10,
         "type": "UInt64"
       }
     ],
     [
       "ServerVersion",
       {
-        "nth": 11,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 11,
         "type": "UInt64"
       }
     ],
     [
       "NFTokenOfferNode",
       {
-        "nth": 12,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 12,
         "type": "UInt64"
       }
     ],
     [
       "EmitBurden",
       {
-        "nth": 13,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 13,
         "type": "UInt64"
       }
     ],
     [
       "HookOn",
       {
-        "nth": 16,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 16,
         "type": "UInt64"
       }
     ],
     [
       "HookInstructionCount",
       {
-        "nth": 17,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 17,
         "type": "UInt64"
       }
     ],
     [
       "HookReturnCode",
       {
-        "nth": 18,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 18,
         "type": "UInt64"
       }
     ],
     [
       "ReferenceCount",
       {
-        "nth": 19,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 19,
         "type": "UInt64"
       }
     ],
     [
       "XChainClaimID",
       {
-        "nth": 20,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 20,
         "type": "UInt64"
       }
     ],
     [
       "XChainAccountCreateCount",
       {
-        "nth": 21,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 21,
         "type": "UInt64"
       }
     ],
     [
       "XChainAccountClaimCount",
       {
-        "nth": 22,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 22,
         "type": "UInt64"
       }
     ],
     [
       "AssetPrice",
       {
-        "nth": 23,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 23,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "MaximumAmount",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 24,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "OutstandingAmount",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 25,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "MPTAmount",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 26,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "IssuerNode",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 27,
+        "type": "UInt64"
+      }
+    ],
+    [
+      "SubjectNode",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 28,
         "type": "UInt64"
       }
     ],
     [
       "EmailHash",
       {
-        "nth": 1,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
         "type": "Hash128"
-      }
-    ],
-    [
-      "TakerPaysCurrency",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash160"
-      }
-    ],
-    [
-      "TakerPaysIssuer",
-      {
-        "nth": 2,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash160"
-      }
-    ],
-    [
-      "TakerGetsCurrency",
-      {
-        "nth": 3,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash160"
-      }
-    ],
-    [
-      "TakerGetsIssuer",
-      {
-        "nth": 4,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Hash160"
       }
     ],
     [
       "LedgerHash",
       {
-        "nth": 1,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
         "type": "Hash256"
       }
     ],
     [
       "ParentHash",
       {
-        "nth": 2,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
         "type": "Hash256"
       }
     ],
     [
       "TransactionHash",
       {
-        "nth": 3,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 3,
         "type": "Hash256"
       }
     ],
     [
       "AccountHash",
       {
-        "nth": 4,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 4,
         "type": "Hash256"
       }
     ],
     [
       "PreviousTxnID",
       {
-        "nth": 5,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 5,
         "type": "Hash256"
       }
     ],
     [
       "LedgerIndex",
       {
-        "nth": 6,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 6,
         "type": "Hash256"
       }
     ],
     [
       "WalletLocator",
       {
-        "nth": 7,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 7,
         "type": "Hash256"
       }
     ],
     [
       "RootIndex",
       {
-        "nth": 8,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 8,
         "type": "Hash256"
       }
     ],
     [
       "AccountTxnID",
       {
-        "nth": 9,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 9,
         "type": "Hash256"
       }
     ],
     [
       "NFTokenID",
       {
-        "nth": 10,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 10,
         "type": "Hash256"
       }
     ],
     [
       "EmitParentTxnID",
       {
-        "nth": 11,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 11,
         "type": "Hash256"
       }
     ],
     [
       "EmitNonce",
       {
-        "nth": 12,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 12,
         "type": "Hash256"
       }
     ],
     [
       "EmitHookHash",
       {
-        "nth": 13,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 13,
         "type": "Hash256"
       }
     ],
     [
       "AMMID",
       {
-        "nth": 14,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 14,
         "type": "Hash256"
       }
     ],
     [
       "BookDirectory",
       {
-        "nth": 16,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 16,
         "type": "Hash256"
       }
     ],
     [
       "InvoiceID",
       {
-        "nth": 17,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 17,
         "type": "Hash256"
       }
     ],
     [
       "Nickname",
       {
-        "nth": 18,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 18,
         "type": "Hash256"
       }
     ],
     [
       "Amendment",
       {
-        "nth": 19,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 19,
         "type": "Hash256"
       }
     ],
     [
       "Digest",
       {
-        "nth": 21,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 21,
         "type": "Hash256"
       }
     ],
     [
       "Channel",
       {
-        "nth": 22,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 22,
         "type": "Hash256"
       }
     ],
     [
       "ConsensusHash",
       {
-        "nth": 23,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 23,
         "type": "Hash256"
       }
     ],
     [
       "CheckID",
       {
-        "nth": 24,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 24,
         "type": "Hash256"
       }
     ],
     [
       "ValidatedHash",
       {
-        "nth": 25,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 25,
         "type": "Hash256"
       }
     ],
     [
       "PreviousPageMin",
       {
-        "nth": 26,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 26,
         "type": "Hash256"
       }
     ],
     [
       "NextPageMin",
       {
-        "nth": 27,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 27,
         "type": "Hash256"
       }
     ],
     [
       "NFTokenBuyOffer",
       {
-        "nth": 28,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 28,
         "type": "Hash256"
       }
     ],
     [
       "NFTokenSellOffer",
       {
-        "nth": 29,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 29,
         "type": "Hash256"
       }
     ],
     [
       "HookStateKey",
       {
-        "nth": 30,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 30,
         "type": "Hash256"
       }
     ],
     [
       "HookHash",
       {
-        "nth": 31,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 31,
         "type": "Hash256"
       }
     ],
     [
       "HookNamespace",
       {
-        "nth": 32,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 32,
         "type": "Hash256"
       }
     ],
     [
       "HookSetTxnID",
       {
-        "nth": 33,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 33,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "DomainID",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 34,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "hash",
+      {
+        "isSerialized": false,
+        "isSigningField": false,
+        "isVLEncoded": false,
+        "nth": 257,
+        "type": "Hash256"
+      }
+    ],
+    [
+      "index",
+      {
+        "isSerialized": false,
+        "isSigningField": false,
+        "isVLEncoded": false,
+        "nth": 258,
         "type": "Hash256"
       }
     ],
     [
       "Amount",
       {
-        "nth": 1,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
         "type": "Amount"
       }
     ],
     [
       "Balance",
       {
-        "nth": 2,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
         "type": "Amount"
       }
     ],
     [
       "LimitAmount",
       {
-        "nth": 3,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 3,
         "type": "Amount"
       }
     ],
     [
       "TakerPays",
       {
-        "nth": 4,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 4,
         "type": "Amount"
       }
     ],
     [
       "TakerGets",
       {
-        "nth": 5,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 5,
         "type": "Amount"
       }
     ],
     [
       "LowLimit",
       {
-        "nth": 6,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 6,
         "type": "Amount"
       }
     ],
     [
       "HighLimit",
       {
-        "nth": 7,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 7,
         "type": "Amount"
       }
     ],
     [
       "Fee",
       {
-        "nth": 8,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 8,
         "type": "Amount"
       }
     ],
     [
       "SendMax",
       {
-        "nth": 9,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 9,
         "type": "Amount"
       }
     ],
     [
       "DeliverMin",
       {
-        "nth": 10,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 10,
         "type": "Amount"
       }
     ],
     [
       "Amount2",
       {
-        "nth": 11,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 11,
         "type": "Amount"
       }
     ],
     [
       "BidMin",
       {
-        "nth": 12,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 12,
         "type": "Amount"
       }
     ],
     [
       "BidMax",
       {
-        "nth": 13,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 13,
         "type": "Amount"
       }
     ],
     [
       "MinimumOffer",
       {
-        "nth": 16,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 16,
         "type": "Amount"
       }
     ],
     [
       "RippleEscrow",
       {
-        "nth": 17,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 17,
         "type": "Amount"
       }
     ],
     [
       "DeliveredAmount",
       {
-        "nth": 18,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 18,
         "type": "Amount"
       }
     ],
     [
       "NFTokenBrokerFee",
       {
-        "nth": 19,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 19,
         "type": "Amount"
       }
     ],
     [
       "BaseFeeDrops",
       {
-        "nth": 22,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 22,
         "type": "Amount"
       }
     ],
     [
       "ReserveBaseDrops",
       {
-        "nth": 23,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 23,
         "type": "Amount"
       }
     ],
     [
       "ReserveIncrementDrops",
       {
-        "nth": 24,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 24,
         "type": "Amount"
       }
     ],
     [
       "LPTokenOut",
       {
-        "nth": 25,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 25,
         "type": "Amount"
       }
     ],
     [
       "LPTokenIn",
       {
-        "nth": 26,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 26,
         "type": "Amount"
       }
     ],
     [
       "EPrice",
       {
-        "nth": 27,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 27,
         "type": "Amount"
       }
     ],
     [
       "Price",
       {
-        "nth": 28,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 28,
         "type": "Amount"
       }
     ],
     [
       "SignatureReward",
       {
-        "nth": 29,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 29,
         "type": "Amount"
       }
     ],
     [
       "MinAccountCreateAmount",
       {
-        "nth": 30,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 30,
         "type": "Amount"
       }
     ],
     [
       "LPTokenBalance",
       {
-        "nth": 31,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 31,
         "type": "Amount"
       }
     ],
     [
       "PublicKey",
       {
-        "nth": 1,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 1,
         "type": "Blob"
       }
     ],
     [
       "MessageKey",
       {
-        "nth": 2,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 2,
         "type": "Blob"
       }
     ],
     [
       "SigningPubKey",
       {
-        "nth": 3,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 3,
         "type": "Blob"
       }
     ],
     [
       "TxnSignature",
       {
-        "nth": 4,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": false,
+        "isVLEncoded": true,
+        "nth": 4,
         "type": "Blob"
       }
     ],
     [
       "URI",
       {
-        "nth": 5,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 5,
         "type": "Blob"
       }
     ],
     [
       "Signature",
       {
-        "nth": 6,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": false,
+        "isVLEncoded": true,
+        "nth": 6,
         "type": "Blob"
       }
     ],
     [
       "Domain",
       {
-        "nth": 7,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 7,
         "type": "Blob"
       }
     ],
     [
       "FundCode",
       {
-        "nth": 8,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 8,
         "type": "Blob"
       }
     ],
     [
       "RemoveCode",
       {
-        "nth": 9,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 9,
         "type": "Blob"
       }
     ],
     [
       "ExpireCode",
       {
-        "nth": 10,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 10,
         "type": "Blob"
       }
     ],
     [
       "CreateCode",
       {
-        "nth": 11,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 11,
         "type": "Blob"
       }
     ],
     [
       "MemoType",
       {
-        "nth": 12,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 12,
         "type": "Blob"
       }
     ],
     [
       "MemoData",
       {
-        "nth": 13,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 13,
         "type": "Blob"
       }
     ],
     [
       "MemoFormat",
       {
-        "nth": 14,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 14,
         "type": "Blob"
       }
     ],
     [
       "Fulfillment",
       {
-        "nth": 16,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 16,
         "type": "Blob"
       }
     ],
     [
       "Condition",
       {
-        "nth": 17,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 17,
         "type": "Blob"
       }
     ],
     [
       "MasterSignature",
       {
-        "nth": 18,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": false,
+        "isVLEncoded": true,
+        "nth": 18,
         "type": "Blob"
       }
     ],
     [
       "UNLModifyValidator",
       {
-        "nth": 19,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 19,
         "type": "Blob"
       }
     ],
     [
       "ValidatorToDisable",
       {
-        "nth": 20,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 20,
         "type": "Blob"
       }
     ],
     [
       "ValidatorToReEnable",
       {
-        "nth": 21,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 21,
         "type": "Blob"
       }
     ],
     [
       "HookStateData",
       {
-        "nth": 22,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 22,
         "type": "Blob"
       }
     ],
     [
       "HookReturnString",
       {
-        "nth": 23,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 23,
         "type": "Blob"
       }
     ],
     [
       "HookParameterName",
       {
-        "nth": 24,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 24,
         "type": "Blob"
       }
     ],
     [
       "HookParameterValue",
       {
-        "nth": 25,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 25,
         "type": "Blob"
       }
     ],
     [
       "DIDDocument",
       {
-        "nth": 26,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 26,
         "type": "Blob"
       }
     ],
     [
       "Data",
       {
-        "nth": 27,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 27,
         "type": "Blob"
       }
     ],
     [
       "AssetClass",
       {
-        "nth": 28,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 28,
         "type": "Blob"
       }
     ],
     [
       "Provider",
       {
-        "nth": 29,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 29,
+        "type": "Blob"
+      }
+    ],
+    [
+      "MPTokenMetadata",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 30,
+        "type": "Blob"
+      }
+    ],
+    [
+      "CredentialType",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 31,
         "type": "Blob"
       }
     ],
     [
       "Account",
       {
-        "nth": 1,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 1,
         "type": "AccountID"
       }
     ],
     [
       "Owner",
       {
-        "nth": 2,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 2,
         "type": "AccountID"
       }
     ],
     [
       "Destination",
       {
-        "nth": 3,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 3,
         "type": "AccountID"
       }
     ],
     [
       "Issuer",
       {
-        "nth": 4,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 4,
         "type": "AccountID"
       }
     ],
     [
       "Authorize",
       {
-        "nth": 5,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 5,
         "type": "AccountID"
       }
     ],
     [
       "Unauthorize",
       {
-        "nth": 6,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 6,
         "type": "AccountID"
       }
     ],
     [
       "RegularKey",
       {
-        "nth": 8,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 8,
         "type": "AccountID"
       }
     ],
     [
       "NFTokenMinter",
       {
-        "nth": 9,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 9,
         "type": "AccountID"
       }
     ],
     [
       "EmitCallback",
       {
-        "nth": 10,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 10,
+        "type": "AccountID"
+      }
+    ],
+    [
+      "Holder",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 11,
         "type": "AccountID"
       }
     ],
     [
       "HookAccount",
       {
-        "nth": 16,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 16,
         "type": "AccountID"
       }
     ],
     [
       "OtherChainSource",
       {
-        "nth": 18,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 18,
         "type": "AccountID"
       }
     ],
     [
       "OtherChainDestination",
       {
-        "nth": 19,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 19,
         "type": "AccountID"
       }
     ],
     [
       "AttestationSignerAccount",
       {
-        "nth": 20,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 20,
         "type": "AccountID"
       }
     ],
     [
       "AttestationRewardAccount",
       {
-        "nth": 21,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 21,
         "type": "AccountID"
       }
     ],
     [
       "LockingChainDoor",
       {
-        "nth": 22,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 22,
         "type": "AccountID"
       }
     ],
     [
       "IssuingChainDoor",
       {
-        "nth": 23,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 23,
         "type": "AccountID"
       }
     ],
     [
-      "Indexes",
+      "Subject",
       {
-        "nth": 1,
+        "isSerialized": true,
+        "isSigningField": true,
         "isVLEncoded": true,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Vector256"
+        "nth": 24,
+        "type": "AccountID"
       }
     ],
     [
-      "Hashes",
+      "Number",
       {
-        "nth": 2,
-        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
-        "type": "Vector256"
-      }
-    ],
-    [
-      "Amendments",
-      {
-        "nth": 3,
-        "isVLEncoded": true,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Vector256"
-      }
-    ],
-    [
-      "NFTokenOffers",
-      {
-        "nth": 4,
-        "isVLEncoded": true,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Vector256"
-      }
-    ],
-    [
-      "Paths",
-      {
+        "isVLEncoded": false,
         "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "PathSet"
-      }
-    ],
-    [
-      "BaseAsset",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Currency"
-      }
-    ],
-    [
-      "QuoteAsset",
-      {
-        "nth": 2,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Currency"
-      }
-    ],
-    [
-      "LockingChainIssue",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Issue"
-      }
-    ],
-    [
-      "IssuingChainIssue",
-      {
-        "nth": 2,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Issue"
-      }
-    ],
-    [
-      "Asset",
-      {
-        "nth": 3,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Issue"
-      }
-    ],
-    [
-      "Asset2",
-      {
-        "nth": 4,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "Issue"
-      }
-    ],
-    [
-      "XChainBridge",
-      {
-        "nth": 1,
-        "isVLEncoded": false,
-        "isSerialized": true,
-        "isSigningField": true,
-        "type": "XChainBridge"
+        "type": "Number"
       }
     ],
     [
       "TransactionMetaData",
       {
-        "nth": 2,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
         "type": "STObject"
       }
     ],
     [
       "CreatedNode",
       {
-        "nth": 3,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 3,
         "type": "STObject"
       }
     ],
     [
       "DeletedNode",
       {
-        "nth": 4,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 4,
         "type": "STObject"
       }
     ],
     [
       "ModifiedNode",
       {
-        "nth": 5,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 5,
         "type": "STObject"
       }
     ],
     [
       "PreviousFields",
       {
-        "nth": 6,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 6,
         "type": "STObject"
       }
     ],
     [
       "FinalFields",
       {
-        "nth": 7,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 7,
         "type": "STObject"
       }
     ],
     [
       "NewFields",
       {
-        "nth": 8,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 8,
         "type": "STObject"
       }
     ],
     [
       "TemplateEntry",
       {
-        "nth": 9,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 9,
         "type": "STObject"
       }
     ],
     [
       "Memo",
       {
-        "nth": 10,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 10,
         "type": "STObject"
       }
     ],
     [
       "SignerEntry",
       {
-        "nth": 11,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 11,
         "type": "STObject"
       }
     ],
     [
       "NFToken",
       {
-        "nth": 12,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 12,
         "type": "STObject"
       }
     ],
     [
       "EmitDetails",
       {
-        "nth": 13,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 13,
         "type": "STObject"
       }
     ],
     [
       "Hook",
       {
-        "nth": 14,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 14,
         "type": "STObject"
       }
     ],
     [
       "Signer",
       {
-        "nth": 16,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 16,
         "type": "STObject"
       }
     ],
     [
       "Majority",
       {
-        "nth": 18,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 18,
         "type": "STObject"
       }
     ],
     [
       "DisabledValidator",
       {
-        "nth": 19,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 19,
         "type": "STObject"
       }
     ],
     [
       "EmittedTxn",
       {
-        "nth": 20,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 20,
         "type": "STObject"
       }
     ],
     [
       "HookExecution",
       {
-        "nth": 21,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 21,
         "type": "STObject"
       }
     ],
     [
       "HookDefinition",
       {
-        "nth": 22,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 22,
         "type": "STObject"
       }
     ],
     [
       "HookParameter",
       {
-        "nth": 23,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 23,
         "type": "STObject"
       }
     ],
     [
       "HookGrant",
       {
-        "nth": 24,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 24,
         "type": "STObject"
       }
     ],
     [
       "VoteEntry",
       {
-        "nth": 25,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 25,
         "type": "STObject"
       }
     ],
     [
       "AuctionSlot",
       {
-        "nth": 26,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 26,
         "type": "STObject"
       }
     ],
     [
       "AuthAccount",
       {
-        "nth": 27,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 27,
         "type": "STObject"
       }
     ],
     [
       "XChainClaimProofSig",
       {
-        "nth": 28,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 28,
         "type": "STObject"
       }
     ],
     [
       "XChainCreateAccountProofSig",
       {
-        "nth": 29,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 29,
         "type": "STObject"
       }
     ],
     [
       "XChainClaimAttestationCollectionElement",
       {
-        "nth": 30,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 30,
         "type": "STObject"
       }
     ],
     [
       "XChainCreateAccountAttestationCollectionElement",
       {
-        "nth": 31,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 31,
         "type": "STObject"
       }
     ],
     [
       "PriceData",
       {
-        "nth": 32,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 32,
+        "type": "STObject"
+      }
+    ],
+    [
+      "Credential",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 33,
         "type": "STObject"
       }
     ],
     [
       "Signers",
       {
-        "nth": 3,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": false,
+        "isVLEncoded": false,
+        "nth": 3,
         "type": "STArray"
       }
     ],
     [
       "SignerEntries",
       {
-        "nth": 4,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 4,
         "type": "STArray"
       }
     ],
     [
       "Template",
       {
-        "nth": 5,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 5,
         "type": "STArray"
       }
     ],
     [
       "Necessary",
       {
-        "nth": 6,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 6,
         "type": "STArray"
       }
     ],
     [
       "Sufficient",
       {
-        "nth": 7,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 7,
         "type": "STArray"
       }
     ],
     [
       "AffectedNodes",
       {
-        "nth": 8,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 8,
         "type": "STArray"
       }
     ],
     [
       "Memos",
       {
-        "nth": 9,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 9,
         "type": "STArray"
       }
     ],
     [
       "NFTokens",
       {
-        "nth": 10,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 10,
         "type": "STArray"
       }
     ],
     [
       "Hooks",
       {
-        "nth": 11,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 11,
         "type": "STArray"
       }
     ],
     [
       "VoteSlots",
       {
-        "nth": 12,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 12,
         "type": "STArray"
       }
     ],
     [
       "Majorities",
       {
-        "nth": 16,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 16,
         "type": "STArray"
       }
     ],
     [
       "DisabledValidators",
       {
-        "nth": 17,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 17,
         "type": "STArray"
       }
     ],
     [
       "HookExecutions",
       {
-        "nth": 18,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 18,
         "type": "STArray"
       }
     ],
     [
       "HookParameters",
       {
-        "nth": 19,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 19,
         "type": "STArray"
       }
     ],
     [
       "HookGrants",
       {
-        "nth": 20,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 20,
         "type": "STArray"
       }
     ],
     [
       "XChainClaimAttestations",
       {
-        "nth": 21,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 21,
         "type": "STArray"
       }
     ],
     [
       "XChainCreateAccountAttestations",
       {
-        "nth": 22,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 22,
         "type": "STArray"
       }
     ],
     [
       "PriceDataSeries",
       {
-        "nth": 24,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 24,
         "type": "STArray"
       }
     ],
     [
       "AuthAccounts",
       {
-        "nth": 25,
-        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 25,
         "type": "STArray"
+      }
+    ],
+    [
+      "AuthorizeCredentials",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 26,
+        "type": "STArray"
+      }
+    ],
+    [
+      "UnauthorizeCredentials",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 27,
+        "type": "STArray"
+      }
+    ],
+    [
+      "AcceptedCredentials",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 28,
+        "type": "STArray"
+      }
+    ],
+    [
+      "CloseResolution",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "Method",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "TransactionResult",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 3,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "Scale",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 4,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "AssetScale",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 5,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "TickSize",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 16,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "UNLModifyDisabling",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 17,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "HookResult",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 18,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "WasLockingChainSend",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 19,
+        "type": "UInt8"
+      }
+    ],
+    [
+      "TakerPaysCurrency",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
+        "type": "Hash160"
+      }
+    ],
+    [
+      "TakerPaysIssuer",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
+        "type": "Hash160"
+      }
+    ],
+    [
+      "TakerGetsCurrency",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 3,
+        "type": "Hash160"
+      }
+    ],
+    [
+      "TakerGetsIssuer",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 4,
+        "type": "Hash160"
+      }
+    ],
+    [
+      "Paths",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
+        "type": "PathSet"
+      }
+    ],
+    [
+      "Indexes",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 1,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "Hashes",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 2,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "Amendments",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 3,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "NFTokenOffers",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 4,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "CredentialIDs",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": true,
+        "nth": 5,
+        "type": "Vector256"
+      }
+    ],
+    [
+      "MPTokenIssuanceID",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
+        "type": "Hash192"
+      }
+    ],
+    [
+      "LockingChainIssue",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
+        "type": "Issue"
+      }
+    ],
+    [
+      "IssuingChainIssue",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
+        "type": "Issue"
+      }
+    ],
+    [
+      "Asset",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 3,
+        "type": "Issue"
+      }
+    ],
+    [
+      "Asset2",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 4,
+        "type": "Issue"
+      }
+    ],
+    [
+      "XChainBridge",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
+        "type": "XChainBridge"
+      }
+    ],
+    [
+      "BaseAsset",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 1,
+        "type": "Currency"
+      }
+    ],
+    [
+      "QuoteAsset",
+      {
+        "isSerialized": true,
+        "isSigningField": true,
+        "isVLEncoded": false,
+        "nth": 2,
+        "type": "Currency"
+      }
+    ],
+    [
+      "Transaction",
+      {
+        "isSerialized": false,
+        "isSigningField": false,
+        "isVLEncoded": false,
+        "nth": 257,
+        "type": "Transaction"
+      }
+    ],
+    [
+      "LedgerEntry",
+      {
+        "isSerialized": false,
+        "isSigningField": false,
+        "isVLEncoded": false,
+        "nth": 257,
+        "type": "LedgerEntry"
+      }
+    ],
+    [
+      "Validation",
+      {
+        "isSerialized": false,
+        "isSigningField": false,
+        "isVLEncoded": false,
+        "nth": 257,
+        "type": "Validation"
+      }
+    ],
+    [
+      "Metadata",
+      {
+        "isSerialized": false,
+        "isSigningField": false,
+        "isVLEncoded": false,
+        "nth": 257,
+        "type": "Metadata"
       }
     ]
   ],
+  "LEDGER_ENTRY_TYPES": {
+    "AMM": 121,
+    "AccountRoot": 97,
+    "Amendments": 102,
+    "Bridge": 105,
+    "Check": 67,
+    "Credential": 129,
+    "DID": 73,
+    "DepositPreauth": 112,
+    "DirectoryNode": 100,
+    "Escrow": 117,
+    "FeeSettings": 115,
+    "Invalid": -1,
+    "LedgerHashes": 104,
+    "MPToken": 127,
+    "MPTokenIssuance": 126,
+    "NFTokenOffer": 55,
+    "NFTokenPage": 80,
+    "NegativeUNL": 78,
+    "Offer": 111,
+    "Oracle": 128,
+    "PayChannel": 120,
+    "PermissionedDomain": 130,
+    "RippleState": 114,
+    "SignerList": 83,
+    "Ticket": 84,
+    "XChainOwnedClaimID": 113,
+    "XChainOwnedCreateAccountClaimID": 116
+  },
   "TRANSACTION_RESULTS": {
-    "telLOCAL_ERROR": -399,
+    "tecAMM_ACCOUNT": 168,
+    "tecAMM_BALANCE": 163,
+    "tecAMM_EMPTY": 166,
+    "tecAMM_FAILED": 164,
+    "tecAMM_INVALID_TOKENS": 165,
+    "tecAMM_NOT_EMPTY": 167,
+    "tecARRAY_EMPTY": 190,
+    "tecARRAY_TOO_LARGE": 191,
+    "tecBAD_CREDENTIALS": 193,
+    "tecCANT_ACCEPT_OWN_NFTOKEN_OFFER": 158,
+    "tecCLAIM": 100,
+    "tecCRYPTOCONDITION_ERROR": 146,
+    "tecDIR_FULL": 121,
+    "tecDST_TAG_NEEDED": 143,
+    "tecDUPLICATE": 149,
+    "tecEMPTY_DID": 187,
+    "tecEXPIRED": 148,
+    "tecFAILED_PROCESSING": 105,
+    "tecFROZEN": 137,
+    "tecHAS_OBLIGATIONS": 151,
+    "tecHOOK_REJECTED": 153,
+    "tecINCOMPLETE": 169,
+    "tecINSUFFICIENT_FUNDS": 159,
+    "tecINSUFFICIENT_PAYMENT": 161,
+    "tecINSUFFICIENT_RESERVE": 141,
+    "tecINSUFF_FEE": 136,
+    "tecINSUF_RESERVE_LINE": 122,
+    "tecINSUF_RESERVE_OFFER": 123,
+    "tecINTERNAL": 144,
+    "tecINVALID_UPDATE_TIME": 188,
+    "tecINVARIANT_FAILED": 147,
+    "tecKILLED": 150,
+    "tecLOCKED": 192,
+    "tecMAX_SEQUENCE_REACHED": 154,
+    "tecNEED_MASTER_KEY": 142,
+    "tecNFTOKEN_BUY_SELL_MISMATCH": 156,
+    "tecNFTOKEN_OFFER_TYPE_MISMATCH": 157,
+    "tecNO_ALTERNATIVE_KEY": 130,
+    "tecNO_AUTH": 134,
+    "tecNO_DST": 124,
+    "tecNO_DST_INSUF_XRP": 125,
+    "tecNO_ENTRY": 140,
+    "tecNO_ISSUER": 133,
+    "tecNO_LINE": 135,
+    "tecNO_LINE_INSUF_RESERVE": 126,
+    "tecNO_LINE_REDUNDANT": 127,
+    "tecNO_PERMISSION": 139,
+    "tecNO_REGULAR_KEY": 131,
+    "tecNO_SUITABLE_NFTOKEN_PAGE": 155,
+    "tecNO_TARGET": 138,
+    "tecOBJECT_NOT_FOUND": 160,
+    "tecOVERSIZE": 145,
+    "tecOWNERS": 132,
+    "tecPATH_DRY": 128,
+    "tecPATH_PARTIAL": 101,
+    "tecTOKEN_PAIR_NOT_FOUND": 189,
+    "tecTOO_SOON": 152,
+    "tecUNFUNDED": 129,
+    "tecUNFUNDED_ADD": 102,
+    "tecUNFUNDED_AMM": 162,
+    "tecUNFUNDED_OFFER": 103,
+    "tecUNFUNDED_PAYMENT": 104,
+    "tecXCHAIN_ACCOUNT_CREATE_PAST": 181,
+    "tecXCHAIN_ACCOUNT_CREATE_TOO_MANY": 182,
+    "tecXCHAIN_BAD_CLAIM_ID": 172,
+    "tecXCHAIN_BAD_PUBLIC_KEY_ACCOUNT_PAIR": 185,
+    "tecXCHAIN_BAD_TRANSFER_ISSUE": 170,
+    "tecXCHAIN_CLAIM_NO_QUORUM": 173,
+    "tecXCHAIN_CREATE_ACCOUNT_DISABLED": 186,
+    "tecXCHAIN_CREATE_ACCOUNT_NONXRP_ISSUE": 175,
+    "tecXCHAIN_INSUFF_CREATE_AMOUNT": 180,
+    "tecXCHAIN_NO_CLAIM_ID": 171,
+    "tecXCHAIN_NO_SIGNERS_LIST": 178,
+    "tecXCHAIN_PAYMENT_FAILED": 183,
+    "tecXCHAIN_PROOF_UNKNOWN_KEY": 174,
+    "tecXCHAIN_REWARD_MISMATCH": 177,
+    "tecXCHAIN_SELF_COMMIT": 184,
+    "tecXCHAIN_SENDING_ACCOUNT_MISMATCH": 179,
+    "tecXCHAIN_WRONG_CHAIN": 176,
+
+    "tefALREADY": -198,
+    "tefBAD_ADD_AUTH": -197,
+    "tefBAD_AUTH": -196,
+    "tefBAD_AUTH_MASTER": -183,
+    "tefBAD_LEDGER": -195,
+    "tefBAD_QUORUM": -185,
+    "tefBAD_SIGNATURE": -186,
+    "tefCREATED": -194,
+    "tefEXCEPTION": -193,
+    "tefFAILURE": -199,
+    "tefINTERNAL": -192,
+    "tefINVALID_LEDGER_FIX_TYPE": -178,
+    "tefINVARIANT_FAILED": -182,
+    "tefMASTER_DISABLED": -188,
+    "tefMAX_LEDGER": -187,
+    "tefNFTOKEN_IS_NOT_TRANSFERABLE": -179,
+    "tefNOT_MULTI_SIGNING": -184,
+    "tefNO_AUTH_REQUIRED": -191,
+    "tefNO_TICKET": -180,
+    "tefPAST_SEQ": -190,
+    "tefTOO_BIG": -181,
+    "tefWRONG_PRIOR": -189,
+
     "telBAD_DOMAIN": -398,
     "telBAD_PATH_COUNT": -397,
     "telBAD_PUBLIC_KEY": -396,
-    "telFAILED_PROCESSING": -395,
-    "telINSUF_FEE_P": -394,
-    "telNO_DST_PARTIAL": -393,
     "telCAN_NOT_QUEUE": -392,
     "telCAN_NOT_QUEUE_BALANCE": -391,
-    "telCAN_NOT_QUEUE_BLOCKS": -390,
     "telCAN_NOT_QUEUE_BLOCKED": -389,
+    "telCAN_NOT_QUEUE_BLOCKS": -390,
     "telCAN_NOT_QUEUE_FEE": -388,
     "telCAN_NOT_QUEUE_FULL": -387,
-    "telWRONG_NETWORK": -386,
-    "telREQUIRES_NETWORK_ID": -385,
-    "telNETWORK_ID_MAKES_TX_NON_CANONICAL": -384,
     "telENV_RPC_FAILED": -383,
+    "telFAILED_PROCESSING": -395,
+    "telINSUF_FEE_P": -394,
+    "telLOCAL_ERROR": -399,
+    "telNETWORK_ID_MAKES_TX_NON_CANONICAL": -384,
+    "telNO_DST_PARTIAL": -393,
+    "telREQUIRES_NETWORK_ID": -385,
+    "telWRONG_NETWORK": -386,
 
-    "temMALFORMED": -299,
+    "temARRAY_EMPTY": -253,
+    "temARRAY_TOO_LARGE": -252,
+    "temBAD_AMM_TOKENS": -261,
     "temBAD_AMOUNT": -298,
     "temBAD_CURRENCY": -297,
     "temBAD_EXPIRATION": -296,
     "temBAD_FEE": -295,
     "temBAD_ISSUER": -294,
     "temBAD_LIMIT": -293,
+    "temBAD_NFTOKEN_TRANSFER_FEE": -262,
     "temBAD_OFFER": -292,
     "temBAD_PATH": -291,
     "temBAD_PATH_LOOP": -290,
+    "temBAD_QUORUM": -271,
     "temBAD_REGKEY": -289,
     "temBAD_SEND_XRP_LIMIT": -288,
     "temBAD_SEND_XRP_MAX": -287,
@@ -2778,204 +3044,140 @@
     "temBAD_SEND_XRP_PATHS": -284,
     "temBAD_SEQUENCE": -283,
     "temBAD_SIGNATURE": -282,
+    "temBAD_SIGNER": -272,
     "temBAD_SRC_ACCOUNT": -281,
+    "temBAD_TICK_SIZE": -269,
+    "temBAD_TRANSFER_FEE": -251,
     "temBAD_TRANSFER_RATE": -280,
+    "temBAD_WEIGHT": -270,
+    "temCANNOT_PREAUTH_SELF": -267,
+    "temDISABLED": -273,
     "temDST_IS_SRC": -279,
     "temDST_NEEDED": -278,
+    "temEMPTY_DID": -254,
     "temINVALID": -277,
+    "temINVALID_ACCOUNT_ID": -268,
+    "temINVALID_COUNT": -266,
     "temINVALID_FLAG": -276,
+    "temMALFORMED": -299,
     "temREDUNDANT": -275,
     "temRIPPLE_EMPTY": -274,
-    "temDISABLED": -273,
-    "temBAD_SIGNER": -272,
-    "temBAD_QUORUM": -271,
-    "temBAD_WEIGHT": -270,
-    "temBAD_TICK_SIZE": -269,
-    "temINVALID_ACCOUNT_ID": -268,
-    "temCANNOT_PREAUTH_SELF": -267,
-    "temINVALID_COUNT": -266,
+    "temSEQ_AND_TICKET": -263,
     "temUNCERTAIN": -265,
     "temUNKNOWN": -264,
-    "temSEQ_AND_TICKET": -263,
-    "temBAD_NFTOKEN_TRANSFER_FEE": -262,
-    "temBAD_AMM_TOKENS": -261,
-    "temXCHAIN_EQUAL_DOOR_ACCOUNTS": -260,
     "temXCHAIN_BAD_PROOF": -259,
     "temXCHAIN_BRIDGE_BAD_ISSUES": -258,
-    "temXCHAIN_BRIDGE_NONDOOR_OWNER": -257,
     "temXCHAIN_BRIDGE_BAD_MIN_ACCOUNT_CREATE_AMOUNT": -256,
     "temXCHAIN_BRIDGE_BAD_REWARD_AMOUNT": -255,
-    "temEMPTY_DID": -254,
-    "temARRAY_EMPTY": -253,
-    "temARRAY_TOO_LARGE": -252,
+    "temXCHAIN_BRIDGE_NONDOOR_OWNER": -257,
+    "temXCHAIN_EQUAL_DOOR_ACCOUNTS": -260,
 
-    "tefFAILURE": -199,
-    "tefALREADY": -198,
-    "tefBAD_ADD_AUTH": -197,
-    "tefBAD_AUTH": -196,
-    "tefBAD_LEDGER": -195,
-    "tefCREATED": -194,
-    "tefEXCEPTION": -193,
-    "tefINTERNAL": -192,
-    "tefNO_AUTH_REQUIRED": -191,
-    "tefPAST_SEQ": -190,
-    "tefWRONG_PRIOR": -189,
-    "tefMASTER_DISABLED": -188,
-    "tefMAX_LEDGER": -187,
-    "tefBAD_SIGNATURE": -186,
-    "tefBAD_QUORUM": -185,
-    "tefNOT_MULTI_SIGNING": -184,
-    "tefBAD_AUTH_MASTER": -183,
-    "tefINVARIANT_FAILED": -182,
-    "tefTOO_BIG": -181,
-    "tefNO_TICKET": -180,
-    "tefNFTOKEN_IS_NOT_TRANSFERABLE": -179,
-
-    "terRETRY": -99,
     "terFUNDS_SPENT": -98,
     "terINSUF_FEE_B": -97,
+    "terLAST": -91,
     "terNO_ACCOUNT": -96,
+    "terNO_AMM": -87,
     "terNO_AUTH": -95,
     "terNO_LINE": -94,
+    "terNO_RIPPLE": -90,
     "terOWNERS": -93,
     "terPRE_SEQ": -92,
-    "terLAST": -91,
-    "terNO_RIPPLE": -90,
-    "terQUEUED": -89,
     "terPRE_TICKET": -88,
-    "terNO_AMM": -87,
+    "terQUEUED": -89,
+    "terRETRY": -99,
 
-    "tesSUCCESS": 0,
-
-    "tecCLAIM": 100,
-    "tecPATH_PARTIAL": 101,
-    "tecUNFUNDED_ADD": 102,
-    "tecUNFUNDED_OFFER": 103,
-    "tecUNFUNDED_PAYMENT": 104,
-    "tecFAILED_PROCESSING": 105,
-    "tecDIR_FULL": 121,
-    "tecINSUF_RESERVE_LINE": 122,
-    "tecINSUF_RESERVE_OFFER": 123,
-    "tecNO_DST": 124,
-    "tecNO_DST_INSUF_XRP": 125,
-    "tecNO_LINE_INSUF_RESERVE": 126,
-    "tecNO_LINE_REDUNDANT": 127,
-    "tecPATH_DRY": 128,
-    "tecUNFUNDED": 129,
-    "tecNO_ALTERNATIVE_KEY": 130,
-    "tecNO_REGULAR_KEY": 131,
-    "tecOWNERS": 132,
-    "tecNO_ISSUER": 133,
-    "tecNO_AUTH": 134,
-    "tecNO_LINE": 135,
-    "tecINSUFF_FEE": 136,
-    "tecFROZEN": 137,
-    "tecNO_TARGET": 138,
-    "tecNO_PERMISSION": 139,
-    "tecNO_ENTRY": 140,
-    "tecINSUFFICIENT_RESERVE": 141,
-    "tecNEED_MASTER_KEY": 142,
-    "tecDST_TAG_NEEDED": 143,
-    "tecINTERNAL": 144,
-    "tecOVERSIZE": 145,
-    "tecCRYPTOCONDITION_ERROR": 146,
-    "tecINVARIANT_FAILED": 147,
-    "tecEXPIRED": 148,
-    "tecDUPLICATE": 149,
-    "tecKILLED": 150,
-    "tecHAS_OBLIGATIONS": 151,
-    "tecTOO_SOON": 152,
-    "tecHOOK_REJECTED": 153,
-    "tecMAX_SEQUENCE_REACHED": 154,
-    "tecNO_SUITABLE_NFTOKEN_PAGE": 155,
-    "tecNFTOKEN_BUY_SELL_MISMATCH": 156,
-    "tecNFTOKEN_OFFER_TYPE_MISMATCH": 157,
-    "tecCANT_ACCEPT_OWN_NFTOKEN_OFFER": 158,
-    "tecINSUFFICIENT_FUNDS": 159,
-    "tecOBJECT_NOT_FOUND": 160,
-    "tecINSUFFICIENT_PAYMENT": 161,
-    "tecUNFUNDED_AMM": 162,
-    "tecAMM_BALANCE": 163,
-    "tecAMM_FAILED": 164,
-    "tecAMM_INVALID_TOKENS": 165,
-    "tecAMM_EMPTY": 166,
-    "tecAMM_NOT_EMPTY": 167,
-    "tecAMM_ACCOUNT": 168,
-    "tecINCOMPLETE": 169,
-    "tecXCHAIN_BAD_TRANSFER_ISSUE": 170,
-    "tecXCHAIN_NO_CLAIM_ID": 171,
-    "tecXCHAIN_BAD_CLAIM_ID": 172,
-    "tecXCHAIN_CLAIM_NO_QUORUM": 173,
-    "tecXCHAIN_PROOF_UNKNOWN_KEY": 174,
-    "tecXCHAIN_CREATE_ACCOUNT_NONXRP_ISSUE": 175,
-    "tecXCHAIN_WRONG_CHAIN": 176,
-    "tecXCHAIN_REWARD_MISMATCH": 177,
-    "tecXCHAIN_NO_SIGNERS_LIST": 178,
-    "tecXCHAIN_SENDING_ACCOUNT_MISMATCH": 179,
-    "tecXCHAIN_INSUFF_CREATE_AMOUNT": 180,
-    "tecXCHAIN_ACCOUNT_CREATE_PAST": 181,
-    "tecXCHAIN_ACCOUNT_CREATE_TOO_MANY": 182,
-    "tecXCHAIN_PAYMENT_FAILED": 183,
-    "tecXCHAIN_SELF_COMMIT": 184,
-    "tecXCHAIN_BAD_PUBLIC_KEY_ACCOUNT_PAIR": 185,
-    "tecXCHAIN_CREATE_ACCOUNT_DISABLED": 186,
-    "tecEMPTY_DID": 187,
-    "tecINVALID_UPDATE_TIME": 188,
-    "tecTOKEN_PAIR_NOT_FOUND": 189,
-    "tecARRAY_EMPTY": 190,
-    "tecARRAY_TOO_LARGE": 191
+    "tesSUCCESS": 0
   },
   "TRANSACTION_TYPES": {
-    "Invalid": -1,
-    "Payment": 0,
+    "AMMBid": 39,
+    "AMMClawback": 31,
+    "AMMCreate": 35,
+    "AMMDelete": 40,
+    "AMMDeposit": 36,
+    "AMMVote": 38,
+    "AMMWithdraw": 37,
+    "AccountDelete": 21,
+    "AccountSet": 3,
+    "CheckCancel": 18,
+    "CheckCash": 17,
+    "CheckCreate": 16,
+    "Clawback": 30,
+    "CredentialAccept": 59,
+    "CredentialCreate": 58,
+    "CredentialDelete": 60,
+    "DIDDelete": 50,
+    "DIDSet": 49,
+    "DepositPreauth": 19,
+    "EnableAmendment": 100,
+    "EscrowCancel": 4,
     "EscrowCreate": 1,
     "EscrowFinish": 2,
-    "AccountSet": 3,
-    "EscrowCancel": 4,
-    "SetRegularKey": 5,
-    "NickNameSet": 6,
-    "OfferCreate": 7,
+    "Invalid": -1,
+    "LedgerStateFix": 53,
+    "MPTokenAuthorize": 57,
+    "MPTokenIssuanceCreate": 54,
+    "MPTokenIssuanceDestroy": 55,
+    "MPTokenIssuanceSet": 56,
+    "NFTokenAcceptOffer": 29,
+    "NFTokenBurn": 26,
+    "NFTokenCancelOffer": 28,
+    "NFTokenCreateOffer": 27,
+    "NFTokenMint": 25,
+    "NFTokenModify": 61,
     "OfferCancel": 8,
-    "Contract": 9,
-    "TicketCreate": 10,
-    "TicketCancel": 11,
-    "SignerListSet": 12,
+    "OfferCreate": 7,
+    "OracleDelete": 52,
+    "OracleSet": 51,
+    "Payment": 0,
+    "PaymentChannelClaim": 15,
     "PaymentChannelCreate": 13,
     "PaymentChannelFund": 14,
-    "PaymentChannelClaim": 15,
-    "CheckCreate": 16,
-    "CheckCash": 17,
-    "CheckCancel": 18,
-    "DepositPreauth": 19,
-    "TrustSet": 20,
-    "AccountDelete": 21,
-    "SetHook": 22,
-    "NFTokenMint": 25,
-    "NFTokenBurn": 26,
-    "NFTokenCreateOffer": 27,
-    "NFTokenCancelOffer": 28,
-    "NFTokenAcceptOffer": 29,
-    "Clawback": 30,
-    "AMMCreate": 35,
-    "AMMDeposit": 36,
-    "AMMWithdraw": 37,
-    "AMMVote": 38,
-    "AMMBid": 39,
-    "AMMDelete": 40,
-    "XChainCreateClaimID": 41,
-    "XChainCommit": 42,
-    "XChainClaim": 43,
-    "XChainAccountCreateCommit": 44,
-    "XChainAddClaimAttestation": 45,
-    "XChainAddAccountCreateAttestation": 46,
-    "XChainModifyBridge": 47,
-    "XChainCreateBridge": 48,
-    "DIDSet": 49,
-    "DIDDelete": 50,
-    "OracleSet": 51,
-    "OracleDelete": 52,
-    "EnableAmendment": 100,
+    "PermissionedDomainDelete": 63,
+    "PermissionedDomainSet": 62,
     "SetFee": 101,
-    "UNLModify": 102
+    "SetRegularKey": 5,
+    "SignerListSet": 12,
+    "TicketCreate": 10,
+    "TrustSet": 20,
+    "UNLModify": 102,
+    "XChainAccountCreateCommit": 44,
+    "XChainAddAccountCreateAttestation": 46,
+    "XChainAddClaimAttestation": 45,
+    "XChainClaim": 43,
+    "XChainCommit": 42,
+    "XChainCreateBridge": 48,
+    "XChainCreateClaimID": 41,
+    "XChainModifyBridge": 47
+  },
+  "TYPES": {
+    "AccountID": 8,
+    "Amount": 6,
+    "Blob": 7,
+    "Currency": 26,
+    "Done": -1,
+    "Hash128": 4,
+    "Hash160": 17,
+    "Hash192": 21,
+    "Hash256": 5,
+    "Issue": 24,
+    "LedgerEntry": 10002,
+    "Metadata": 10004,
+    "NotPresent": 0,
+    "Number": 9,
+    "PathSet": 18,
+    "STArray": 15,
+    "STObject": 14,
+    "Transaction": 10001,
+    "UInt16": 1,
+    "UInt32": 2,
+    "UInt384": 22,
+    "UInt512": 23,
+    "UInt64": 3,
+    "UInt8": 16,
+    "UInt96": 20,
+    "Unknown": -2,
+    "Validation": 10003,
+    "Vector256": 19,
+    "XChainBridge": 25
   }
 }

--- a/xrpl4j-core/src/main/resources/definitions.json
+++ b/xrpl4j-core/src/main/resources/definitions.json
@@ -913,20 +913,20 @@
     [
       "IssuerNode",
       {
+        "nth": 27,
+        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "isVLEncoded": false,
-        "nth": 27,
         "type": "UInt64"
       }
     ],
     [
       "SubjectNode",
       {
+        "nth": 28,
+        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "isVLEncoded": false,
-        "nth": 28,
         "type": "UInt64"
       }
     ],
@@ -1253,10 +1253,10 @@
     [
       "DomainID",
       {
+        "nth": 34,
+        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "isVLEncoded": false,
-        "nth": 34,
         "type": "Hash256"
       }
     ],
@@ -1843,10 +1843,10 @@
     [
       "CredentialType",
       {
+        "nth": 31,
+        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
-        "isVLEncoded": true,
-        "nth": 31,
         "type": "Blob"
       }
     ],
@@ -2023,21 +2023,11 @@
     [
       "Subject",
       {
-        "isSerialized": true,
-        "isSigningField": true,
-        "isVLEncoded": true,
         "nth": 24,
-        "type": "AccountID"
-      }
-    ],
-    [
-      "Number",
-      {
+        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
-        "isVLEncoded": false,
-        "nth": 1,
-        "type": "Number"
+        "type": "AccountID"
       }
     ],
     [
@@ -2333,10 +2323,10 @@
     [
       "Credential",
       {
+        "nth": 33,
+        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "isVLEncoded": false,
-        "nth": 33,
         "type": "STObject"
       }
     ],
@@ -2533,32 +2523,31 @@
     [
       "AuthorizeCredentials",
       {
+        "nth": 26,
+        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "isVLEncoded": false,
-        "nth": 26,
         "type": "STArray"
       }
     ],
     [
       "UnauthorizeCredentials",
       {
+        "nth": 27,
+        "isVLEncoded": false,
         "isSerialized": true,
         "isSigningField": true,
-        "isVLEncoded": false,
-        "nth": 27,
         "type": "STArray"
       }
     ],
     [
-      "AcceptedCredentials",
-      {
-        "isSerialized": true,
-        "isSigningField": true,
-        "isVLEncoded": false,
-        "nth": 28,
-        "type": "STArray"
-      }
+      "AcceptedCredentials", {
+      "nth": 28,
+      "isVLEncoded": false,
+      "isSerialized": true,
+      "isSigningField": true,
+      "type": "STArray"
+    }
     ],
     [
       "CloseResolution",
@@ -2743,10 +2732,10 @@
     [
       "CredentialIDs",
       {
+        "nth": 5,
+        "isVLEncoded": true,
         "isSerialized": true,
         "isSigningField": true,
-        "isVLEncoded": true,
-        "nth": 5,
         "type": "Vector256"
       }
     ],
@@ -2877,7 +2866,6 @@
     "Amendments": 102,
     "Bridge": 105,
     "Check": 67,
-    "Credential": 129,
     "DID": 73,
     "DepositPreauth": 112,
     "DirectoryNode": 100,
@@ -2892,6 +2880,7 @@
     "NegativeUNL": 78,
     "Offer": 111,
     "Oracle": 128,
+    "Credential": 129,
     "PayChannel": 120,
     "PermissionedDomain": 130,
     "RippleState": 114,
@@ -2921,7 +2910,6 @@
     "tecFAILED_PROCESSING": 105,
     "tecFROZEN": 137,
     "tecHAS_OBLIGATIONS": 151,
-    "tecHOOK_REJECTED": 153,
     "tecINCOMPLETE": 169,
     "tecINSUFFICIENT_FUNDS": 159,
     "tecINSUFFICIENT_PAYMENT": 161,
@@ -2980,7 +2968,6 @@
     "tecXCHAIN_SELF_COMMIT": 184,
     "tecXCHAIN_SENDING_ACCOUNT_MISMATCH": 179,
     "tecXCHAIN_WRONG_CHAIN": 176,
-
     "tefALREADY": -198,
     "tefBAD_ADD_AUTH": -197,
     "tefBAD_AUTH": -196,
@@ -3003,7 +2990,6 @@
     "tefPAST_SEQ": -190,
     "tefTOO_BIG": -181,
     "tefWRONG_PRIOR": -189,
-
     "telBAD_DOMAIN": -398,
     "telBAD_PATH_COUNT": -397,
     "telBAD_PUBLIC_KEY": -396,
@@ -3021,7 +3007,6 @@
     "telNO_DST_PARTIAL": -393,
     "telREQUIRES_NETWORK_ID": -385,
     "telWRONG_NETWORK": -386,
-
     "temARRAY_EMPTY": -253,
     "temARRAY_TOO_LARGE": -252,
     "temBAD_AMM_TOKENS": -261,
@@ -3071,7 +3056,6 @@
     "temXCHAIN_BRIDGE_BAD_REWARD_AMOUNT": -255,
     "temXCHAIN_BRIDGE_NONDOOR_OWNER": -257,
     "temXCHAIN_EQUAL_DOOR_ACCOUNTS": -260,
-
     "terFUNDS_SPENT": -98,
     "terINSUF_FEE_B": -97,
     "terLAST": -91,
@@ -3085,7 +3069,6 @@
     "terPRE_TICKET": -88,
     "terQUEUED": -89,
     "terRETRY": -99,
-
     "tesSUCCESS": 0
   },
   "TRANSACTION_TYPES": {
@@ -3102,8 +3085,8 @@
     "CheckCash": 17,
     "CheckCreate": 16,
     "Clawback": 30,
-    "CredentialAccept": 59,
     "CredentialCreate": 58,
+    "CredentialAccept": 59,
     "CredentialDelete": 60,
     "DIDDelete": 50,
     "DIDSet": 49,
@@ -3132,8 +3115,8 @@
     "PaymentChannelClaim": 15,
     "PaymentChannelCreate": 13,
     "PaymentChannelFund": 14,
-    "PermissionedDomainDelete": 63,
     "PermissionedDomainSet": 62,
+    "PermissionedDomainDelete": 63,
     "SetFee": 101,
     "SetRegularKey": 5,
     "SignerListSet": 12,
@@ -3163,7 +3146,6 @@
     "LedgerEntry": 10002,
     "Metadata": 10004,
     "NotPresent": 0,
-    "Number": 9,
     "PathSet": 18,
     "STArray": 15,
     "STObject": 14,

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtilsTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtilsTest.java
@@ -846,7 +846,7 @@ public class SignatureUtilsTest {
 
   @Test
   void addSignatureToAmmClawback() {
-    AmmClawback ammCreate = AmmClawback.builder()
+    AmmClawback ammClawback = AmmClawback.builder()
         .account(sourcePublicKey.deriveAddress())
         .holder(sourcePublicKey.deriveAddress())
         .amount(
@@ -868,7 +868,7 @@ public class SignatureUtilsTest {
         .signingPublicKey(sourcePublicKey)
         .build();
 
-    addSignatureToTransactionHelper(ammCreate);
+    addSignatureToTransactionHelper(ammClawback);
   }
 
   @Test

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtilsTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtilsTest.java
@@ -61,6 +61,7 @@ import org.xrpl.xrpl4j.model.transactions.AccountDelete;
 import org.xrpl.xrpl4j.model.transactions.AccountSet;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.AmmBid;
+import org.xrpl.xrpl4j.model.transactions.AmmClawback;
 import org.xrpl.xrpl4j.model.transactions.AmmCreate;
 import org.xrpl.xrpl4j.model.transactions.AmmDelete;
 import org.xrpl.xrpl4j.model.transactions.AmmDeposit;
@@ -839,6 +840,33 @@ public class SignatureUtilsTest {
       .tradingFee(TradingFee.of(UnsignedInteger.valueOf(500)))
       .signingPublicKey(sourcePublicKey)
       .build();
+
+    addSignatureToTransactionHelper(ammCreate);
+  }
+
+  @Test
+  void addSignatureToAmmClawback() {
+    AmmClawback ammCreate = AmmClawback.builder()
+        .account(sourcePublicKey.deriveAddress())
+        .holder(sourcePublicKey.deriveAddress())
+        .amount(
+            IssuedCurrencyAmount.builder()
+                .currency("TST")
+                .issuer(Address.of("rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"))
+                .value("25")
+                .build()
+        )
+        .asset(Issue.XRP)
+        .asset2(
+            Issue.builder()
+                .issuer(Address.of("rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"))
+                .currency("TST")
+                .build()
+        )
+        .fee(XrpCurrencyAmount.ofDrops(10))
+        .sequence(UnsignedInteger.valueOf(6))
+        .signingPublicKey(sourcePublicKey)
+        .build();
 
     addSignatureToTransactionHelper(ammCreate);
   }

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/AmmClawbackTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/AmmClawbackTest.java
@@ -1,0 +1,138 @@
+package org.xrpl.xrpl4j.model.transactions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.primitives.UnsignedInteger;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.crypto.keys.PublicKey;
+import org.xrpl.xrpl4j.model.AbstractJsonTest;
+import org.xrpl.xrpl4j.model.flags.AmmClawbackTransactionFlags;
+import org.xrpl.xrpl4j.model.flags.TransactionFlags;
+import org.xrpl.xrpl4j.model.ledger.Issue;
+
+public class AmmClawbackTest extends AbstractJsonTest {
+
+  @Test
+  void testJson() throws JSONException, JsonProcessingException {
+    AmmClawback ammClawback = AmmClawback.builder()
+        .account(Address.of("rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm"))
+        .amount(
+            IssuedCurrencyAmount.builder()
+                .currency("TST")
+                .issuer(Address.of("rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"))
+                .value("25")
+                .build()
+        )
+        .asset(Issue.builder().currency("TST").issuer(Address.of("rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd")).build())
+        .asset2(Issue.builder().currency("TST").issuer(Address.of("rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd")).build())
+        .holder(Address.of("rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm"))
+        .fee(XrpCurrencyAmount.ofDrops(10))
+        .sequence(UnsignedInteger.valueOf(6))
+        .signingPublicKey(
+            PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
+        )
+        .build();
+
+    String json = "{\n" +
+        "    \"Account\" : \"rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm\",\n" +
+        "    \"Amount\" : {\n" +
+        "        \"currency\" : \"TST\",\n" +
+        "        \"issuer\" : \"rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd\",\n" +
+        "        \"value\" : \"25\"\n" +
+        "    },\n" +
+        "    \"Asset\" : {\n" +
+        "        \"currency\" : \"TST\",\n" +
+        "        \"issuer\" : \"rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd\"\n" +
+        "    },\n" +
+        "    \"Asset2\" : {\n" +
+        "        \"currency\" : \"TST\",\n" +
+        "        \"issuer\" : \"rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd\"\n" +
+        "    },\n" +
+        "    \"Holder\" : \"rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm\",\n" +
+        "    \"Fee\" : \"10\",\n" +
+        "    \"Sequence\" : 6,\n" +
+        "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+        "    \"TransactionType\" : \"AMMClawback\"\n" +
+        "}";
+
+    assertCanSerializeAndDeserialize(ammClawback, json);
+  }
+
+  @Test
+  void testJsonWithUnsetFlags() throws JSONException, JsonProcessingException {
+    AmmClawback ammClawback = AmmClawback.builder()
+        .account(Address.of("rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm"))
+        .amount(
+            IssuedCurrencyAmount.builder()
+                .currency("TST")
+                .issuer(Address.of("rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"))
+                .value("25")
+                .build()
+        )
+        .holder(Address.of("rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm"))
+        .fee(XrpCurrencyAmount.ofDrops(10))
+        .sequence(UnsignedInteger.valueOf(6))
+        .signingPublicKey(
+            PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
+        )
+        .flags(TransactionFlags.UNSET)
+        .build();
+
+    String json = "{\n" +
+        "    \"Account\" : \"rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm\",\n" +
+        "    \"Amount\" : {\n" +
+        "        \"currency\" : \"TST\",\n" +
+        "        \"issuer\" : \"rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd\",\n" +
+        "        \"value\" : \"25\"\n" +
+        "    },\n" +
+        "    \"Holder\" : \"rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm\",\n" +
+        "    \"Flags\" : 0,\n" +
+        "    \"Fee\" : \"10\",\n" +
+        "    \"Sequence\" : 6,\n" +
+        "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+        "    \"TransactionType\" : \"AMMClawback\"\n" +
+        "}";
+
+    assertCanSerializeAndDeserialize(ammClawback, json);
+  }
+
+  @Test
+  void testJsonWithNonZeroFlags() throws JSONException, JsonProcessingException {
+    AmmClawbackTransactionFlags.Builder builder = new AmmClawbackTransactionFlags.Builder();
+
+    AmmClawback ammClawback = AmmClawback.builder()
+        .account(Address.of("rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm"))
+        .amount(
+            IssuedCurrencyAmount.builder()
+                .currency("TST")
+                .issuer(Address.of("rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"))
+                .value("25")
+                .build()
+        )
+        .holder(Address.of("rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm"))
+        .fee(XrpCurrencyAmount.ofDrops(10))
+        .sequence(UnsignedInteger.valueOf(6))
+        .signingPublicKey(
+            PublicKey.fromBase16EncodedPublicKey("02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC")
+        )
+        .flags(builder.tfClawTwoAssets().build())
+        .build();
+
+    String json = "{\n" +
+        "    \"Account\" : \"rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm\",\n" +
+        "    \"Amount\" : {\n" +
+        "        \"currency\" : \"TST\",\n" +
+        "        \"issuer\" : \"rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd\",\n" +
+        "        \"value\" : \"25\"\n" +
+        "    },\n" +
+        "    \"Holder\" : \"rJVUeRqDFNs2xqA7ncVE6ZoAhPUoaJJSQm\",\n" +
+        "    \"Flags\" : 343243252524,\n" +
+        "    \"Fee\" : \"10\",\n" +
+        "    \"Sequence\" : 6,\n" +
+        "    \"SigningPubKey\" : \"02356E89059A75438887F9FEE2056A2890DB82A68353BE9C0C0C8F89C0018B37FC\",\n" +
+        "    \"TransactionType\" : \"AMMClawback\"\n" +
+        "}";
+
+    assertCanSerializeAndDeserialize(ammClawback, json);
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/TransactionTypeTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/TransactionTypeTests.java
@@ -101,6 +101,7 @@ public class TransactionTypeTests {
     assertThat(TransactionType.CLAWBACK.value()).isEqualTo("Clawback");
     assertThat(TransactionType.AMM_BID.value()).isEqualTo("AMMBid");
     assertThat(TransactionType.AMM_CREATE.value()).isEqualTo("AMMCreate");
+    assertThat(TransactionType.AMM_CLAWBACK.value()).isEqualTo("AMMClawback");
     assertThat(TransactionType.AMM_DEPOSIT.value()).isEqualTo("AMMDeposit");
     assertThat(TransactionType.AMM_VOTE.value()).isEqualTo("AMMVote");
     assertThat(TransactionType.AMM_WITHDRAW.value()).isEqualTo("AMMWithdraw");

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AmmIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AmmIT.java
@@ -263,10 +263,6 @@ public class AmmIT extends AbstractIT {
       .flags(AmmWithdrawFlags.SINGLE_ASSET)
       .build();
 
-    String x = withdraw.toString();
-
-    System.out.println(x);
-
     SingleSignedTransaction<AmmWithdraw> signedWithdraw = signatureService.sign(traderKeyPair.privateKey(), withdraw);
 
     SubmitResult<AmmWithdraw> voteSubmitResult = xrplClient.submit(signedWithdraw);

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AmmIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AmmIT.java
@@ -646,7 +646,7 @@ public class AmmIT extends AbstractIT {
     return ammInfoResult;
   }
 
-  public void enableRippling(KeyPair issuerKeyPair, AccountInfoResult issuerAccount, FeeResult feeResult)
+  private void enableRippling(KeyPair issuerKeyPair, AccountInfoResult issuerAccount, FeeResult feeResult)
     throws JsonRpcClientErrorException, JsonProcessingException {
     AccountSet accountSet = AccountSet.builder()
       .account(issuerKeyPair.publicKey().deriveAddress())

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/RippledContainer.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/RippledContainer.java
@@ -69,7 +69,7 @@ public class RippledContainer {
    * No-args constructor.
    */
   public RippledContainer() {
-    rippledContainer = new GenericContainer<>("rippleci/rippled:2.2.0-rc3")
+    rippledContainer = new GenericContainer<>("rippleci/rippled:2.3.0")
       .withCreateContainerCmdModifier((Consumer<CreateContainerCmd>) (cmd) ->
         cmd.withEntrypoint("/opt/ripple/bin/rippled"))
       .withCommand("-a --start --conf /config/rippled.cfg")


### PR DESCRIPTION
Opened a Draft MR to see if I am doing something wrong with how I am setting up the integration tests using AMMClawback.

I saw there was a `createAMM` method, but I noticed in the AMMClawback docs that a flag (Allow Trustline Clawback) needed to be enabled in order to use this new transaction. In my integration test, I do the following:

1. enable rippling
2. enable this Allow Trustline Clawback flag
3. create a trustline from trader wallet to issuer wallet for "TST"
4. create a trustline from trader wallet to issuer wallet for "ZFT"
5. send "ZFT" from issuer wallet to trader wallet
6. send "TST" from issuer wallet to trader wallet
7. create an AMMCreate transaction with `amount` being `100` "ZFT", and `amount2` being `250` "TST"

i get back:
```
org.opentest4j.AssertionFailedError: 
expected: "tesSUCCESS"
 but was: "tecNO_PERMISSION"
Expected :"tesSUCCESS"
Actual   :"tecNO_PERMISSION"
```

I see that the error code mentions the following:
```
tecNO_PERMISSION | At least one of the deposit assets cannot be used in an AMM.
```

i have tried a few different currency options, but no luck

i have also been able to do this same transaction with the xrpl.js library using all the same values, except what gets autofilled from their `submitAndWait` function. Any idea what I could be doing wrong?
