### PR TITLE
Use rippleci/xrpld Docker image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,12 +179,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>com.github.docker-java</groupId>
-        <artifactId>docker-java-api</artifactId>
-        <version>3.7.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest</artifactId>
         <version>2.2</version>

--- a/xrpl4j-integration-tests/pom.xml
+++ b/xrpl4j-integration-tests/pom.xml
@@ -44,11 +44,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.docker-java</groupId>
-      <artifactId>docker-java-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <scope>test</scope>

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/RippledContainer.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/RippledContainer.java
@@ -22,7 +22,6 @@ package org.xrpl.xrpl4j.tests.environment;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
-import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.google.common.base.Preconditions;
 import okhttp3.HttpUrl;
 import org.awaitility.Awaitility;
@@ -82,14 +81,13 @@ public class RippledContainer {
    * No-args constructor.
    */
   public RippledContainer() {
-    try (GenericContainer<?> container = new GenericContainer<>("rippleci/rippled:develop")) {
-      this.rippledContainer = container.withCreateContainerCmdModifier((Consumer<CreateContainerCmd>) (cmd) ->
-          cmd.withEntrypoint("/opt/xrpld/bin/xrpld"))
-        .withCommand("-a --start --conf /config/xrpld.cfg")
+    try (GenericContainer<?> container = new GenericContainer<>("rippleci/xrpld:develop")) {
+      this.rippledContainer = container
+        .withCommand("--standalone")
         .withExposedPorts(5005)
         .withImagePullPolicy(PullPolicy.alwaysPull())
         .withClasspathResourceMapping("xrpld",
-          "/config",
+          "/etc/opt/xrpld/",
           BindMode.READ_ONLY)
         .waitingFor(new LogMessageWaitStrategy().withRegEx(".*Application starting.*"));
     }

--- a/xrpl4j-integration-tests/src/test/resources/xrpld/xrpld.cfg
+++ b/xrpl4j-integration-tests/src/test/resources/xrpld/xrpld.cfg
@@ -66,7 +66,7 @@ small
 
 [node_db]
 type=NuDB
-path=/var/lib/rippled/db/nudb
+path=/var/lib/xrpld/db/nudb
 advisory_delete=0
 
 # How many ledgers do we want to keep (history)?
@@ -81,10 +81,10 @@ online_delete=2000
 #256
 
 [database_path]
-/var/lib/rippled/db
+/var/lib/xrpld/db
 
 [debug_logfile]
-/var/log/rippled/debug.log
+/var/log/xrpld/debug.log
 
 [sntp_servers]
 time.windows.com


### PR DESCRIPTION
Updates `RippledContainer` and test config to be compatible with the `rippleci/xrpld:develop` Docker image.

### Changes

1. Docker image: rippleci/rippled:develop → rippleci/xrpld:develop
2. Command: Replaced custom entrypoint/command with --standalone
3. Config mount: /config → /etc/opt/xrpld/ (matches image's expected config location)
4. xrpld.cfg: Updated filesystem paths from **/var/lib/rippled/** to **/var/lib/xrpld/** and **/var/log/rippled/** to **/var/log/xrpld/** to match the image's directory structure
5. Removed unused docker-java-api dependency from both parent and integration-tests pom.xml