### PR TITLE
Remove Clio Devnet from ITs

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/ServerInfoIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/ServerInfoIT.java
@@ -91,12 +91,6 @@ public class ServerInfoIT {
       reportingModeServerInfo -> fail("Shouldn't be a Reporting server")
     );
 
-    // Ripple Devnet (Clio)
-    getXrplClient(HttpUrl.parse("https://clio.devnet.rippletest.net:51234/")).serverInformation().info().handle(
-      rippledServerInfo -> fail("Shouldn't be a rippled server"),
-      this::assertValidNetworkId,
-      reportingModeServerInfo -> fail("Shouldn't be a Reporting server")
-    );
   }
 
   private String getType(ServerInfo info) {


### PR DESCRIPTION
This devnet is failing due to TLS issues with a new webserver. This test currently runs against Clio in Testnet and Mainnet, which is sufficient enough to mean we don’t need to test against this removed Clio Devnet endpoint.