### PR TITLE
Disable BatchTransactionIT on Devnet

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/BatchTransactionIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/BatchTransactionIT.java
@@ -70,7 +70,8 @@ import java.util.stream.Collectors;
 public class BatchTransactionIT extends AbstractIT {
 
   static boolean shouldNotRun() {
-    return System.getProperty("useTestnet") != null ||
+    return System.getProperty("useDevnet") != null ||
+      System.getProperty("useTestnet") != null ||
       System.getProperty("useClioTestnet") != null;
   }
 


### PR DESCRIPTION
`Batch` amendment is disabled on Devnet. Skip `BatchTransactionIT` to avoid CI failures and unintended PR merge blockers.