### PR TITLE
Fix GitHub actions (#583)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'oracle'
+          distribution: 'temurin'
           java-version: '8'
           cache: 'maven'
       - name: Build
@@ -35,7 +35,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          distribution: 'oracle'
+          distribution: 'temurin'
           java-version: '21'
           cache: 'maven'
       # Set up Android
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         # test against each major Java version
-        java: [ 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 ]
+        java: [ 11, 15, 16, 17, 21, 23 ]
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
-          distribution: 'oracle'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build
@@ -67,11 +67,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      # Set up Adopt OpenJDK Hotspot 16
-      - name: Set up OpenJDK 16
+      # Set up Temurin 21
+      - name: Set up OpenJDK 21
         uses: actions/setup-java@v4
         with:
-          distribution: 'oracle'
+          distribution: 'temurin'
           java-version: 21
           cache: 'maven'
       # Maven install with JVM locale = de_DE
@@ -87,7 +87,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'oracle'
+          distribution: 'temurin'
           java-version: '8'
           cache: 'maven'
       - name: Build
@@ -102,7 +102,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'oracle'
+          distribution: 'temurin'
           java-version: '8'
           cache: 'maven' # setup-java v4 includes maven caching
       - name: Build
@@ -116,7 +116,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'oracle'
+          distribution: 'temurin'
           java-version: '8'
           cache: 'maven'
       - name: Build

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,17 +31,16 @@ jobs:
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
+      # Set up Java 17
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: '21'
+          cache: 'maven'
       # Set up Android
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
-      - name: Cache mvn dependencies
-        uses: actions/cache@v4
-        env:
-          cache-name: mvn-deps
-        with:
-          path: ~/.m2
-          key: ${{ env.cache-name }}-${{ hashFiles('pom.xml') }}
-          restore-keys: ${{ env.cache-name }}-
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -Pandroid
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,24 +25,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
-  build_android:
-    runs-on: ubuntu-latest
-    steps:
-      # Checks-out the repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v4
-      # Set up Java 17
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'
-      # Set up Android
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-      - name: Build
-        run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -Pandroid
-
   build_jdk_temurin_other:
     runs-on: ubuntu-latest
     strategy:
@@ -76,6 +58,24 @@ jobs:
       # Maven install with JVM locale = de_DE
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DargLine="-Duser.language=de -Duser.country=DE"
+
+  build_android:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out the repository under $GITHUB_WORKSPACE
+      - uses: actions/checkout@v4
+      # Set up Java 17
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      # Set up Android
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+      - name: Build
+        run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -Pandroid
 
   build_devnet_its:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: 'oracle'
           java-version: '8'
           cache: 'maven'
       - name: Build
@@ -35,7 +35,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: 'oracle'
           java-version: '21'
           cache: 'maven'
       # Set up Android
@@ -57,7 +57,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: 'oracle'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build
@@ -71,7 +71,7 @@ jobs:
       - name: Set up OpenJDK 16
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: 'oracle'
           java-version: 21
           cache: 'maven'
       # Maven install with JVM locale = de_DE
@@ -87,7 +87,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: 'oracle'
           java-version: '8'
           cache: 'maven'
       - name: Build
@@ -102,7 +102,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: 'oracle'
           java-version: '8'
           cache: 'maven' # setup-java v4 includes maven caching
       - name: Build
@@ -116,7 +116,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: 'oracle'
           java-version: '8'
           cache: 'maven'
       - name: Build

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
           cache: 'maven'
       - name: Build
@@ -35,7 +35,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '21'
           cache: 'maven'
       # Set up Android
@@ -57,7 +57,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build
@@ -71,7 +71,7 @@ jobs:
       - name: Set up OpenJDK 16
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 21
           cache: 'maven'
       # Maven install with JVM locale = de_DE
@@ -87,7 +87,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
           cache: 'maven'
       - name: Build
@@ -102,7 +102,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
           cache: 'maven' # setup-java v4 includes maven caching
       - name: Build
@@ -116,7 +116,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
           cache: 'maven'
       - name: Build

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,13 +1,12 @@
 name: xrpl4j-CI
 
-
 on:
   push:
   pull_request:
     types: [ assigned ]
 jobs:
-  build_java8:
-    runs-on: ubuntu-20.04
+  build_jdk_temurin_8:
+    runs-on: ubuntu-latest
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
@@ -27,7 +26,7 @@ jobs:
           fail_ci_if_error: true
 
   build_android:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
@@ -44,11 +43,11 @@ jobs:
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -Pandroid
 
-  build_other_java:
-    runs-on: ubuntu-20.04
+  build_jdk_temurin_other:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        # test against each major Java version
+        # test against each major Java version (Java 8 built separately above for codecov upload)
         java: [ 11, 16, 17, 21 ]
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
@@ -63,12 +62,12 @@ jobs:
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true
 
-  build_open_jdk_non_us:
-    runs-on: ubuntu-20.04
+  build_jdk_temurin_non_us:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       # Set up Temurin 21
-      - name: Set up OpenJDK 21
+      - name: Set up Temurin v21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -79,7 +78,7 @@ jobs:
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DargLine="-Duser.language=de -Duser.country=DE"
 
   build_devnet_its:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
@@ -94,7 +93,7 @@ jobs:
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DuseDevnet
 
   build_testnet_reporting_its:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
@@ -107,8 +106,9 @@ jobs:
           cache: 'maven' # setup-java v4 includes maven caching
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DuseTestnet
+
   build_testnet_clio_its:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,26 +25,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
-  build_jdk_temurin_8_mac:
-    runs-on: macos-latest
-    steps:
-      # Checks-out the repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v4
-      # Set up Java 8
-      - name: Set up JDK 8
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '8'
-          cache: 'maven'
-      - name: Build
-        run: mvn dependency:go-offline install
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v3.1.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-
   build_jdk_semeru_8:
     runs-on: ubuntu-latest
     steps:
@@ -108,6 +88,21 @@ jobs:
       # Maven install with JVM locale = de_DE
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DargLine="-Duser.language=de -Duser.country=DE"
+
+  build_jdk_temurin_mac:
+    runs-on: macos-latest
+    steps:
+      # Checks-out the repository under $GITHUB_WORKSPACE
+      - uses: actions/checkout@v4
+      # Set up Java 21
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      - name: Build
+        run: mvn dependency:go-offline install
 
   build_android:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,11 +12,11 @@ jobs:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
       # Set up Java 8
-      - name: Set up JDK 1.8
+      - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: '1.8'
+          java-version: '8'
           cache: 'maven'
       - name: Build
         run: mvn dependency:go-offline install
@@ -85,11 +85,11 @@ jobs:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
       # Set up Java 8
-      - name: Set up JDK 1.8
+      - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: '1.8'
+          java-version: '8'
           cache: 'maven'
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DuseDevnet
@@ -100,11 +100,11 @@ jobs:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
       # Set up Java 8
-      - name: Set up JDK 1.8
+      - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: '1.8'
+          java-version: '8'
           cache: 'maven' # setup-java v4 includes maven caching
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DuseTestnet
@@ -114,11 +114,11 @@ jobs:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4
       # Set up Java 8
-      - name: Set up JDK 1.8
+      - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: '1.8'
+          java-version: '8'
           cache: 'maven'
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DuseClioTestnet -DuseClioMainnet

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,26 +4,20 @@ name: xrpl4j-CI
 on:
   push:
   pull_request:
-    types: [assigned]
+    types: [ assigned ]
 jobs:
   build_java8:
     runs-on: ubuntu-20.04
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Set up Java 8
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
-      - name: Cache mvn dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: mvn-deps
-        with:
-          path: ~/.m2
-          key: ${{ env.cache-name }}-${{ hashFiles('pom.xml') }}
-          restore-keys: ${{ env.cache-name }}-
+          distribution: 'adopt'
+          java-version: '1.8'
+          cache: 'maven'
       - name: Build
         run: mvn dependency:go-offline install
       - name: Upload to Codecov
@@ -36,12 +30,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Set up Android
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
+        uses: android-actions/setup-android@v3
       - name: Cache mvn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: mvn-deps
         with:
@@ -56,44 +50,31 @@ jobs:
     strategy:
       matrix:
         # test against each major Java version
-        java: [ 9, 10, 11, 12, 13, 14, 15, 16, 17 ]
+        java: [ 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 ]
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Set up Java version
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'adopt'
           java-version: ${{ matrix.java }}
-      - name: Cache mvn dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: mvn-deps
-        with:
-          path: ~/.m2
-          key: ${{ env.cache-name }}-${{ hashFiles('pom.xml') }}
-          restore-keys: ${{ env.cache-name }}-
+          cache: 'maven'
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true
 
   build_open_jdk_non_us:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Set up Adopt OpenJDK Hotspot 16
       - name: Set up OpenJDK 16
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          distribution: adopt
-          java-version: 16
-      - name: Cache mvn dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: mvn-deps
-        with:
-          path: ~/.m2
-          key: ${{ env.cache-name }}-${{ hashFiles('pom.xml') }}
-          restore-keys: ${{ env.cache-name }}-
+          distribution: 'adopt'
+          java-version: 21
+          cache: 'maven'
       # Maven install with JVM locale = de_DE
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DargLine="-Duser.language=de -Duser.country=DE"
@@ -102,20 +83,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Set up Java 8
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
-      - name: Cache mvn dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: mvn-deps
-        with:
-          path: ~/.m2
-          key: ${{ env.cache-name }}-${{ hashFiles('pom.xml') }}
-          restore-keys: ${{ env.cache-name }}-
+          distribution: 'adopt'
+          java-version: '1.8'
+          cache: 'maven'
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DuseDevnet
 
@@ -123,39 +98,27 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Set up Java 8
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
-      - name: Cache mvn dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: mvn-deps
-        with:
-          path: ~/.m2
-          key: ${{ env.cache-name }}-${{ hashFiles('pom.xml') }}
-          restore-keys: ${{ env.cache-name }}-
+          distribution: 'adopt'
+          java-version: '1.8'
+          cache: 'maven' # setup-java v4 includes maven caching
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DuseTestnet
   build_testnet_clio_its:
     runs-on: ubuntu-20.04
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Set up Java 8
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
-      - name: Cache mvn dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: mvn-deps
-        with:
-          path: ~/.m2
-          key: ${{ env.cache-name }}-${{ hashFiles('pom.xml') }}
-          restore-keys: ${{ env.cache-name }}-
+          distribution: 'adopt'
+          java-version: '1.8'
+          cache: 'maven'
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DuseClioTestnet -DuseClioMainnet

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -60,20 +60,20 @@ jobs:
       - name: Build
         run: mvn dependency:go-offline install
 
-    build_jdk_zulu_8:
-      runs-on: ubuntu-latest
-      steps:
-        # Checks-out the repository under $GITHUB_WORKSPACE
-        - uses: actions/checkout@v4
-        # Set up Java 8
-        - name: Set up JDK 8
-          uses: actions/setup-java@v4
-          with:
-            distribution: 'zulu'
-            java-version: '8'
-            cache: 'maven'
-        - name: Build
-          run: mvn dependency:go-offline install
+  build_jdk_zulu_8:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out the repository under $GITHUB_WORKSPACE
+      - uses: actions/checkout@v4
+      # Set up Java 8
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+          cache: 'maven'
+      - name: Build
+        run: mvn dependency:go-offline install
 
   build_jdk_temurin_other:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         # test against each major Java version
-        java: [ 11, 16, 17, 21, 23 ]
+        java: [ 11, 16, 17, 21 ]
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         # test against each major Java version
-        java: [ 11, 15, 16, 17, 21, 23 ]
+        java: [ 11, 16, 17, 21, 23 ]
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,6 +25,56 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
+  build_jdk_temurin_8_mac:
+    runs-on: macos-latest
+    steps:
+      # Checks-out the repository under $GITHUB_WORKSPACE
+      - uses: actions/checkout@v4
+      # Set up Java 8
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
+      - name: Build
+        run: mvn dependency:go-offline install
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+
+  build_jdk_semeru_8:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out the repository under $GITHUB_WORKSPACE
+      - uses: actions/checkout@v4
+      # Set up Java 8
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'semeru'
+          java-version: '8'
+          cache: 'maven'
+      - name: Build
+        run: mvn dependency:go-offline install
+
+    build_jdk_zulu_8:
+      runs-on: ubuntu-latest
+      steps:
+        # Checks-out the repository under $GITHUB_WORKSPACE
+        - uses: actions/checkout@v4
+        # Set up Java 8
+        - name: Set up JDK 8
+          uses: actions/setup-java@v4
+          with:
+            distribution: 'zulu'
+            java-version: '8'
+            cache: 'maven'
+        - name: Build
+          run: mvn dependency:go-offline install
+
   build_jdk_temurin_other:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -89,21 +89,6 @@ jobs:
       - name: Build
         run: mvn dependency:go-offline install -Dmaven.javadoc.skip=true -DargLine="-Duser.language=de -Duser.country=DE"
 
-  build_jdk_temurin_mac:
-    runs-on: macos-latest
-    steps:
-      # Checks-out the repository under $GITHUB_WORKSPACE
-      - uses: actions/checkout@v4
-      # Set up Java 21
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'
-      - name: Build
-        run: mvn dependency:go-offline install
-
   build_android:
     runs-on: ubuntu-latest
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
 
     <cryptoconditions.version>1.0.4</cryptoconditions.version>
     <jackson.version>2.14.2</jackson.version>
-    <feign.version>13.5</feign.version>
+    <feign.version>12.3</feign.version>
     <slf4j.version>2.0.7</slf4j.version>
     <junit-jupiter.version>5.10.1</junit-jupiter.version>
     <guava.version>32.1.1-jre</guava.version>
@@ -505,7 +505,7 @@
         <plugin>
           <groupId>org.sonatype.central</groupId>
           <artifactId>central-publishing-maven-plugin</artifactId>
-          <version>0.7.0</version>
+          <version>0.5.0</version>
           <extensions>true</extensions>
           <configuration>
             <publishingServerId>central</publishingServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
 
     <cryptoconditions.version>1.0.4</cryptoconditions.version>
     <jackson.version>2.14.2</jackson.version>
-    <feign.version>12.3</feign.version>
+    <feign.version>13.5</feign.version>
     <slf4j.version>2.0.7</slf4j.version>
     <junit-jupiter.version>5.10.1</junit-jupiter.version>
     <guava.version>32.1.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -505,7 +505,7 @@
         <plugin>
           <groupId>org.sonatype.central</groupId>
           <artifactId>central-publishing-maven-plugin</artifactId>
-          <version>0.5.0</version>
+          <version>0.7.0</version>
           <extensions>true</extensions>
           <configuration>
             <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
Fixes #583 and #599 by updating the following:

* Update to `actions/checkout@v4` which remove the need for `actions/cache`.
* Update to `actions/setup-java@v4` 
* Update to `temurin` as the primary distribution for the `actions/setup-java` action.
* Update deprected `ubuntu-20.04` to `ubuntu-latest` per [this](https://github.com/actions/runner-images).

NOTE [this announcement](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down) that describes how `actions/cache` will gradually fail through 2/18/2025 to prod project updates.