### PR TITLE
Update only `actions/cache`

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Cache mvn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: mvn-deps
         with:
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
       - name: Cache mvn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: mvn-deps
         with:
@@ -66,7 +66,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Cache mvn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: mvn-deps
         with:
@@ -87,7 +87,7 @@ jobs:
           distribution: adopt
           java-version: 16
       - name: Cache mvn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: mvn-deps
         with:
@@ -109,7 +109,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Cache mvn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: mvn-deps
         with:
@@ -130,7 +130,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Cache mvn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: mvn-deps
         with:
@@ -150,7 +150,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Cache mvn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: mvn-deps
         with:


### PR DESCRIPTION
Fix the current Github Brownout build failure due to old `actions/cache` (read more [here](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)).