### PR TITLE
Add  Amount/TokenAmount

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/IouAmountDeserializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/IouAmountDeserializer.java
@@ -1,0 +1,68 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.xrpl.xrpl4j.model.transactions.amount.IouAmount;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson deserializer for {@link IouAmount}.
+ *
+ * <p>Reads a bare JSON string containing the decimal or scientific-notation value
+ * (e.g. {@code "100.50"} or {@code "1.23e10"}) and constructs an {@link IouAmount} via {@link IouAmount#of(String)}.
+ */
+public class IouAmountDeserializer extends StdDeserializer<IouAmount> {
+
+  /**
+   * No-args constructor.
+   */
+  public IouAmountDeserializer() {
+    super(IouAmount.class);
+  }
+
+  @Override
+  public IouAmount deserialize(
+    final JsonParser jsonParser,
+    final DeserializationContext ctxt
+  ) throws IOException {
+    return fromString(jsonParser.getValueAsString());
+  }
+
+  /**
+   * Construct an {@link IouAmount} from a raw decimal or scientific-notation string
+   * (e.g. {@code "100.50"} or {@code "1.23e10"}).
+   *
+   * <p>Extracted as a package-private static so that {@link IouTokenAmountDeserializer} can
+   * reuse the same parsing logic when reading the {@code "value"} field of a JSON object
+   * without needing to synthesize a sub-{@link JsonParser}.
+   *
+   * @param raw The raw string value. Must not be null.
+   *
+   * @return An {@link IouAmount}.
+   */
+  static IouAmount fromString(final String raw) {
+    return IouAmount.of(raw);
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/IouAmountSerializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/IouAmountSerializer.java
@@ -1,0 +1,54 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+import org.xrpl.xrpl4j.model.transactions.amount.IouAmount;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson serializer for {@link IouAmount}.
+ *
+ * <p>Writes the IOU value as a bare JSON string (e.g. {@code "100.50"} or {@code "1.23e10"}),
+ * matching the scalar representation used when an {@link IouAmount} appears as a standalone field (e.g. in Single Asset
+ * Vault fields).
+ */
+public class IouAmountSerializer extends StdScalarSerializer<IouAmount> {
+
+  /**
+   * No-args constructor.
+   */
+  public IouAmountSerializer() {
+    super(IouAmount.class, false);
+  }
+
+  @Override
+  public void serialize(
+    final IouAmount iouAmount,
+    final JsonGenerator gen,
+    final SerializerProvider provider
+  ) throws IOException {
+    gen.writeString(iouAmount.value());
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/IouTokenAmountDeserializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/IouTokenAmountDeserializer.java
@@ -1,0 +1,62 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.amount.IouTokenAmount;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson deserializer for {@link IouTokenAmount}.
+ *
+ * <p>Reads the wire format {@code {"value":"...","currency":"...","issuer":"..."}} and constructs
+ * an {@link IouTokenAmount}. The {@code value} field is parsed via
+ * {@link IouAmountDeserializer#fromString(String)}, so any change to how
+ * {@link org.xrpl.xrpl4j.model.transactions.amount.IouAmount} deserializes is automatically
+ * reflected here.
+ */
+public class IouTokenAmountDeserializer extends StdDeserializer<IouTokenAmount> {
+
+  /**
+   * No-args constructor.
+   */
+  public IouTokenAmountDeserializer() {
+    super(IouTokenAmount.class);
+  }
+
+  @Override
+  public IouTokenAmount deserialize(
+    final JsonParser jsonParser,
+    final DeserializationContext ctxt
+  ) throws IOException {
+    JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+    return IouTokenAmount.builder()
+      .amount(IouAmountDeserializer.fromString(node.get("value").asText()))
+      .currency(node.get("currency").asText())
+      .issuer(Address.of(node.get("issuer").asText()))
+      .build();
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/IouTokenAmountSerializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/IouTokenAmountSerializer.java
@@ -1,0 +1,61 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.xrpl.xrpl4j.model.transactions.amount.IouTokenAmount;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson serializer for {@link IouTokenAmount}.
+ *
+ * <p>Writes the XRPL wire format {@code {"value":"...","currency":"...","issuer":"..."}}.
+ * The {@code value} field is written by delegating to {@link IouAmountSerializer}, so any change to how
+ * {@link org.xrpl.xrpl4j.model.transactions.amount.IouAmount} serializes is automatically reflected here.
+ */
+public class IouTokenAmountSerializer extends StdSerializer<IouTokenAmount> {
+
+  private static final IouAmountSerializer AMOUNT_SERIALIZER = new IouAmountSerializer();
+
+  /**
+   * No-args constructor.
+   */
+  public IouTokenAmountSerializer() {
+    super(IouTokenAmount.class);
+  }
+
+  @Override
+  public void serialize(
+    final IouTokenAmount iouTokenAmount,
+    final JsonGenerator gen,
+    final SerializerProvider provider
+  ) throws IOException {
+    gen.writeStartObject();
+    gen.writeFieldName("value");
+    AMOUNT_SERIALIZER.serialize(iouTokenAmount.amount(), gen, provider);
+    gen.writeStringField("currency", iouTokenAmount.currency());
+    gen.writeStringField("issuer", iouTokenAmount.issuer().value());
+    gen.writeEndObject();
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/MptAmountDeserializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/MptAmountDeserializer.java
@@ -1,0 +1,72 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.google.common.primitives.UnsignedLong;
+import org.xrpl.xrpl4j.model.transactions.amount.MptAmount;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson deserializer for {@link MptAmount}.
+ *
+ * <p>Reads a bare JSON string containing the integer value, optionally prefixed with {@code -}
+ * (e.g. {@code "1000"} or {@code "-500"}), and constructs an {@link MptAmount} via
+ * {@link MptAmount#of(UnsignedLong, boolean)}.
+ */
+public class MptAmountDeserializer extends StdDeserializer<MptAmount> {
+
+  /**
+   * No-args constructor.
+   */
+  public MptAmountDeserializer() {
+    super(MptAmount.class);
+  }
+
+  @Override
+  public MptAmount deserialize(
+    final JsonParser jsonParser,
+    final DeserializationContext ctxt
+  ) throws IOException {
+    return fromString(jsonParser.getValueAsString());
+  }
+
+  /**
+   * Construct an {@link MptAmount} from a raw decimal-integer string, optionally prefixed with
+   * {@code -} (e.g. {@code "1000"} or {@code "-500"}).
+   *
+   * <p>Extracted as a package-private static so that {@link MptTokenAmountDeserializer} can
+   * reuse the same parsing logic when reading the {@code "value"} field of a JSON object
+   * without needing to synthesize a sub-{@link JsonParser}.
+   *
+   * @param raw The raw string value. Must not be null.
+   *
+   * @return An {@link MptAmount}.
+   */
+  static MptAmount fromString(final String raw) {
+    final boolean isNegative = raw.startsWith("-");
+    final UnsignedLong magnitude = UnsignedLong.valueOf(isNegative ? raw.substring(1) : raw);
+    return MptAmount.of(magnitude, isNegative);
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/MptAmountSerializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/MptAmountSerializer.java
@@ -1,0 +1,53 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+import org.xrpl.xrpl4j.model.transactions.amount.MptAmount;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson serializer for {@link MptAmount}.
+ *
+ * <p>Writes the MPT value as a bare JSON string (e.g. {@code "1000"} or {@code "-500"}),
+ * matching the scalar representation used when an {@link MptAmount} appears as a standalone field.
+ */
+public class MptAmountSerializer extends StdScalarSerializer<MptAmount> {
+
+  /**
+   * No-args constructor.
+   */
+  public MptAmountSerializer() {
+    super(MptAmount.class, false);
+  }
+
+  @Override
+  public void serialize(
+    final MptAmount mptAmount,
+    final JsonGenerator gen,
+    final SerializerProvider provider
+  ) throws IOException {
+    gen.writeString(mptAmount.value());
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/MptTokenAmountDeserializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/MptTokenAmountDeserializer.java
@@ -1,0 +1,60 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.xrpl.xrpl4j.model.transactions.MpTokenIssuanceId;
+import org.xrpl.xrpl4j.model.transactions.amount.MptTokenAmount;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson deserializer for {@link MptTokenAmount}.
+ *
+ * <p>Reads the wire format {@code {"value":"...","mpt_issuance_id":"..."}} and constructs
+ * an {@link MptTokenAmount}. The {@code value} field is parsed via {@link MptAmountDeserializer#fromString(String)}, so
+ * any change to how {@link org.xrpl.xrpl4j.model.transactions.amount.MptAmount} deserializes is automatically reflected
+ * here.
+ */
+public class MptTokenAmountDeserializer extends StdDeserializer<MptTokenAmount> {
+
+  /**
+   * No-args constructor.
+   */
+  public MptTokenAmountDeserializer() {
+    super(MptTokenAmount.class);
+  }
+
+  @Override
+  public MptTokenAmount deserialize(
+    final JsonParser jsonParser,
+    final DeserializationContext ctxt
+  ) throws IOException {
+    JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+    return MptTokenAmount.builder()
+      .amount(MptAmountDeserializer.fromString(node.get("value").asText()))
+      .mptIssuanceId(MpTokenIssuanceId.of(node.get("mpt_issuance_id").asText()))
+      .build();
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/MptTokenAmountSerializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/MptTokenAmountSerializer.java
@@ -1,0 +1,61 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.xrpl.xrpl4j.model.transactions.amount.MptAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.MptTokenAmount;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson serializer for {@link MptTokenAmount}.
+ *
+ * <p>Writes the wire format {@code {"value":"...","mpt_issuance_id":"..."}}.
+ * The {@code value} field is written by delegating to {@link MptAmountSerializer}, so any change to how
+ * {@link MptAmount} serializes is automatically reflected here.
+ */
+public class MptTokenAmountSerializer extends StdSerializer<MptTokenAmount> {
+
+  private static final MptAmountSerializer AMOUNT_SERIALIZER = new MptAmountSerializer();
+
+  /**
+   * No-args constructor.
+   */
+  public MptTokenAmountSerializer() {
+    super(MptTokenAmount.class);
+  }
+
+  @Override
+  public void serialize(
+    final MptTokenAmount mptTokenAmount,
+    final JsonGenerator gen,
+    final SerializerProvider provider
+  ) throws IOException {
+    gen.writeStartObject();
+    gen.writeFieldName("value");
+    AMOUNT_SERIALIZER.serialize(mptTokenAmount.amount(), gen, provider);
+    gen.writeStringField("mpt_issuance_id", mptTokenAmount.mptIssuanceId().value());
+    gen.writeEndObject();
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/TokenAmountDeserializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/TokenAmountDeserializer.java
@@ -1,0 +1,79 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.MpTokenIssuanceId;
+import org.xrpl.xrpl4j.model.transactions.amount.IouTokenAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.MptTokenAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.TokenAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpTokenAmount;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson deserializer for {@link TokenAmount}s.
+ *
+ * <p>Dispatch rules (identical wire format to {@link CurrencyAmountDeserializer}):
+ * <ul>
+ *   <li>JSON object with {@code mpt_issuance_id} field → {@link MptTokenAmount}</li>
+ *   <li>JSON object with {@code currency} and {@code issuer} fields → {@link IouTokenAmount}</li>
+ *   <li>JSON string or number → {@link XrpTokenAmount} (value interpreted as drops)</li>
+ * </ul>
+ */
+public class TokenAmountDeserializer extends StdDeserializer<TokenAmount> {
+
+  /**
+   * No-args constructor.
+   */
+  public TokenAmountDeserializer() {
+    super(TokenAmount.class);
+  }
+
+  @Override
+  public TokenAmount deserialize(
+    final JsonParser jsonParser,
+    final DeserializationContext deserializationContext
+  ) throws IOException {
+    JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+
+    if (node.isContainerNode()) {
+      if (node.has("mpt_issuance_id")) {
+        return MptTokenAmount.builder()
+          .amount(MptAmountDeserializer.fromString(node.get("value").asText()))
+          .mptIssuanceId(MpTokenIssuanceId.of(node.get("mpt_issuance_id").asText()))
+          .build();
+      } else {
+        return IouTokenAmount.builder()
+          .amount(IouAmountDeserializer.fromString(node.get("value").asText()))
+          .currency(node.get("currency").asText())
+          .issuer(Address.of(node.get("issuer").asText()))
+          .build();
+      }
+    } else {
+      return XrpTokenAmount.ofDrops(node.asLong());
+    }
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/XrpAmountDeserializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/XrpAmountDeserializer.java
@@ -1,0 +1,52 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpAmount;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson deserializer for {@link XrpAmount}.
+ *
+ * <p>Reads a bare JSON string or number containing the drop count (e.g. {@code "1000000"} or
+ * {@code "-500"}) and constructs an {@link XrpAmount} via {@link XrpAmount#ofDrops(long)}.
+ */
+public class XrpAmountDeserializer extends StdDeserializer<XrpAmount> {
+
+  /**
+   * No-args constructor.
+   */
+  public XrpAmountDeserializer() {
+    super(XrpAmount.class);
+  }
+
+  @Override
+  public XrpAmount deserialize(
+    final JsonParser jsonParser,
+    final DeserializationContext ctxt
+  ) throws IOException {
+    return XrpAmount.ofDrops(jsonParser.getValueAsLong());
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/XrpAmountSerializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/XrpAmountSerializer.java
@@ -1,0 +1,53 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpAmount;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson serializer for {@link XrpAmount}.
+ *
+ * <p>Writes the drop count as a bare JSON string (e.g. {@code "1000000"} or {@code "-500"}),
+ * matching the XRPL wire format for XRP amounts.
+ */
+public class XrpAmountSerializer extends StdScalarSerializer<XrpAmount> {
+
+  /**
+   * No-args constructor.
+   */
+  public XrpAmountSerializer() {
+    super(XrpAmount.class, false);
+  }
+
+  @Override
+  public void serialize(
+    final XrpAmount xrpAmount,
+    final JsonGenerator gen,
+    final SerializerProvider provider
+  ) throws IOException {
+    gen.writeString(xrpAmount.value());
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/XrpTokenAmountDeserializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/XrpTokenAmountDeserializer.java
@@ -1,0 +1,55 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpTokenAmount;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson deserializer for {@link XrpTokenAmount}.
+ *
+ * <p>Delegates to {@link XrpAmountDeserializer} to read the bare JSON string or number, then
+ * wraps the resulting {@link XrpAmount} via {@link XrpTokenAmount#of(XrpAmount)}.
+ */
+public class XrpTokenAmountDeserializer extends StdDeserializer<XrpTokenAmount> {
+
+  private static final XrpAmountDeserializer AMOUNT_DESERIALIZER = new XrpAmountDeserializer();
+
+  /**
+   * No-args constructor.
+   */
+  public XrpTokenAmountDeserializer() {
+    super(XrpTokenAmount.class);
+  }
+
+  @Override
+  public XrpTokenAmount deserialize(
+    final JsonParser jsonParser,
+    final DeserializationContext ctxt
+  ) throws IOException {
+    return XrpTokenAmount.of(AMOUNT_DESERIALIZER.deserialize(jsonParser, ctxt));
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/XrpTokenAmountSerializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/XrpTokenAmountSerializer.java
@@ -1,0 +1,56 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpTokenAmount;
+
+import java.io.IOException;
+
+/**
+ * Custom Jackson serializer for {@link XrpTokenAmount}.
+ *
+ * <p>Delegates to {@link XrpAmountSerializer}, writing the drop count as a bare JSON string
+ * (e.g. {@code "1000000"}). Any change to how {@link org.xrpl.xrpl4j.model.transactions.amount.XrpAmount}
+ * serializes is automatically reflected here.
+ */
+public class XrpTokenAmountSerializer extends StdScalarSerializer<XrpTokenAmount> {
+
+  private static final XrpAmountSerializer AMOUNT_SERIALIZER = new XrpAmountSerializer();
+
+  /**
+   * No-args constructor.
+   */
+  public XrpTokenAmountSerializer() {
+    super(XrpTokenAmount.class, false);
+  }
+
+  @Override
+  public void serialize(
+    final XrpTokenAmount xrpTokenAmount,
+    final JsonGenerator gen,
+    final SerializerProvider provider
+  ) throws IOException {
+    AMOUNT_SERIALIZER.serialize(xrpTokenAmount.amount(), gen, provider);
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/Xrpl4jModule.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/Xrpl4jModule.java
@@ -28,6 +28,13 @@ import org.xrpl.xrpl4j.model.client.serverinfo.ServerInfo;
 import org.xrpl.xrpl4j.model.flags.Flags;
 import org.xrpl.xrpl4j.model.transactions.CurrencyAmount;
 import org.xrpl.xrpl4j.model.transactions.Transaction;
+import org.xrpl.xrpl4j.model.transactions.amount.IouAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.IouTokenAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.MptAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.MptTokenAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.TokenAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpTokenAmount;
 import org.xrpl.xrpl4j.model.transactions.metadata.AffectedNode;
 
 import java.time.ZonedDateTime;
@@ -56,6 +63,21 @@ public class Xrpl4jModule extends SimpleModule {
     );
 
     addDeserializer(CurrencyAmount.class, new CurrencyAmountDeserializer());
+
+    addSerializer(XrpAmount.class, new XrpAmountSerializer());
+    addDeserializer(XrpAmount.class, new XrpAmountDeserializer());
+    addSerializer(IouAmount.class, new IouAmountSerializer());
+    addDeserializer(IouAmount.class, new IouAmountDeserializer());
+    addSerializer(MptAmount.class, new MptAmountSerializer());
+    addDeserializer(MptAmount.class, new MptAmountDeserializer());
+
+    addDeserializer(TokenAmount.class, new TokenAmountDeserializer());
+    addSerializer(XrpTokenAmount.class, new XrpTokenAmountSerializer());
+    addDeserializer(XrpTokenAmount.class, new XrpTokenAmountDeserializer());
+    addSerializer(IouTokenAmount.class, new IouTokenAmountSerializer());
+    addDeserializer(IouTokenAmount.class, new IouTokenAmountDeserializer());
+    addSerializer(MptTokenAmount.class, new MptTokenAmountSerializer());
+    addDeserializer(MptTokenAmount.class, new MptTokenAmountDeserializer());
 
     addSerializer(LedgerIndex.class, new LedgerIndexSerializer());
     addDeserializer(LedgerIndex.class, new LedgerIndexDeserializer());

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/CurrencyAmount.java
@@ -20,6 +20,16 @@ package org.xrpl.xrpl4j.model.transactions;
  * =========================LICENSE_END==================================
  */
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.xrpl.xrpl4j.model.transactions.amount.Amount;
+import org.xrpl.xrpl4j.model.transactions.amount.IouAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.IouTokenAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.MptAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.MptTokenAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.TokenAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpTokenAmount;
+
 import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -29,12 +39,44 @@ import java.util.function.Function;
  * Marker interface for XRPL Currency Amounts.
  *
  * @see "https://xrpl.org/basic-data-types.html#specifying-currency-amounts"
+ * @deprecated Use {@link TokenAmount} instead. {@link CurrencyAmount} and its subtypes ({@link XrpCurrencyAmount},
+ *   {@link IssuedCurrencyAmount}, {@link MptCurrencyAmount}) will be removed in a future version. Migrate to
+ *   {@link TokenAmount} ({@link XrpTokenAmount}, {@link IouTokenAmount}, {@link MptTokenAmount}) and use {@link Amount}
+ *   for scalar numeric values without asset identity.
  */
+@Deprecated
 public interface CurrencyAmount {
 
+  /**
+   * One XRP, in drops.
+   *
+   * @deprecated Use {@link XrpAmount#ONE_XRP_IN_DROPS} instead.
+   */
+  @Deprecated
   long ONE_XRP_IN_DROPS = 1_000_000L;
+
+  /**
+   * Maximum number of XRP.
+   *
+   * @deprecated Use {@link XrpAmount#MAX_XRP} instead.
+   */
+  @Deprecated
   long MAX_XRP = 100_000_000_000L; // <-- per https://xrpl.org/rippleapi-reference.html#value
+
+  /**
+   * Maximum number of XRP, in drops.
+   *
+   * @deprecated Use {@link XrpAmount#MAX_XRP_IN_DROPS} instead.
+   */
+  @Deprecated
   long MAX_XRP_IN_DROPS = MAX_XRP * ONE_XRP_IN_DROPS;
+
+  /**
+   * Maximum number of XRP, as a BigDecimal.
+   *
+   * @deprecated Use {@link XrpAmount#MAX_XRP_BD} instead.
+   */
+  @Deprecated
   BigDecimal MAX_XRP_BD = BigDecimal.valueOf(MAX_XRP);
 
   /**
@@ -103,5 +145,26 @@ public interface CurrencyAmount {
     } else {
       throw new IllegalStateException(String.format("Unsupported CurrencyAmount Type: %s", this.getClass()));
     }
+  }
+
+  /**
+   * Returns the scalar numeric {@link Amount} for this currency amount, stripping currency metadata (currency code,
+   * issuer, MPT issuance ID). The concrete subtype determines which {@link Amount} implementation is returned:
+   * <ul>
+   *   <li>{@link XrpCurrencyAmount} → {@link XrpAmount} (drops, sign preserved)</li>
+   *   <li>{@link IssuedCurrencyAmount} → {@link IouAmount} (value string passed verbatim)</li>
+   *   <li>{@link MptCurrencyAmount} → {@link MptAmount} (magnitude + sign)</li>
+   * </ul>
+   *
+   * @return An {@link Amount} representing the numeric value of this currency amount.
+   */
+  @JsonIgnore
+  default Amount amount() {
+    return map(
+      xrp -> xrp.isNegative() ? XrpAmount.ofDrops(-xrp.value().longValue())
+        : XrpAmount.ofDrops(xrp.value()),
+      iou -> IouAmount.of(iou.value()),
+      mpt -> MptAmount.of(mpt.unsignedLongValue(), mpt.isNegative())
+    );
   }
 }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/IssuedCurrencyAmount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/IssuedCurrencyAmount.java
@@ -25,14 +25,17 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Auxiliary;
-import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Derived;
+import org.xrpl.xrpl4j.model.transactions.amount.IouTokenAmount;
 
 /**
  * A {@link CurrencyAmount} for Issued Currencies on the XRP Ledger.
  *
+ * @deprecated Use {@link IouTokenAmount} instead.
+ *
  * @see "https://xrpl.org/rippleapi-reference.html#value"
  */
+@Deprecated
 @Value.Immutable
 @JsonSerialize(as = ImmutableIssuedCurrencyAmount.class)
 @JsonDeserialize(as = ImmutableIssuedCurrencyAmount.class)

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/MptCurrencyAmount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/MptCurrencyAmount.java
@@ -9,10 +9,14 @@ import org.immutables.value.Value;
 import org.immutables.value.Value.Auxiliary;
 import org.immutables.value.Value.Derived;
 import org.immutables.value.Value.Immutable;
+import org.xrpl.xrpl4j.model.transactions.amount.MptTokenAmount;
 
 /**
  * {@link CurrencyAmount} type for MPT amounts.
+ *
+ * @deprecated Use {@link MptTokenAmount} instead.
  */
+@Deprecated
 @Immutable
 @JsonSerialize(as = ImmutableMptCurrencyAmount.class)
 @JsonDeserialize(as = ImmutableMptCurrencyAmount.class)

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -182,7 +182,10 @@ public class Wrappers {
   /**
    * A {@link CurrencyAmount} for the XRP currency (non-issued). {@link XrpCurrencyAmount}s are a {@link String}
    * representation of an unsigned integer representing the amount in XRP drops.
+   *
+   * @deprecated Use `XrpTokenAmount` instead.
    */
+  @Deprecated
   @Value.Immutable(builder = true) // This is the default, but it's omitted without this.
   @Wrapped
   @JsonSerialize(as = XrpCurrencyAmount.class, using = XrpCurrencyAmountSerializer.class)

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/Amount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/Amount.java
@@ -1,0 +1,106 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+import com.google.common.annotations.Beta;
+import com.google.common.primitives.UnsignedLong;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * A polymorphic amount type representing a numeric value without currency-type metadata.
+ *
+ * <p>Unlike {@link TokenAmount}, which bundles the currency type (XRP, IOU with currency+issuer, MPT with issuance
+ * ID) together with the quantity, {@link Amount} carries only the scalar numeric value. This is the representation used
+ * by Single Asset Vault (XLS-65) fields such as {@code AssetsTotal}, {@code AssetsAvailable}, {@code AssetsMaximum},
+ * and {@code LossUnrealized}, whose internal type on the ledger is {@code NUMBER} — asset-type-agnostic.</p>
+ *
+ * <p>All three subtypes expose their quantity via {@link #value()}, which returns a
+ * {@link String} for wire-format fidelity. Type safety is provided at <em>construction</em> time through typed static
+ * factories on each subtype:</p>
+ * <ul>
+ *   <li>{@link XrpAmount#ofDrops(long)} / {@link XrpAmount#ofDrops(UnsignedLong)}</li>
+ *   <li>{@link MptAmount#of(UnsignedLong)}</li>
+ *   <li>{@link IouAmount#of(BigDecimal)} / {@link IouAmount#of(String)}</li>
+ * </ul>
+ *
+ * <p><strong>JSON note:</strong> All three subtypes serialize to a plain JSON string
+ * (the {@link #value()}). Because the raw JSON carries no type tag, deserialization
+ * requires knowledge of the vault's {@code Asset} type at the call-site; see the
+ * per-subtype Jackson modules for details (not yet wired up in this prototype).</p>
+ *
+ * <p>This type is {@link Beta} while the XLS-65 Single Asset Vault amendment is
+ * pending mainnet activation.</p>
+ */
+public interface Amount {
+
+  /**
+   * The wire-format string representation of this amount. For {@link XrpAmount} and {@link MptAmount} this is a decimal
+   * integer string (optionally prefixed with {@code -}); for {@link IouAmount} it may additionally contain a decimal
+   * point or scientific-notation exponent.
+   *
+   * @return A non-null {@link String}.
+   */
+  String value();
+
+  /**
+   * Whether this amount is negative.
+   *
+   * @return {@code true} if the drop count is negative; {@code false} otherwise.
+   */
+  default boolean isNegative() {
+    return value().startsWith("-");
+  }
+
+  /**
+   * Dispatches to the appropriate handler based on the concrete subtype of this amount.
+   *
+   * @param xrpAmountHandler A {@link Consumer} invoked when this is an {@link XrpAmount}.
+   * @param mptAmountHandler A {@link Consumer} invoked when this is an {@link MptAmount}.
+   * @param iouAmountHandler A {@link Consumer} invoked when this is an {@link IouAmount}.
+   */
+  default void handle(final Consumer<XrpAmount> xrpAmountHandler, final Consumer<MptAmount> mptAmountHandler,
+    final Consumer<IouAmount> iouAmountHandler) {
+    Objects.requireNonNull(xrpAmountHandler);
+    Objects.requireNonNull(mptAmountHandler);
+    Objects.requireNonNull(iouAmountHandler);
+
+    if (XrpAmount.class.isAssignableFrom(this.getClass())) {
+      xrpAmountHandler.accept((XrpAmount) this);
+    } else if (MptAmount.class.isAssignableFrom(this.getClass())) {
+      mptAmountHandler.accept((MptAmount) this);
+    } else if (IouAmount.class.isAssignableFrom(this.getClass())) {
+      iouAmountHandler.accept((IouAmount) this);
+    } else {
+      throw new IllegalStateException(String.format("Unsupported Amount type: %s", this.getClass()));
+    }
+  }
+
+  /**
+   * Maps this amount to a value of type {@link R} based on its concrete subtype.
+   *
+   * @param xrpAmountMapper A {@link Function} applied when this is an {@link XrpAmount}.
+   * @param mptAmountMapper A {@link Function} applied when this is an {@link MptAmount}.
+   * @param iouAmountMapper A {@link Function} applied when this is an {@link IouAmount}.
+   * @param <R>             The return type.
+   *
+   * @return The result of the matching mapper function.
+   */
+  default <R> R map(final Function<XrpAmount, R> xrpAmountMapper, final Function<MptAmount, R> mptAmountMapper,
+    final Function<IouAmount, R> iouAmountMapper) {
+    Objects.requireNonNull(xrpAmountMapper);
+    Objects.requireNonNull(mptAmountMapper);
+    Objects.requireNonNull(iouAmountMapper);
+
+    if (XrpAmount.class.isAssignableFrom(this.getClass())) {
+      return xrpAmountMapper.apply((XrpAmount) this);
+    } else if (MptAmount.class.isAssignableFrom(this.getClass())) {
+      return mptAmountMapper.apply((MptAmount) this);
+    } else if (IouAmount.class.isAssignableFrom(this.getClass())) {
+      return iouAmountMapper.apply((IouAmount) this);
+    } else {
+      throw new IllegalStateException(String.format("Unsupported Amount type: %s", this.getClass()));
+    }
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/IouAmount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/IouAmount.java
@@ -1,0 +1,97 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.annotations.Beta;
+import org.immutables.value.Value.Auxiliary;
+import org.immutables.value.Value.Derived;
+import org.immutables.value.Value.Immutable;
+import org.xrpl.xrpl4j.model.jackson.modules.IouAmountDeserializer;
+import org.xrpl.xrpl4j.model.jackson.modules.IouAmountSerializer;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * An {@link Amount} representing a quantity of an Issued Currency (IOU).
+ *
+ * <p>IOU values are arbitrary-precision decimals (up to 16 significant digits on
+ * the ledger) and may include scientific notation as returned by the XRPL RPC. Construct via the typed static
+ * factories:
+ * <pre>{@code
+ *   IouAmount amount = IouAmount.of(new BigDecimal("100.50"));
+ *   IouAmount amount = IouAmount.of("1.23e10");   // scientific notation preserved
+ * }</pre>
+ *
+ * <p>The {@link #value()} returns the string exactly as supplied (or as
+ * {@link BigDecimal#toPlainString()} when constructed from a {@link BigDecimal}). This preserves round-trip fidelity
+ * with RPC responses.</p>
+ *
+ * <p>This type is {@link Beta} while the XLS-65 Single Asset Vault amendment is
+ * pending mainnet activation.</p>
+ */
+@Immutable
+@Beta
+@JsonSerialize(using = IouAmountSerializer.class)
+@JsonDeserialize(using = IouAmountDeserializer.class)
+public interface IouAmount extends Amount {
+
+  /**
+   * Construct an {@link IouAmount} from a {@link BigDecimal}.
+   *
+   * <p>The value is stored as a plain decimal string (no scientific notation) via
+   * {@link BigDecimal#toPlainString()}.</p>
+   *
+   * @param value The IOU quantity. Must not be null.
+   *
+   * @return An {@link IouAmount}.
+   */
+  static IouAmount of(final BigDecimal value) {
+    Objects.requireNonNull(value, "value must not be null");
+    return ImmutableIouAmount.builder()
+      .value(value.toPlainString())
+      .build();
+  }
+
+  /**
+   * Construct an {@link IouAmount} from a pre-formatted numeric string.
+   *
+   * <p>Scientific notation (e.g. {@code "1.23e10"}) is accepted and stored verbatim,
+   * preserving the exact representation returned by the RPC. The string is validated as a parseable number at
+   * construction time.</p>
+   *
+   * @param value A non-null, non-empty numeric string.
+   *
+   * @return An {@link IouAmount}.
+   *
+   * @throws NumberFormatException if {@code value} is not a valid decimal number.
+   */
+  static IouAmount of(final String value) {
+    Objects.requireNonNull(value, "value must not be null");
+    // Validate — will throw NumberFormatException for non-numeric input.
+    new BigDecimal(value);
+    return ImmutableIouAmount.builder()
+      .value(value)
+      .build();
+  }
+
+  @Override
+  @Derived
+  @Auxiliary
+  @JsonIgnore
+  default boolean isNegative() {
+    return Amount.super.isNegative();
+  }
+
+  /**
+   * Returns the value as a {@link BigDecimal} for arithmetic or comparison purposes.
+   *
+   * @return A {@link BigDecimal} representing this IOU amount.
+   */
+  @Auxiliary
+  @JsonIgnore
+  default BigDecimal bigDecimalValue() {
+    return new BigDecimal(value());
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/IouTokenAmount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/IouTokenAmount.java
@@ -1,0 +1,109 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value.Immutable;
+import org.xrpl.xrpl4j.model.jackson.modules.IouTokenAmountDeserializer;
+import org.xrpl.xrpl4j.model.jackson.modules.IouTokenAmountSerializer;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.IssuedCurrencyAmount;
+
+/**
+ * A {@link TokenAmount} for issued currencies (IOUs) on the XRP Ledger.
+ *
+ * <p>Construct via the builder:
+ * <pre>{@code
+ *   IouTokenAmount amount = IouTokenAmount.builder()
+ *     .amount(IouAmount.of("100.50"))
+ *     .currency("USD")
+ *     .issuer(Address.of("r..."))
+ *     .build();
+ * }</pre>
+ *
+ * <p>The underlying {@link IouAmount} holds a quoted decimal string (optionally in scientific
+ * notation, e.g. {@code "1.23e11"}), matching the representation returned by the XRPL RPC. Non-XRP values can have up
+ * to 16 decimal digits of precision, with a maximum value of {@code 9999999999999999e80}. The smallest positive non-XRP
+ * value is {@code 1e-81}.</p>
+ *
+ * <p>On the wire this serializes as a JSON object with {@code value}, {@code currency}, and
+ * {@code issuer} fields — the same format as {@link IssuedCurrencyAmount}.</p>
+ *
+ * @see "https://xrpl.org/rippleapi-reference.html#value"
+ */
+@Immutable
+@JsonSerialize(using = IouTokenAmountSerializer.class)
+@JsonDeserialize(using = IouTokenAmountDeserializer.class)
+public interface IouTokenAmount extends TokenAmount {
+
+  /**
+   * The maximum value that an {@link IouTokenAmount} can have.
+   */
+  String MAX_VALUE = "9999999999999999e80";
+
+  /**
+   * The minimum value that an {@link IouTokenAmount} can have.
+   */
+  String MIN_VALUE = "-9999999999999999e80";
+
+  /**
+   * The smallest possible positive value that an {@link IouTokenAmount} can have.
+   */
+  String MIN_POSITIVE_VALUE = "1000000000000000e-96";
+
+  /**
+   * The largest possible negative value that an {@link IouTokenAmount} can have.
+   */
+  String MAX_NEGATIVE_VALUE = "-1000000000000000e-96";
+
+  /**
+   * Construct a builder for this class.
+   *
+   * @return An {@link ImmutableIouTokenAmount.Builder}.
+   */
+  static ImmutableIouTokenAmount.Builder builder() {
+    return ImmutableIouTokenAmount.builder();
+  }
+
+  /**
+   * The scalar numeric value of this IOU amount.
+   *
+   * @return An {@link IouAmount} holding the decimal/scientific-notation string.
+   */
+  @JsonIgnore
+  IouAmount amount();
+
+  /**
+   * Arbitrary code for currency to issue. Cannot be XRP.
+   *
+   * @return A {@link String} containing the currency code.
+   */
+  String currency();
+
+  /**
+   * Unique account {@link Address} of the entity issuing the currency.
+   *
+   * @return The {@link Address} of the issuer account.
+   */
+  Address issuer();
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/MptAmount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/MptAmount.java
@@ -1,0 +1,86 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.annotations.Beta;
+import com.google.common.primitives.UnsignedLong;
+import org.immutables.value.Value.Auxiliary;
+import org.immutables.value.Value.Derived;
+import org.immutables.value.Value.Immutable;
+import org.xrpl.xrpl4j.model.jackson.modules.MptAmountDeserializer;
+import org.xrpl.xrpl4j.model.jackson.modules.MptAmountSerializer;
+
+import java.util.Objects;
+
+/**
+ * An {@link Amount} representing a quantity of a Multi-Purpose Token (MPT).
+ *
+ * <p>MPT amounts are non-negative integers on the ledger (max 2^63 - 1), but the
+ * RPC may return a leading {@code -} when reporting changes in metadata. Construct via the typed static factories:
+ * <pre>{@code
+ *   MptAmount amount = MptAmount.of(UnsignedLong.valueOf(1_000L));
+ *   MptAmount negative = MptAmount.of(UnsignedLong.valueOf(500L), true);  // e.g. from metadata
+ * }</pre>
+ *
+ * <p>The {@link #value()} returns a decimal-integer string, optionally prefixed with
+ * {@code -}. For example {@code "1000"} or {@code "-500"}.</p>
+ *
+ * <p>This type is {@link Beta} while the XLS-65 Single Asset Vault amendment is
+ * pending mainnet activation.</p>
+ */
+@Immutable
+@Beta
+@JsonSerialize(using = MptAmountSerializer.class)
+@JsonDeserialize(using = MptAmountDeserializer.class)
+public interface MptAmount extends Amount {
+
+  /**
+   * Construct a non-negative {@link MptAmount}.
+   *
+   * @param value The MPT quantity. Must not be null.
+   *
+   * @return An {@link MptAmount}.
+   */
+  static MptAmount of(final UnsignedLong value) {
+    Objects.requireNonNull(value, "value must not be null");
+    return ImmutableMptAmount.builder()
+      .value(value.toString())
+      .build();
+  }
+
+  /**
+   * Construct an {@link MptAmount} with an explicit sign, e.g. when constructing a value sourced from transaction
+   * metadata where negative amounts can appear.
+   *
+   * @param magnitude  The absolute MPT quantity. Must not be null.
+   * @param isNegative {@code true} to prefix the value with {@code -}.
+   *
+   * @return An {@link MptAmount}.
+   */
+  static MptAmount of(final UnsignedLong magnitude, final boolean isNegative) {
+    Objects.requireNonNull(magnitude, "magnitude must not be null");
+    return ImmutableMptAmount.builder()
+      .value(isNegative ? "-" + magnitude : magnitude.toString())
+      .build();
+  }
+
+  @Override
+  @Derived
+  @Auxiliary
+  @JsonIgnore
+  default boolean isNegative() {
+    return Amount.super.isNegative();
+  }
+
+  /**
+   * The absolute magnitude of this MPT amount as an {@link UnsignedLong} (sign stripped).
+   *
+   * @return An {@link UnsignedLong}.
+   */
+  @Auxiliary
+  @JsonIgnore
+  default UnsignedLong unsignedLongValue() {
+    return isNegative() ? UnsignedLong.valueOf(value().substring(1)) : UnsignedLong.valueOf(value());
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/MptTokenAmount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/MptTokenAmount.java
@@ -1,0 +1,122 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.primitives.UnsignedLong;
+import org.immutables.value.Value.Auxiliary;
+import org.immutables.value.Value.Derived;
+import org.immutables.value.Value.Immutable;
+import org.xrpl.xrpl4j.model.jackson.modules.MptTokenAmountDeserializer;
+import org.xrpl.xrpl4j.model.jackson.modules.MptTokenAmountSerializer;
+import org.xrpl.xrpl4j.model.transactions.MpTokenIssuanceId;
+import org.xrpl.xrpl4j.model.transactions.MptCurrencyAmount;
+
+/**
+ * A {@link TokenAmount} for Multi-Purpose Tokens (MPTs) on the XRP Ledger.
+ *
+ * <p>Construct via the builder or the convenience factory:
+ * <pre>{@code
+ *   MptTokenAmount amount = MptTokenAmount.builder()
+ *     .amount(MptAmount.of(UnsignedLong.valueOf(1000L)))
+ *     .mptIssuanceId(MpTokenIssuanceId.of("..."))
+ *     .build();
+ *
+ *   // Convenience factory pre-populates amount from an UnsignedLong:
+ *   MptTokenAmount amount = MptTokenAmount.builder(UnsignedLong.valueOf(1000L))
+ *     .mptIssuanceId(MpTokenIssuanceId.of("..."))
+ *     .build();
+ * }</pre>
+ *
+ * <p>MPT amounts are non-negative integers on the ledger (max 2^63 − 1), but the RPC may return a
+ * leading {@code -} when reporting changes in transaction metadata.</p>
+ *
+ * <p>On the wire this serializes as a JSON object with {@code value} and {@code mpt_issuance_id}
+ * fields — the same format as {@link MptCurrencyAmount}.</p>
+ */
+@Immutable
+@JsonSerialize(using = MptTokenAmountSerializer.class)
+@JsonDeserialize(using = MptTokenAmountDeserializer.class)
+public interface MptTokenAmount extends TokenAmount {
+
+  /**
+   * Construct a {@code MptTokenAmount} builder.
+   *
+   * @return An {@link ImmutableMptTokenAmount.Builder}.
+   */
+  static ImmutableMptTokenAmount.Builder builder() {
+    return ImmutableMptTokenAmount.builder();
+  }
+
+  /**
+   * Construct a {@code MptTokenAmount} builder pre-populated with a non-negative amount.
+   *
+   * @param value The MPT quantity. Must not be null.
+   *
+   * @return An {@link ImmutableMptTokenAmount.Builder}.
+   */
+  static ImmutableMptTokenAmount.Builder builder(final UnsignedLong value) {
+    return ImmutableMptTokenAmount.builder()
+      .amount(MptAmount.of(value));
+  }
+
+  /**
+   * The scalar numeric value of this MPT amount.
+   *
+   * @return An {@link MptAmount} holding the integer string.
+   */
+  @JsonIgnore
+  MptAmount amount();
+
+  /**
+   * The MPT issuance ID that identifies which MPT this amount is for.
+   *
+   * @return A {@link MpTokenIssuanceId}.
+   */
+  @JsonProperty("mpt_issuance_id")
+  MpTokenIssuanceId mptIssuanceId();
+
+  /**
+   * The absolute magnitude of this MPT amount as an {@link UnsignedLong} (sign stripped).
+   *
+   * @return An {@link UnsignedLong}.
+   */
+  @Auxiliary
+  @JsonIgnore
+  default UnsignedLong unsignedLongValue() {
+    return amount().unsignedLongValue();
+  }
+
+  /**
+   * Indicates whether this amount is positive or negative.
+   *
+   * @return {@code true} if this amount is negative; {@code false} otherwise.
+   */
+  @Derived
+  @JsonIgnore
+  @Auxiliary
+  default boolean isNegative() {
+    return amount().isNegative();
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/TokenAmount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/TokenAmount.java
@@ -1,0 +1,109 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.xrpl.xrpl4j.model.jackson.modules.TokenAmountDeserializer;
+import org.xrpl.xrpl4j.model.transactions.CurrencyAmount;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Polymorphic marker interface for XRPL token amounts. Represents an amount of a specific asset — XRP, an issued
+ * currency (IOU), or a multi-purpose token (MPT).
+ *
+ * <p>This type is the successor to {@link CurrencyAmount}. Both coexist during the transition
+ * period; {@link CurrencyAmount} is deprecated and will be removed in a future version in favour of this type and its
+ * companion {@link Amount} (the scalar numeric value without asset identity).
+ *
+ * <p>The three concrete subtypes are:
+ * <ul>
+ *   <li>{@link XrpTokenAmount} — XRP denominated in drops</li>
+ *   <li>{@link IouTokenAmount} — an issued currency with currency code and issuer</li>
+ *   <li>{@link MptTokenAmount} — a multi-purpose token identified by its issuance ID</li>
+ * </ul>
+ *
+ * <p>Use {@link #handle} or {@link #map} to dispatch on the concrete subtype.
+ *
+ * @see "https://xrpl.org/basic-data-types.html#specifying-currency-amounts"
+ */
+@JsonDeserialize(using = TokenAmountDeserializer.class)
+public interface TokenAmount {
+
+  /**
+   * Handle this {@link TokenAmount} depending on its actual polymorphic subtype.
+   *
+   * @param xrpTokenAmountHandler A {@link Consumer} that is called if this instance is of type {@link XrpTokenAmount}.
+   * @param iouTokenAmountHandler A {@link Consumer} that is called if this instance is of type {@link IouTokenAmount}.
+   * @param mptTokenAmountHandler A {@link Consumer} that is called if this instance is of type {@link MptTokenAmount}.
+   */
+  default void handle(
+    final Consumer<XrpTokenAmount> xrpTokenAmountHandler,
+    final Consumer<IouTokenAmount> iouTokenAmountHandler,
+    final Consumer<MptTokenAmount> mptTokenAmountHandler
+  ) {
+    Objects.requireNonNull(xrpTokenAmountHandler);
+    Objects.requireNonNull(iouTokenAmountHandler);
+    Objects.requireNonNull(mptTokenAmountHandler);
+
+    if (XrpTokenAmount.class.isAssignableFrom(this.getClass())) {
+      xrpTokenAmountHandler.accept((XrpTokenAmount) this);
+    } else if (IouTokenAmount.class.isAssignableFrom(this.getClass())) {
+      iouTokenAmountHandler.accept((IouTokenAmount) this);
+    } else if (MptTokenAmount.class.isAssignableFrom(this.getClass())) {
+      mptTokenAmountHandler.accept((MptTokenAmount) this);
+    } else {
+      throw new IllegalStateException(String.format("Unsupported TokenAmount type: %s", this.getClass()));
+    }
+  }
+
+  /**
+   * Map this {@link TokenAmount} to an instance of {@link R}, depending on its actual polymorphic subtype.
+   *
+   * @param xrpTokenAmountMapper A {@link Function} that is called if this instance is of type {@link XrpTokenAmount}.
+   * @param iouTokenAmountMapper A {@link Function} that is called if this instance is of type {@link IouTokenAmount}.
+   * @param mptTokenAmountMapper A {@link Function} that is called if this instance is of type {@link MptTokenAmount}.
+   * @param <R>                  The type of object to return after mapping.
+   *
+   * @return A {@link R} constructed by the appropriate mapper function.
+   */
+  default <R> R map(
+    final Function<XrpTokenAmount, R> xrpTokenAmountMapper,
+    final Function<IouTokenAmount, R> iouTokenAmountMapper,
+    final Function<MptTokenAmount, R> mptTokenAmountMapper
+  ) {
+    Objects.requireNonNull(xrpTokenAmountMapper);
+    Objects.requireNonNull(iouTokenAmountMapper);
+    Objects.requireNonNull(mptTokenAmountMapper);
+
+    if (XrpTokenAmount.class.isAssignableFrom(this.getClass())) {
+      return xrpTokenAmountMapper.apply((XrpTokenAmount) this);
+    } else if (IouTokenAmount.class.isAssignableFrom(this.getClass())) {
+      return iouTokenAmountMapper.apply((IouTokenAmount) this);
+    } else if (MptTokenAmount.class.isAssignableFrom(this.getClass())) {
+      return mptTokenAmountMapper.apply((MptTokenAmount) this);
+    } else {
+      throw new IllegalStateException(String.format("Unsupported TokenAmount type: %s", this.getClass()));
+    }
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/XrpAmount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/XrpAmount.java
@@ -1,0 +1,215 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Preconditions;
+import com.google.common.primitives.UnsignedLong;
+import org.immutables.value.Value.Auxiliary;
+import org.immutables.value.Value.Derived;
+import org.immutables.value.Value.Immutable;
+import org.xrpl.xrpl4j.model.immutables.FluentCompareTo;
+import org.xrpl.xrpl4j.model.jackson.modules.XrpAmountDeserializer;
+import org.xrpl.xrpl4j.model.jackson.modules.XrpAmountSerializer;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.Objects;
+
+/**
+ * An {@link Amount} representing XRP, denominated in drops.
+ *
+ * <p>Construct via the typed static factories rather than the raw builder:
+ * <pre>{@code
+ *   XrpAmount amount = XrpAmount.ofDrops(1_000_000L);   // 1 XRP
+ *   XrpAmount amount = XrpAmount.ofDrops(UnsignedLong.valueOf(1_000_000L));
+ *   XrpAmount amount = XrpAmount.ofXrp(new BigDecimal("1.5"));   // 1.5 XRP
+ * }</pre>
+ *
+ * <p>The {@link #value()} always returns a decimal-integer string representing the
+ * drop count, prefixed with {@code -} if the amount is negative (which can occur in metadata returned by the RPC). For
+ * example, {@code "1000000"} or {@code "-500"}.</p>
+ *
+ */
+@Immutable
+@JsonSerialize(using = XrpAmountSerializer.class)
+@JsonDeserialize(using = XrpAmountDeserializer.class)
+public interface XrpAmount extends Amount {
+
+  /**
+   * The number of drops in one XRP.
+   */
+  long ONE_XRP_IN_DROPS = 1_000_000L;
+
+  /**
+   * The maximum number of whole XRP.
+   */
+  long MAX_XRP = 100_000_000_000L; // per https://xrpl.org/rippleapi-reference.html#value
+
+  /**
+   * The maximum number of drops of XRP.
+   */
+  long MAX_XRP_IN_DROPS = MAX_XRP * ONE_XRP_IN_DROPS;
+
+  /**
+   * The smallest representable whole-XRP amount (1 drop = 0.000001 XRP).
+   */
+  BigDecimal MIN_XRP_BD = new BigDecimal("0.000001");
+
+  /**
+   * The maximum number of whole XRP, as a {@link BigDecimal}.
+   */
+  BigDecimal MAX_XRP_BD = BigDecimal.valueOf(MAX_XRP);
+
+  /**
+   * Construct an {@link XrpAmount} from a (possibly negative) number of drops.
+   *
+   * @param drops The number of drops. May be negative.
+   *
+   * @return An {@link XrpAmount}.
+   */
+  static XrpAmount ofDrops(final long drops) {
+    return ImmutableXrpAmount.builder()
+      .value(drops < 0 ? "-" + Math.abs(drops) : String.valueOf(drops))
+      .build();
+  }
+
+  /**
+   * Construct a non-negative {@link XrpAmount} from an {@link UnsignedLong} drop count.
+   *
+   * @param drops The number of drops. Must not be null.
+   *
+   * @return An {@link XrpAmount}.
+   */
+  static XrpAmount ofDrops(final UnsignedLong drops) {
+    Objects.requireNonNull(drops, "drops must not be null");
+    return ImmutableXrpAmount.builder()
+      .value(drops.toString())
+      .build();
+  }
+
+  /**
+   * Construct an {@link XrpAmount} from a {@link BigDecimal} amount denominated in whole XRP units.
+   *
+   * <p>The absolute value must be at least {@link XrpAmount#MIN_XRP_BD} ({@code 0.000001}) and no greater
+   * than {@link XrpAmount#MAX_XRP_BD} ({@code 100,000,000,000} XRP). Zero is also accepted.
+   *
+   * <pre>{@code
+   *   XrpAmount amount = XrpAmount.ofXrp(new BigDecimal("1.5"));   // 1,500,000 drops
+   * }</pre>
+   *
+   * @param amount A {@link BigDecimal} amount of XRP. Must not be null.
+   *
+   * @return An {@link XrpAmount} representing the equivalent number of drops.
+   *
+   * @throws IllegalArgumentException if the amount is out of range.
+   */
+  static XrpAmount ofXrp(final BigDecimal amount) {
+    Objects.requireNonNull(amount, "amount must not be null");
+
+    if (FluentCompareTo.is(amount).equalTo(BigDecimal.ZERO)) {
+      return ofDrops(UnsignedLong.ZERO);
+    }
+
+    final BigDecimal absAmount = amount.abs();
+    Preconditions.checkArgument(
+      FluentCompareTo.is(absAmount).greaterThanEqualTo(XrpAmount.MIN_XRP_BD),
+      String.format("Amount must be greater-than-or-equal-to %s XRP", XrpAmount.MIN_XRP_BD)
+    );
+    Preconditions.checkArgument(
+      FluentCompareTo.is(absAmount).lessThanOrEqualTo(MAX_XRP_BD),
+      String.format("Amount must be less-than-or-equal-to %s XRP", MAX_XRP_BD)
+    );
+
+    final boolean isNegative = amount.signum() < 0;
+    final UnsignedLong drops = UnsignedLong.valueOf(absAmount.scaleByPowerOfTen(6).toBigIntegerExact());
+    return ofDrops(isNegative ? -(drops.longValue()) : drops.longValue());
+  }
+
+  @Override
+  @Derived
+  @Auxiliary
+  @JsonIgnore
+  default boolean isNegative() {
+    return Amount.super.isNegative();
+  }
+
+  /**
+   * The absolute drop count as an {@link UnsignedLong} (sign stripped).
+   *
+   * @return An {@link UnsignedLong} representing the magnitude.
+   */
+  @Auxiliary
+  @JsonIgnore
+  default UnsignedLong unsignedLongValue() {
+    return isNegative() ? UnsignedLong.valueOf(value().substring(1)) : UnsignedLong.valueOf(value());
+  }
+
+  /**
+   * Converts this drop amount to a {@link BigDecimal} denominated in whole XRP units. For example, {@code 1_000_000}
+   * drops returns {@code 1.0}.
+   *
+   * @return A {@link BigDecimal} in whole XRP.
+   */
+  @Auxiliary
+  @JsonIgnore
+  default BigDecimal toXrp() {
+    final BigDecimal drops = new BigDecimal(unsignedLongValue().bigIntegerValue())
+      .divide(BigDecimal.valueOf(1_000_000L), MathContext.DECIMAL128);
+    return isNegative() ? drops.negate() : drops;
+  }
+
+  /**
+   * Adds another {@link XrpAmount} to this amount.
+   *
+   * @param other An {@link XrpAmount} to add to this. Must not be null.
+   *
+   * @return The sum of this amount and {@code other}, as an {@link XrpAmount}.
+   */
+  @Auxiliary
+  @JsonIgnore
+  default XrpAmount plus(final XrpAmount other) {
+    Objects.requireNonNull(other, "other must not be null");
+    final long a = isNegative() ? -(unsignedLongValue().longValue()) : unsignedLongValue().longValue();
+    final long b =
+      other.isNegative() ? -(other.unsignedLongValue().longValue()) : other.unsignedLongValue().longValue();
+    return ofDrops(a + b);
+  }
+
+  /**
+   * Subtracts another {@link XrpAmount} from this amount.
+   *
+   * @param other An {@link XrpAmount} to subtract from this. Must not be null.
+   *
+   * @return The difference of this amount and {@code other}, as an {@link XrpAmount}.
+   */
+  @Auxiliary
+  @JsonIgnore
+  default XrpAmount minus(final XrpAmount other) {
+    Objects.requireNonNull(other, "other must not be null");
+    final long a = isNegative() ? -(unsignedLongValue().longValue()) : unsignedLongValue().longValue();
+    final long b =
+      other.isNegative() ? -(other.unsignedLongValue().longValue()) : other.unsignedLongValue().longValue();
+    return ofDrops(a - b);
+  }
+
+  /**
+   * Multiplies this amount by another {@link XrpAmount}.
+   *
+   * <p>The sign of the result follows standard multiplication rules: if exactly one operand is
+   * negative the result is negative; if both operands share the same sign the result is positive.
+   *
+   * @param other An {@link XrpAmount} to multiply by. Must not be null.
+   *
+   * @return The product of this amount and {@code other}, as an {@link XrpAmount}.
+   */
+  @Auxiliary
+  @JsonIgnore
+  default XrpAmount times(final XrpAmount other) {
+    Objects.requireNonNull(other, "other must not be null");
+    final UnsignedLong product = unsignedLongValue().times(other.unsignedLongValue());
+    // XOR: result is negative iff exactly one operand is negative.
+    final boolean resultNegative = isNegative() != other.isNegative();
+    return resultNegative ? ofDrops(-(product.longValue())) : ofDrops(product);
+  }
+}

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/XrpTokenAmount.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/amount/XrpTokenAmount.java
@@ -1,0 +1,103 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.primitives.UnsignedLong;
+import org.immutables.value.Value.Immutable;
+import org.xrpl.xrpl4j.model.jackson.modules.XrpTokenAmountDeserializer;
+import org.xrpl.xrpl4j.model.jackson.modules.XrpTokenAmountSerializer;
+
+import java.util.Objects;
+
+/**
+ * A {@link TokenAmount} representing XRP, denominated in drops.
+ *
+ * <p>Construct via the typed static factories rather than the raw builder:
+ * <pre>{@code
+ *   XrpTokenAmount amount = XrpTokenAmount.ofDrops(1_000_000L);   // 1 XRP
+ *   XrpTokenAmount amount = XrpTokenAmount.ofDrops(UnsignedLong.valueOf(1_000_000L));
+ * }</pre>
+ *
+ * <p>The underlying {@link XrpAmount} stores the drop count as a decimal-integer string, optionally
+ * prefixed with {@code -} if the amount is negative (which can occur in metadata returned by the RPC).
+ *
+ * <p>On the wire, XRP amounts serialize as a bare JSON string containing the drop count (e.g.
+ * {@code "1000000"}), not as a JSON object.
+ */
+@Immutable
+@JsonSerialize(using = XrpTokenAmountSerializer.class)
+@JsonDeserialize(using = XrpTokenAmountDeserializer.class)
+public interface XrpTokenAmount extends TokenAmount {
+
+  /**
+   * Construct an {@link XrpTokenAmount} from a (possibly negative) number of drops.
+   *
+   * @param drops The number of drops. May be negative (e.g. when sourced from transaction metadata).
+   *
+   * @return An {@link XrpTokenAmount}.
+   */
+  static XrpTokenAmount ofDrops(final long drops) {
+    return ImmutableXrpTokenAmount.builder()
+      .amount(XrpAmount.ofDrops(drops))
+      .build();
+  }
+
+  /**
+   * Construct a non-negative {@link XrpTokenAmount} from an {@link UnsignedLong} drop count.
+   *
+   * @param drops The number of drops. Must not be null.
+   *
+   * @return An {@link XrpTokenAmount}.
+   */
+  static XrpTokenAmount ofDrops(final UnsignedLong drops) {
+    Objects.requireNonNull(drops, "drops must not be null");
+    return ImmutableXrpTokenAmount.builder()
+      .amount(XrpAmount.ofDrops(drops))
+      .build();
+  }
+
+  /**
+   * Construct an {@link XrpTokenAmount} that wraps an existing {@link XrpAmount}.
+   *
+   * <p>This is the preferred factory when converting from a deserialized {@link XrpAmount}.
+   *
+   * @param amount An {@link XrpAmount} to wrap. Must not be null.
+   *
+   * @return An {@link XrpTokenAmount}.
+   */
+  static XrpTokenAmount of(final XrpAmount amount) {
+    Objects.requireNonNull(amount, "amount must not be null");
+    return ImmutableXrpTokenAmount.builder()
+      .amount(amount)
+      .build();
+  }
+
+  /**
+   * The scalar numeric value of this XRP amount.
+   *
+   * @return An {@link XrpAmount} holding the drop count.
+   */
+  @JsonIgnore
+  XrpAmount amount();
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/IouAmountDeserializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/IouAmountDeserializerTest.java
@@ -1,0 +1,94 @@
+package org.xrpl.xrpl4j.model.jackson.modules.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.jackson.modules.IouAmountDeserializer;
+import org.xrpl.xrpl4j.model.transactions.amount.IouAmount;
+
+/**
+ * Unit tests for {@link IouAmountDeserializer}.
+ */
+class IouAmountDeserializerTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  @Test
+  void deserializesDecimal() throws JsonProcessingException {
+    IouAmount amount = objectMapper.readValue("\"100.50\"", IouAmount.class);
+    assertThat(amount.value()).isEqualTo("100.50");
+    assertThat(amount.isNegative()).isFalse();
+  }
+
+  @Test
+  void deserializesWholeNumber() throws JsonProcessingException {
+    IouAmount amount = objectMapper.readValue("\"15\"", IouAmount.class);
+    assertThat(amount.value()).isEqualTo("15");
+  }
+
+  @Test
+  void deserializesScientificNotation() throws JsonProcessingException {
+    // Scientific notation is preserved verbatim
+    IouAmount amount = objectMapper.readValue("\"1.23e10\"", IouAmount.class);
+    assertThat(amount.value()).isEqualTo("1.23e10");
+  }
+
+  @Test
+  void deserializesNegative() throws JsonProcessingException {
+    IouAmount amount = objectMapper.readValue("\"-100.50\"", IouAmount.class);
+    assertThat(amount.value()).isEqualTo("-100.50");
+    assertThat(amount.isNegative()).isTrue();
+  }
+
+  @Test
+  void deserializesZero() throws JsonProcessingException {
+    IouAmount amount = objectMapper.readValue("\"0\"", IouAmount.class);
+    assertThat(amount.value()).isEqualTo("0");
+    assertThat(amount.isNegative()).isFalse();
+  }
+
+  @Test
+  void roundTrip() throws JsonProcessingException {
+    IouAmount original = IouAmount.of("1234567890.123456");
+    String json = objectMapper.writeValueAsString(original);
+    IouAmount deserialized = objectMapper.readValue(json, IouAmount.class);
+    assertThat(deserialized).isEqualTo(original);
+  }
+
+  @Test
+  void roundTripScientificNotation() throws JsonProcessingException {
+    IouAmount original = IouAmount.of("9999999999999999e80");
+    String json = objectMapper.writeValueAsString(original);
+    IouAmount deserialized = objectMapper.readValue(json, IouAmount.class);
+    assertThat(deserialized).isEqualTo(original);
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/IouAmountSerializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/IouAmountSerializerTest.java
@@ -1,0 +1,70 @@
+package org.xrpl.xrpl4j.model.jackson.modules.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.jackson.modules.IouAmountSerializer;
+import org.xrpl.xrpl4j.model.transactions.amount.IouAmount;
+
+/**
+ * Unit tests for {@link IouAmountSerializer}.
+ */
+class IouAmountSerializerTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  @Test
+  void serializesDecimal() throws JsonProcessingException {
+    assertThat(objectMapper.writeValueAsString(IouAmount.of("100.50"))).isEqualTo("\"100.50\"");
+  }
+
+  @Test
+  void serializesWholeNumber() throws JsonProcessingException {
+    assertThat(objectMapper.writeValueAsString(IouAmount.of("15"))).isEqualTo("\"15\"");
+  }
+
+  @Test
+  void serializesScientificNotation() throws JsonProcessingException {
+    // Scientific notation is preserved verbatim as returned by the XRPL RPC
+    assertThat(objectMapper.writeValueAsString(IouAmount.of("1.23e10"))).isEqualTo("\"1.23e10\"");
+  }
+
+  @Test
+  void serializesNegative() throws JsonProcessingException {
+    assertThat(objectMapper.writeValueAsString(IouAmount.of("-100.50"))).isEqualTo("\"-100.50\"");
+  }
+
+  @Test
+  void serializesZero() throws JsonProcessingException {
+    assertThat(objectMapper.writeValueAsString(IouAmount.of("0"))).isEqualTo("\"0\"");
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/IouTokenAmountDeserializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/IouTokenAmountDeserializerTest.java
@@ -1,0 +1,107 @@
+package org.xrpl.xrpl4j.model.jackson.modules.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.jackson.modules.IouTokenAmountDeserializer;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.amount.IouAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.IouTokenAmount;
+
+/**
+ * Unit tests for {@link IouTokenAmountDeserializer}.
+ */
+class IouTokenAmountDeserializerTest {
+
+  private static final String ISSUER = "rJbVo4xrsGN8o3vLKGXe1s1uW8mAMYHamV";
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  @Test
+  void deserializesIouObject() throws JsonProcessingException {
+    String json = "{\"value\":\"100.50\",\"currency\":\"USD\",\"issuer\":\"" + ISSUER + "\"}";
+    IouTokenAmount iouTokenAmount = objectMapper.readValue(json, IouTokenAmount.class);
+    assertThat(iouTokenAmount.amount().value()).isEqualTo("100.50");
+    assertThat(iouTokenAmount.currency()).isEqualTo("USD");
+    assertThat(iouTokenAmount.issuer()).isEqualTo(Address.of(ISSUER));
+    assertThat(iouTokenAmount.amount().isNegative()).isFalse();
+  }
+
+  @Test
+  void deserializesNegativeValue() throws JsonProcessingException {
+    // Negative IOU values appear in transaction metadata
+    String json = "{\"value\":\"-50.5\",\"currency\":\"EUR\",\"issuer\":\"" + ISSUER + "\"}";
+    IouTokenAmount iouTokenAmount = objectMapper.readValue(json, IouTokenAmount.class);
+    assertThat(iouTokenAmount.amount().value()).isEqualTo("-50.5");
+    assertThat(iouTokenAmount.amount().isNegative()).isTrue();
+  }
+
+  @Test
+  void deserializesScientificNotation() throws JsonProcessingException {
+    String json = "{\"value\":\"1.23e10\",\"currency\":\"USD\",\"issuer\":\"" + ISSUER + "\"}";
+    IouTokenAmount amount = objectMapper.readValue(json, IouTokenAmount.class);
+    assertThat(amount.amount().value()).isEqualTo("1.23e10");
+  }
+
+  @Test
+  void deserializesHexCurrencyCode() throws JsonProcessingException {
+    // Non-standard 40-character hex currency codes must be preserved verbatim
+    String hexCurrency = "7872706C346A436F696E00000000000000000000";
+    String json = "{\"value\":\"15\",\"currency\":\"" + hexCurrency + "\",\"issuer\":\"" + ISSUER + "\"}";
+    IouTokenAmount amount = objectMapper.readValue(json, IouTokenAmount.class);
+    assertThat(amount.currency()).isEqualTo(hexCurrency);
+  }
+
+  @Test
+  void roundTrip() throws JsonProcessingException {
+    IouTokenAmount original = IouTokenAmount.builder()
+      .amount(IouAmount.of("100.50"))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+    String json = objectMapper.writeValueAsString(original);
+    IouTokenAmount deserialized = objectMapper.readValue(json, IouTokenAmount.class);
+    assertThat(deserialized).isEqualTo(original);
+  }
+
+  @Test
+  void roundTripNegative() throws JsonProcessingException {
+    IouTokenAmount original = IouTokenAmount.builder()
+      .amount(IouAmount.of("-50.5"))
+      .currency("EUR")
+      .issuer(Address.of(ISSUER))
+      .build();
+    String json = objectMapper.writeValueAsString(original);
+    IouTokenAmount deserialized = objectMapper.readValue(json, IouTokenAmount.class);
+    assertThat(deserialized).isEqualTo(original);
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/IouTokenAmountSerializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/IouTokenAmountSerializerTest.java
@@ -1,0 +1,108 @@
+package org.xrpl.xrpl4j.model.jackson.modules.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.jackson.modules.IouTokenAmountSerializer;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.amount.IouAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.IouTokenAmount;
+
+/**
+ * Unit tests for {@link IouTokenAmountSerializer}.
+ */
+class IouTokenAmountSerializerTest {
+
+  private static final String ISSUER = "rJbVo4xrsGN8o3vLKGXe1s1uW8mAMYHamV";
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  @Test
+  void serializesIouObject() throws JsonProcessingException, JSONException {
+    IouTokenAmount amount = IouTokenAmount.builder()
+      .amount(IouAmount.of("100.50"))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+    JSONAssert.assertEquals(
+      "{\"value\":\"100.50\",\"currency\":\"USD\",\"issuer\":\"" + ISSUER + "\"}",
+      objectMapper.writeValueAsString(amount),
+      JSONCompareMode.STRICT
+    );
+  }
+
+  @Test
+  void serializesScientificNotation() throws JsonProcessingException, JSONException {
+    IouTokenAmount amount = IouTokenAmount.builder()
+      .amount(IouAmount.of("1.23e10"))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+    JSONAssert.assertEquals(
+      "{\"value\":\"1.23e10\",\"currency\":\"USD\",\"issuer\":\"" + ISSUER + "\"}",
+      objectMapper.writeValueAsString(amount),
+      JSONCompareMode.STRICT
+    );
+  }
+
+  @Test
+  void serializesNegativeValue() throws JsonProcessingException, JSONException {
+    // Negative IOU values appear in transaction metadata
+    IouTokenAmount amount = IouTokenAmount.builder()
+      .amount(IouAmount.of("-50.5"))
+      .currency("EUR")
+      .issuer(Address.of(ISSUER))
+      .build();
+    JSONAssert.assertEquals(
+      "{\"value\":\"-50.5\",\"currency\":\"EUR\",\"issuer\":\"" + ISSUER + "\"}",
+      objectMapper.writeValueAsString(amount),
+      JSONCompareMode.STRICT
+    );
+  }
+
+  @Test
+  void serializesHexCurrencyCode() throws JsonProcessingException, JSONException {
+    // Non-standard 40-character hex currency codes must be preserved verbatim
+    String hexCurrency = "7872706C346A436F696E00000000000000000000";
+    IouTokenAmount amount = IouTokenAmount.builder()
+      .amount(IouAmount.of("15"))
+      .currency(hexCurrency)
+      .issuer(Address.of(ISSUER))
+      .build();
+    JSONAssert.assertEquals(
+      "{\"value\":\"15\",\"currency\":\"" + hexCurrency + "\",\"issuer\":\"" + ISSUER + "\"}",
+      objectMapper.writeValueAsString(amount),
+      JSONCompareMode.STRICT
+    );
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/MptAmountDeserializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/MptAmountDeserializerTest.java
@@ -1,0 +1,86 @@
+package org.xrpl.xrpl4j.model.jackson.modules.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.jackson.modules.MptAmountDeserializer;
+import org.xrpl.xrpl4j.model.transactions.amount.MptAmount;
+
+/**
+ * Unit tests for {@link MptAmountDeserializer}.
+ */
+class MptAmountDeserializerTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  @Test
+  void deserializesPositive() throws JsonProcessingException {
+    MptAmount amount = objectMapper.readValue("\"1000\"", MptAmount.class);
+    assertThat(amount.value()).isEqualTo("1000");
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(1000L));
+  }
+
+  @Test
+  void deserializesZero() throws JsonProcessingException {
+    MptAmount amount = objectMapper.readValue("\"0\"", MptAmount.class);
+    assertThat(amount.value()).isEqualTo("0");
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.ZERO);
+  }
+
+  @Test
+  void deserializesNegative() throws JsonProcessingException {
+    // Negative values appear in transaction metadata
+    MptAmount amount = objectMapper.readValue("\"-500\"", MptAmount.class);
+    assertThat(amount.value()).isEqualTo("-500");
+    assertThat(amount.isNegative()).isTrue();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(500L));
+  }
+
+  @Test
+  void roundTrip() throws JsonProcessingException {
+    MptAmount original = MptAmount.of(UnsignedLong.valueOf(1_000_000L));
+    String json = objectMapper.writeValueAsString(original);
+    MptAmount deserialized = objectMapper.readValue(json, MptAmount.class);
+    assertThat(deserialized).isEqualTo(original);
+  }
+
+  @Test
+  void roundTripNegative() throws JsonProcessingException {
+    MptAmount original = MptAmount.of(UnsignedLong.valueOf(500L), true);
+    String json = objectMapper.writeValueAsString(original);
+    MptAmount deserialized = objectMapper.readValue(json, MptAmount.class);
+    assertThat(deserialized).isEqualTo(original);
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/MptAmountSerializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/MptAmountSerializerTest.java
@@ -1,0 +1,68 @@
+package org.xrpl.xrpl4j.model.jackson.modules.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.jackson.modules.MptAmountSerializer;
+import org.xrpl.xrpl4j.model.transactions.amount.MptAmount;
+
+/**
+ * Unit tests for {@link MptAmountSerializer}.
+ */
+class MptAmountSerializerTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  @Test
+  void serializesPositive() throws JsonProcessingException {
+    assertThat(objectMapper.writeValueAsString(MptAmount.of(UnsignedLong.valueOf(1000L)))).isEqualTo("\"1000\"");
+  }
+
+  @Test
+  void serializesZero() throws JsonProcessingException {
+    assertThat(objectMapper.writeValueAsString(MptAmount.of(UnsignedLong.ZERO))).isEqualTo("\"0\"");
+  }
+
+  @Test
+  void serializesNegative() throws JsonProcessingException {
+    // Negative values appear in transaction metadata
+    assertThat(objectMapper.writeValueAsString(MptAmount.of(UnsignedLong.valueOf(500L), true))).isEqualTo("\"-500\"");
+  }
+
+  @Test
+  void serializesLargeValue() throws JsonProcessingException {
+    UnsignedLong large = UnsignedLong.valueOf(Long.MAX_VALUE);
+    assertThat(objectMapper.writeValueAsString(MptAmount.of(large)))
+      .isEqualTo("\"" + large + "\"");
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/MptTokenAmountDeserializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/MptTokenAmountDeserializerTest.java
@@ -1,0 +1,99 @@
+package org.xrpl.xrpl4j.model.jackson.modules.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.jackson.modules.MptTokenAmountDeserializer;
+import org.xrpl.xrpl4j.model.transactions.MpTokenIssuanceId;
+import org.xrpl.xrpl4j.model.transactions.amount.MptAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.MptTokenAmount;
+
+/**
+ * Unit tests for {@link MptTokenAmountDeserializer}.
+ */
+class MptTokenAmountDeserializerTest {
+
+  private static final String ISSUANCE_ID = "00000143A58DCB491FD36A15A7D3172E6A9F088A5478BA41";
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  @Test
+  void deserializesMptObject() throws JsonProcessingException {
+    String json = "{\"value\":\"1000\",\"mpt_issuance_id\":\"" + ISSUANCE_ID + "\"}";
+    MptTokenAmount amount = objectMapper.readValue(json, MptTokenAmount.class);
+    assertThat(amount.amount().value()).isEqualTo("1000");
+    assertThat(amount.mptIssuanceId()).isEqualTo(MpTokenIssuanceId.of(ISSUANCE_ID));
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(1000L));
+  }
+
+  @Test
+  void deserializesZeroValue() throws JsonProcessingException {
+    String json = "{\"value\":\"0\",\"mpt_issuance_id\":\"" + ISSUANCE_ID + "\"}";
+    MptTokenAmount amount = objectMapper.readValue(json, MptTokenAmount.class);
+    assertThat(amount.amount().value()).isEqualTo("0");
+    assertThat(amount.isNegative()).isFalse();
+  }
+
+  @Test
+  void deserializesNegativeValue() throws JsonProcessingException {
+    // Negative values appear in transaction metadata
+    String json = "{\"value\":\"-500\",\"mpt_issuance_id\":\"" + ISSUANCE_ID + "\"}";
+    MptTokenAmount amount = objectMapper.readValue(json, MptTokenAmount.class);
+    assertThat(amount.amount().value()).isEqualTo("-500");
+    assertThat(amount.isNegative()).isTrue();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(500L));
+  }
+
+  @Test
+  void roundTrip() throws JsonProcessingException {
+    MptTokenAmount original = MptTokenAmount.builder()
+      .amount(MptAmount.of(UnsignedLong.valueOf(1_000_000L)))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    String json = objectMapper.writeValueAsString(original);
+    MptTokenAmount deserialized = objectMapper.readValue(json, MptTokenAmount.class);
+    assertThat(deserialized).isEqualTo(original);
+  }
+
+  @Test
+  void roundTripNegative() throws JsonProcessingException {
+    MptTokenAmount original = MptTokenAmount.builder()
+      .amount(MptAmount.of(UnsignedLong.valueOf(500L), true))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    String json = objectMapper.writeValueAsString(original);
+    MptTokenAmount deserialized = objectMapper.readValue(json, MptTokenAmount.class);
+    assertThat(deserialized).isEqualTo(original);
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/MptTokenAmountSerializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/MptTokenAmountSerializerTest.java
@@ -1,0 +1,103 @@
+package org.xrpl.xrpl4j.model.jackson.modules.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.UnsignedLong;
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.jackson.modules.MptTokenAmountSerializer;
+import org.xrpl.xrpl4j.model.transactions.MpTokenIssuanceId;
+import org.xrpl.xrpl4j.model.transactions.amount.MptAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.MptTokenAmount;
+
+/**
+ * Unit tests for {@link MptTokenAmountSerializer}.
+ */
+class MptTokenAmountSerializerTest {
+
+  private static final String ISSUANCE_ID = "00000143A58DCB491FD36A15A7D3172E6A9F088A5478BA41";
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  @Test
+  void serializesMptObject() throws JsonProcessingException, JSONException {
+    MptTokenAmount amount = MptTokenAmount.builder()
+      .amount(MptAmount.of(UnsignedLong.valueOf(1000L)))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    JSONAssert.assertEquals(
+      "{\"value\":\"1000\",\"mpt_issuance_id\":\"" + ISSUANCE_ID + "\"}",
+      objectMapper.writeValueAsString(amount),
+      JSONCompareMode.STRICT
+    );
+  }
+
+  @Test
+  void serializesZeroValue() throws JsonProcessingException, JSONException {
+    MptTokenAmount amount = MptTokenAmount.builder()
+      .amount(MptAmount.of(UnsignedLong.ZERO))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    JSONAssert.assertEquals(
+      "{\"value\":\"0\",\"mpt_issuance_id\":\"" + ISSUANCE_ID + "\"}",
+      objectMapper.writeValueAsString(amount),
+      JSONCompareMode.STRICT
+    );
+  }
+
+  @Test
+  void serializesNegativeValue() throws JsonProcessingException, JSONException {
+    // Negative values appear in transaction metadata
+    MptTokenAmount amount = MptTokenAmount.builder()
+      .amount(MptAmount.of(UnsignedLong.valueOf(500L), true))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    JSONAssert.assertEquals(
+      "{\"value\":\"-500\",\"mpt_issuance_id\":\"" + ISSUANCE_ID + "\"}",
+      objectMapper.writeValueAsString(amount),
+      JSONCompareMode.STRICT
+    );
+  }
+
+  @Test
+  void serializesConvenienceBuilder() throws JsonProcessingException, JSONException {
+    // Verify the UnsignedLong convenience factory produces the same wire format
+    MptTokenAmount amount = MptTokenAmount.builder(UnsignedLong.valueOf(1000L))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    JSONAssert.assertEquals(
+      "{\"value\":\"1000\",\"mpt_issuance_id\":\"" + ISSUANCE_ID + "\"}",
+      objectMapper.writeValueAsString(amount),
+      JSONCompareMode.STRICT
+    );
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/TokenAmountDeserializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/TokenAmountDeserializerTest.java
@@ -1,0 +1,138 @@
+package org.xrpl.xrpl4j.model.jackson.modules.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.jackson.modules.TokenAmountDeserializer;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.MpTokenIssuanceId;
+import org.xrpl.xrpl4j.model.transactions.amount.IouTokenAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.MptTokenAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.TokenAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpTokenAmount;
+
+/**
+ * Unit tests for {@link TokenAmountDeserializer} — the polymorphic dispatcher that chooses {@link XrpTokenAmount},
+ * {@link IouTokenAmount}, or {@link MptTokenAmount} based on wire shape.
+ */
+class TokenAmountDeserializerTest {
+
+  private static final String ISSUER = "rJbVo4xrsGN8o3vLKGXe1s1uW8mAMYHamV";
+  private static final String ISSUANCE_ID = "00000143A58DCB491FD36A15A7D3172E6A9F088A5478BA41";
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  // -------------------------------------------------------------------------
+  // XRP dispatch — bare JSON string
+  // -------------------------------------------------------------------------
+
+  @Test
+  void deserializesXrpFromString() throws JsonProcessingException {
+    TokenAmount amount = objectMapper.readValue("\"1000000\"", TokenAmount.class);
+    assertThat(amount).isInstanceOf(XrpTokenAmount.class);
+    XrpTokenAmount xrpTokenAmount = (XrpTokenAmount) amount;
+    assertThat(xrpTokenAmount.amount().value()).isEqualTo("1000000");
+    assertThat(xrpTokenAmount.amount().isNegative()).isFalse();
+  }
+
+  @Test
+  void deserializesNegativeXrpFromString() throws JsonProcessingException {
+    // Negative XRP drop values appear in transaction metadata
+    TokenAmount tokenAmount = objectMapper.readValue("\"-500\"", TokenAmount.class);
+    assertThat(tokenAmount).isInstanceOf(XrpTokenAmount.class);
+    assertThat(((XrpTokenAmount) tokenAmount).amount().isNegative()).isTrue();
+    assertThat(((XrpTokenAmount) tokenAmount).amount().unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(500L));
+  }
+
+  @Test
+  void deserializesZeroXrpFromString() throws JsonProcessingException {
+    TokenAmount amount = objectMapper.readValue("\"0\"", TokenAmount.class);
+    assertThat(amount).isInstanceOf(XrpTokenAmount.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // IOU dispatch — object with currency + issuer fields
+  // -------------------------------------------------------------------------
+
+  @Test
+  void deserializesIouFromObject() throws JsonProcessingException {
+    String json = "{\"value\":\"100.50\",\"currency\":\"USD\",\"issuer\":\"" + ISSUER + "\"}";
+    TokenAmount amount = objectMapper.readValue(json, TokenAmount.class);
+    assertThat(amount).isInstanceOf(IouTokenAmount.class);
+    IouTokenAmount iou = (IouTokenAmount) amount;
+    assertThat(iou.amount().value()).isEqualTo("100.50");
+    assertThat(iou.currency()).isEqualTo("USD");
+    assertThat(iou.issuer()).isEqualTo(Address.of(ISSUER));
+  }
+
+  @Test
+  void deserializesNegativeIouFromObject() throws JsonProcessingException {
+    String json = "{\"value\":\"-50.5\",\"currency\":\"EUR\",\"issuer\":\"" + ISSUER + "\"}";
+    TokenAmount tokenAmount = objectMapper.readValue(json, TokenAmount.class);
+    assertThat(tokenAmount).isInstanceOf(IouTokenAmount.class);
+    assertThat(((IouTokenAmount) tokenAmount).amount().isNegative()).isTrue();
+  }
+
+  @Test
+  void deserializesIouScientificNotation() throws JsonProcessingException {
+    String json = "{\"value\":\"1.23e10\",\"currency\":\"USD\",\"issuer\":\"" + ISSUER + "\"}";
+    TokenAmount amount = objectMapper.readValue(json, TokenAmount.class);
+    assertThat(amount).isInstanceOf(IouTokenAmount.class);
+    assertThat(((IouTokenAmount) amount).amount().value()).isEqualTo("1.23e10");
+  }
+
+  // -------------------------------------------------------------------------
+  // MPT dispatch — object with mpt_issuance_id field
+  // -------------------------------------------------------------------------
+
+  @Test
+  void deserializesMptFromObject() throws JsonProcessingException {
+    String json = "{\"value\":\"1000\",\"mpt_issuance_id\":\"" + ISSUANCE_ID + "\"}";
+    TokenAmount amount = objectMapper.readValue(json, TokenAmount.class);
+    assertThat(amount).isInstanceOf(MptTokenAmount.class);
+    MptTokenAmount mpt = (MptTokenAmount) amount;
+    assertThat(mpt.amount().value()).isEqualTo("1000");
+    assertThat(mpt.mptIssuanceId()).isEqualTo(MpTokenIssuanceId.of(ISSUANCE_ID));
+  }
+
+  @Test
+  void deserializesNegativeMptFromObject() throws JsonProcessingException {
+    // Negative MPT values appear in transaction metadata
+    String json = "{\"value\":\"-500\",\"mpt_issuance_id\":\"" + ISSUANCE_ID + "\"}";
+    TokenAmount amount = objectMapper.readValue(json, TokenAmount.class);
+    assertThat(amount).isInstanceOf(MptTokenAmount.class);
+    MptTokenAmount mpt = (MptTokenAmount) amount;
+    assertThat(mpt.isNegative()).isTrue();
+    assertThat(mpt.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(500L));
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/XrpAmountDeserializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/XrpAmountDeserializerTest.java
@@ -1,0 +1,86 @@
+package org.xrpl.xrpl4j.model.jackson.modules.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.jackson.modules.XrpAmountDeserializer;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpAmount;
+
+/**
+ * Unit tests for {@link XrpAmountDeserializer}.
+ */
+class XrpAmountDeserializerTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  @Test
+  void deserializesPositiveDrops() throws JsonProcessingException {
+    XrpAmount amount = objectMapper.readValue("\"1000000\"", XrpAmount.class);
+    assertThat(amount.value()).isEqualTo("1000000");
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(1_000_000L));
+  }
+
+  @Test
+  void deserializesZero() throws JsonProcessingException {
+    XrpAmount amount = objectMapper.readValue("\"0\"", XrpAmount.class);
+    assertThat(amount.value()).isEqualTo("0");
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.ZERO);
+  }
+
+  @Test
+  void deserializesNegativeDrops() throws JsonProcessingException {
+    // Negative drop counts appear in transaction metadata
+    XrpAmount amount = objectMapper.readValue("\"-500\"", XrpAmount.class);
+    assertThat(amount.value()).isEqualTo("-500");
+    assertThat(amount.isNegative()).isTrue();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(500L));
+  }
+
+  @Test
+  void roundTrip() throws JsonProcessingException {
+    XrpAmount original = XrpAmount.ofDrops(1_000_000L);
+    String json = objectMapper.writeValueAsString(original);
+    XrpAmount deserialized = objectMapper.readValue(json, XrpAmount.class);
+    assertThat(deserialized).isEqualTo(original);
+  }
+
+  @Test
+  void roundTripNegative() throws JsonProcessingException {
+    XrpAmount original = XrpAmount.ofDrops(-500L);
+    String json = objectMapper.writeValueAsString(original);
+    XrpAmount deserialized = objectMapper.readValue(json, XrpAmount.class);
+    assertThat(deserialized).isEqualTo(original);
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/XrpAmountSerializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/XrpAmountSerializerTest.java
@@ -1,0 +1,66 @@
+package org.xrpl.xrpl4j.model.jackson.modules.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.jackson.modules.XrpAmountSerializer;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpAmount;
+
+/**
+ * Unit tests for {@link XrpAmountSerializer}.
+ */
+class XrpAmountSerializerTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  @Test
+  void serializesPositiveDrops() throws JsonProcessingException {
+    assertThat(objectMapper.writeValueAsString(XrpAmount.ofDrops(1_000_000L))).isEqualTo("\"1000000\"");
+  }
+
+  @Test
+  void serializesZero() throws JsonProcessingException {
+    assertThat(objectMapper.writeValueAsString(XrpAmount.ofDrops(0L))).isEqualTo("\"0\"");
+  }
+
+  @Test
+  void serializesNegativeDrops() throws JsonProcessingException {
+    // Negative values appear in transaction metadata
+    assertThat(objectMapper.writeValueAsString(XrpAmount.ofDrops(-500L))).isEqualTo("\"-500\"");
+  }
+
+  @Test
+  void serializesMaxDrops() throws JsonProcessingException {
+    assertThat(objectMapper.writeValueAsString(XrpAmount.ofDrops(XrpAmount.MAX_XRP_IN_DROPS)))
+      .isEqualTo("\"" + XrpAmount.MAX_XRP_IN_DROPS + "\"");
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/XrpTokenAmountDeserializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/XrpTokenAmountDeserializerTest.java
@@ -1,0 +1,96 @@
+package org.xrpl.xrpl4j.model.jackson.modules.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.jackson.modules.XrpTokenAmountDeserializer;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpAmount;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpTokenAmount;
+
+/**
+ * Unit tests for {@link XrpTokenAmountDeserializer}.
+ */
+class XrpTokenAmountDeserializerTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  @Test
+  void deserializesPositiveDrops() throws JsonProcessingException {
+    XrpTokenAmount xrpTokenAmount = objectMapper.readValue("\"1000000\"", XrpTokenAmount.class);
+    assertThat(xrpTokenAmount.amount().value()).isEqualTo("1000000");
+    assertThat(xrpTokenAmount.amount().isNegative()).isFalse();
+    assertThat(xrpTokenAmount.amount().unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(1_000_000L));
+  }
+
+  @Test
+  void deserializesZeroDrops() throws JsonProcessingException {
+    XrpTokenAmount xrpTokenAmount = objectMapper.readValue("\"0\"", XrpTokenAmount.class);
+    assertThat(xrpTokenAmount.amount().value()).isEqualTo("0");
+    assertThat(xrpTokenAmount.amount().isNegative()).isFalse();
+  }
+
+  @Test
+  void deserializesNegativeDrops() throws JsonProcessingException {
+    // Negative drop counts appear in transaction metadata
+    XrpTokenAmount xrpTokenAmount = objectMapper.readValue("\"-500\"", XrpTokenAmount.class);
+    assertThat(xrpTokenAmount.amount().value()).isEqualTo("-500");
+    assertThat(xrpTokenAmount.amount().isNegative()).isTrue();
+    assertThat(xrpTokenAmount.amount().unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(500L));
+  }
+
+  @Test
+  void roundTrip() throws JsonProcessingException {
+    XrpTokenAmount original = XrpTokenAmount.ofDrops(1_000_000L);
+    String json = objectMapper.writeValueAsString(original);
+    XrpTokenAmount deserialized = objectMapper.readValue(json, XrpTokenAmount.class);
+    assertThat(deserialized).isEqualTo(original);
+  }
+
+  @Test
+  void roundTripNegative() throws JsonProcessingException {
+    XrpTokenAmount original = XrpTokenAmount.ofDrops(-500L);
+    String json = objectMapper.writeValueAsString(original);
+    XrpTokenAmount deserialized = objectMapper.readValue(json, XrpTokenAmount.class);
+    assertThat(deserialized).isEqualTo(original);
+  }
+
+  @Test
+  void ofXrpAmountFactory() throws JsonProcessingException {
+    // XrpTokenAmount.of(XrpAmount) is the wrap factory used by XrpTokenAmountDeserializer
+    XrpAmount xrpAmount = XrpAmount.ofDrops(1_000_000L);
+    XrpTokenAmount wrapped = XrpTokenAmount.of(xrpAmount);
+    assertThat(wrapped.amount()).isEqualTo(xrpAmount);
+    // Verify it serializes correctly
+    assertThat(objectMapper.writeValueAsString(wrapped)).isEqualTo("\"1000000\"");
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/XrpTokenAmountSerializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/amount/XrpTokenAmountSerializerTest.java
@@ -1,0 +1,67 @@
+package org.xrpl.xrpl4j.model.jackson.modules.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.jackson.modules.XrpTokenAmountSerializer;
+import org.xrpl.xrpl4j.model.transactions.amount.XrpTokenAmount;
+
+/**
+ * Unit tests for {@link XrpTokenAmountSerializer}.
+ */
+class XrpTokenAmountSerializerTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  @Test
+  void serializesDropsAsString() throws JsonProcessingException {
+    assertThat(objectMapper.writeValueAsString(XrpTokenAmount.ofDrops(1_000_000L))).isEqualTo("\"1000000\"");
+  }
+
+  @Test
+  void serializesZeroDrops() throws JsonProcessingException {
+    assertThat(objectMapper.writeValueAsString(XrpTokenAmount.ofDrops(0L))).isEqualTo("\"0\"");
+  }
+
+  @Test
+  void serializesNegativeDrops() throws JsonProcessingException {
+    // Negative values appear in transaction metadata
+    assertThat(objectMapper.writeValueAsString(XrpTokenAmount.ofDrops(-500L))).isEqualTo("\"-500\"");
+  }
+
+  @Test
+  void serializesFromUnsignedLong() throws JsonProcessingException {
+    assertThat(objectMapper.writeValueAsString(XrpTokenAmount.ofDrops(UnsignedLong.valueOf(1_000_000L))))
+      .isEqualTo("\"1000000\"");
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/AmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/AmountTest.java
@@ -1,0 +1,221 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Unit tests for {@link Amount} — {@link Amount#isNegative()}, {@link Amount#handle}, and {@link Amount#map}.
+ *
+ * <p>Because {@link Amount} is an interface, each test exercises it through one of its three
+ * concrete subtypes ({@link XrpAmount}, {@link IouAmount}, {@link MptAmount}).
+ */
+class AmountTest {
+
+  // -------------------------------------------------------------------------
+  // isNegative()
+  // -------------------------------------------------------------------------
+
+  @Test
+  void isNegativeFalseForPositiveXrp() {
+    assertThat((Amount) XrpAmount.ofDrops(1_000L)).satisfies(a -> assertThat(a.isNegative()).isFalse());
+  }
+
+  @Test
+  void isNegativeTrueForNegativeXrp() {
+    assertThat((Amount) XrpAmount.ofDrops(-1_000L)).satisfies(a -> assertThat(a.isNegative()).isTrue());
+  }
+
+  @Test
+  void isNegativeFalseForPositiveIou() {
+    assertThat((Amount) IouAmount.of("100.50")).satisfies(a -> assertThat(a.isNegative()).isFalse());
+  }
+
+  @Test
+  void isNegativeTrueForNegativeIou() {
+    assertThat((Amount) IouAmount.of("-100.50")).satisfies(a -> assertThat(a.isNegative()).isTrue());
+  }
+
+  @Test
+  void isNegativeFalseForPositiveMpt() {
+    assertThat((Amount) MptAmount.of(UnsignedLong.valueOf(1_000L))).satisfies(a -> assertThat(a.isNegative()).isFalse());
+  }
+
+  @Test
+  void isNegativeTrueForNegativeMpt() {
+    assertThat((Amount) MptAmount.of(UnsignedLong.valueOf(1_000L), true))
+      .satisfies(a -> assertThat(a.isNegative()).isTrue());
+  }
+
+  // -------------------------------------------------------------------------
+  // handle() — correct branch dispatched
+  // -------------------------------------------------------------------------
+
+  @Test
+  void handleDispatchesToXrpHandler() {
+    AtomicBoolean xrpCalled = new AtomicBoolean(false);
+    XrpAmount.ofDrops(1_000L).handle(
+      xrp -> xrpCalled.set(true),
+      mpt -> { throw new AssertionError("mpt handler called for XrpAmount"); },
+      iou -> { throw new AssertionError("iou handler called for XrpAmount"); }
+    );
+    assertThat(xrpCalled).isTrue();
+  }
+
+  @Test
+  void handleDispatchesToMptHandler() {
+    AtomicBoolean mptCalled = new AtomicBoolean(false);
+    MptAmount.of(UnsignedLong.valueOf(1_000L)).handle(
+      xrp -> { throw new AssertionError("xrp handler called for MptAmount"); },
+      mpt -> mptCalled.set(true),
+      iou -> { throw new AssertionError("iou handler called for MptAmount"); }
+    );
+    assertThat(mptCalled).isTrue();
+  }
+
+  @Test
+  void handleDispatchesToIouHandler() {
+    AtomicBoolean iouCalled = new AtomicBoolean(false);
+    IouAmount.of("100.50").handle(
+      xrp -> { throw new AssertionError("xrp handler called for IouAmount"); },
+      mpt -> { throw new AssertionError("mpt handler called for IouAmount"); },
+      iou -> iouCalled.set(true)
+    );
+    assertThat(iouCalled).isTrue();
+  }
+
+  @Test
+  void handlePassesCorrectValueToXrpHandler() {
+    XrpAmount xrp = XrpAmount.ofDrops(42_000L);
+    xrp.handle(
+      received -> assertThat(received).isEqualTo(xrp),
+      mpt -> { },
+      iou -> { }
+    );
+  }
+
+  @Test
+  void handlePassesCorrectValueToMptHandler() {
+    MptAmount mpt = MptAmount.of(UnsignedLong.valueOf(99L));
+    mpt.handle(
+      xrp -> { },
+      received -> assertThat(received).isEqualTo(mpt),
+      iou -> { }
+    );
+  }
+
+  @Test
+  void handlePassesCorrectValueToIouHandler() {
+    IouAmount iou = IouAmount.of("7.77");
+    iou.handle(
+      xrp -> { },
+      mpt -> { },
+      received -> assertThat(received).isEqualTo(iou)
+    );
+  }
+
+  @Test
+  void handleNullXrpHandlerThrows() {
+    assertThatThrownBy(() -> XrpAmount.ofDrops(1L).handle(null, mpt -> { }, iou -> { }))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void handleNullMptHandlerThrows() {
+    assertThatThrownBy(() -> XrpAmount.ofDrops(1L).handle(xrp -> { }, null, iou -> { }))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void handleNullIouHandlerThrows() {
+    assertThatThrownBy(() -> XrpAmount.ofDrops(1L).handle(xrp -> { }, mpt -> { }, null))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // map() — correct branch dispatched and return value propagated
+  // -------------------------------------------------------------------------
+
+  @Test
+  void mapDispatchesToXrpMapper() {
+    String result = XrpAmount.ofDrops(1_000L).map(
+      xrp -> "xrp",
+      mpt -> { throw new AssertionError("mpt mapper called for XrpAmount"); },
+      iou -> { throw new AssertionError("iou mapper called for XrpAmount"); }
+    );
+    assertThat(result).isEqualTo("xrp");
+  }
+
+  @Test
+  void mapDispatchesToMptMapper() {
+    String result = MptAmount.of(UnsignedLong.valueOf(1_000L)).map(
+      xrp -> { throw new AssertionError("xrp mapper called for MptAmount"); },
+      mpt -> "mpt",
+      iou -> { throw new AssertionError("iou mapper called for MptAmount"); }
+    );
+    assertThat(result).isEqualTo("mpt");
+  }
+
+  @Test
+  void mapDispatchesToIouMapper() {
+    String result = IouAmount.of("100.50").map(
+      xrp -> { throw new AssertionError("xrp mapper called for IouAmount"); },
+      mpt -> { throw new AssertionError("mpt mapper called for IouAmount"); },
+      iou -> "iou"
+    );
+    assertThat(result).isEqualTo("iou");
+  }
+
+  @Test
+  void mapReturnsValueFromXrpMapper() {
+    XrpAmount xrp = XrpAmount.ofDrops(1_000_000L);
+    Long drops = xrp.map(
+      x -> x.unsignedLongValue().longValue(),
+      mpt -> -1L,
+      iou -> -1L
+    );
+    assertThat(drops).isEqualTo(1_000_000L);
+  }
+
+  @Test
+  void mapNullXrpMapperThrows() {
+    assertThatThrownBy(() -> XrpAmount.ofDrops(1L).map(null, mpt -> "mpt", iou -> "iou"))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void mapNullMptMapperThrows() {
+    assertThatThrownBy(() -> XrpAmount.ofDrops(1L).map(xrp -> "xrp", null, iou -> "iou"))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void mapNullIouMapperThrows() {
+    assertThatThrownBy(() -> XrpAmount.ofDrops(1L).map(xrp -> "xrp", mpt -> "mpt", null))
+      .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/IouAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/IouAmountTest.java
@@ -1,0 +1,132 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+/**
+ * Unit tests for {@link IouAmount} — factory methods and accessor helpers.
+ */
+class IouAmountTest {
+
+  // -------------------------------------------------------------------------
+  // of(String)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void ofStringDecimal() {
+    IouAmount amount = IouAmount.of("100.50");
+    assertThat(amount.value()).isEqualTo("100.50");
+    assertThat(amount.isNegative()).isFalse();
+  }
+
+  @Test
+  void ofStringNegative() {
+    IouAmount amount = IouAmount.of("-50.5");
+    assertThat(amount.value()).isEqualTo("-50.5");
+    assertThat(amount.isNegative()).isTrue();
+  }
+
+  @Test
+  void ofStringScientificNotation() {
+    // Scientific notation is preserved verbatim
+    IouAmount amount = IouAmount.of("1.23e10");
+    assertThat(amount.value()).isEqualTo("1.23e10");
+  }
+
+  @Test
+  void ofStringZero() {
+    IouAmount amount = IouAmount.of("0");
+    assertThat(amount.value()).isEqualTo("0");
+    assertThat(amount.isNegative()).isFalse();
+  }
+
+  @Test
+  void ofStringInvalidThrows() {
+    assertThatThrownBy(() -> IouAmount.of("not-a-number"))
+      .isInstanceOf(NumberFormatException.class);
+  }
+
+  @Test
+  void ofStringNullThrows() {
+    assertThatThrownBy(() -> IouAmount.of((String) null))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // of(BigDecimal)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void ofBigDecimalPositive() {
+    IouAmount amount = IouAmount.of(new BigDecimal("100.50"));
+    // BigDecimal.toPlainString() does not use scientific notation
+    assertThat(amount.value()).isEqualTo("100.50");
+    assertThat(amount.isNegative()).isFalse();
+  }
+
+  @Test
+  void ofBigDecimalNegative() {
+    IouAmount amount = IouAmount.of(new BigDecimal("-50.5"));
+    assertThat(amount.value()).isEqualTo("-50.5");
+    assertThat(amount.isNegative()).isTrue();
+  }
+
+  @Test
+  void ofBigDecimalAvoidsSciNotation() {
+    // 1.23e10 as BigDecimal → toPlainString() = "12300000000"
+    IouAmount amount = IouAmount.of(new BigDecimal("1.23e10"));
+    assertThat(amount.value()).isEqualTo("12300000000");
+  }
+
+  @Test
+  void ofBigDecimalNullThrows() {
+    assertThatThrownBy(() -> IouAmount.of((BigDecimal) null))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // bigDecimalValue()
+  // -------------------------------------------------------------------------
+
+  @Test
+  void bigDecimalValueFromPlainString() {
+    IouAmount amount = IouAmount.of("100.50");
+    assertThat(amount.bigDecimalValue()).isEqualByComparingTo(new BigDecimal("100.50"));
+  }
+
+  @Test
+  void bigDecimalValueFromScientificNotation() {
+    IouAmount amount = IouAmount.of("1.23e10");
+    assertThat(amount.bigDecimalValue()).isEqualByComparingTo(new BigDecimal("12300000000"));
+  }
+
+  @Test
+  void bigDecimalValueNegative() {
+    IouAmount amount = IouAmount.of("-50.5");
+    assertThat(amount.bigDecimalValue()).isEqualByComparingTo(new BigDecimal("-50.5"));
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/IouTokenAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/IouTokenAmountTest.java
@@ -1,0 +1,182 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.transactions.Address;
+
+/**
+ * Unit tests for {@link IouTokenAmount} — builder, accessors, and boundary constants.
+ */
+class IouTokenAmountTest {
+
+  private static final String ISSUER = "rJbVo4xrsGN8o3vLKGXe1s1uW8mAMYHamV";
+
+  // -------------------------------------------------------------------------
+  // builder + accessors
+  // -------------------------------------------------------------------------
+
+  @Test
+  void builderSetsAllFields() {
+    IouTokenAmount amount = IouTokenAmount.builder()
+      .amount(IouAmount.of("100.50"))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+
+    assertThat(amount.amount().value()).isEqualTo("100.50");
+    assertThat(amount.currency()).isEqualTo("USD");
+    assertThat(amount.issuer()).isEqualTo(Address.of(ISSUER));
+  }
+
+  @Test
+  void builderWithNegativeAmount() {
+    // Negative IOU values appear in transaction metadata
+    IouTokenAmount amount = IouTokenAmount.builder()
+      .amount(IouAmount.of("-50.5"))
+      .currency("EUR")
+      .issuer(Address.of(ISSUER))
+      .build();
+
+    assertThat(amount.amount().isNegative()).isTrue();
+    assertThat(amount.amount().value()).isEqualTo("-50.5");
+  }
+
+  @Test
+  void builderWithScientificNotation() {
+    IouTokenAmount amount = IouTokenAmount.builder()
+      .amount(IouAmount.of("1.23e10"))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+
+    assertThat(amount.amount().value()).isEqualTo("1.23e10");
+  }
+
+  @Test
+  void builderWithHexCurrencyCode() {
+    // Non-standard 40-character hex currency codes are preserved verbatim
+    String hexCurrency = "7872706C346A436F696E00000000000000000000";
+    IouTokenAmount amount = IouTokenAmount.builder()
+      .amount(IouAmount.of("15"))
+      .currency(hexCurrency)
+      .issuer(Address.of(ISSUER))
+      .build();
+
+    assertThat(amount.currency()).isEqualTo(hexCurrency);
+  }
+
+  // -------------------------------------------------------------------------
+  // boundary constants
+  // -------------------------------------------------------------------------
+
+  @Test
+  void maxValueConstantIsParseable() {
+    // Verify the constant is a valid numeric string
+    IouTokenAmount amount = IouTokenAmount.builder()
+      .amount(IouAmount.of(IouTokenAmount.MAX_VALUE))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+    assertThat(amount.amount().value()).isEqualTo(IouTokenAmount.MAX_VALUE);
+    assertThat(amount.amount().isNegative()).isFalse();
+  }
+
+  @Test
+  void minValueConstantIsParseable() {
+    IouTokenAmount amount = IouTokenAmount.builder()
+      .amount(IouAmount.of(IouTokenAmount.MIN_VALUE))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+    assertThat(amount.amount().isNegative()).isTrue();
+  }
+
+  @Test
+  void minPositiveValueConstantIsParseable() {
+    IouTokenAmount amount = IouTokenAmount.builder()
+      .amount(IouAmount.of(IouTokenAmount.MIN_POSITIVE_VALUE))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+    assertThat(amount.amount().isNegative()).isFalse();
+  }
+
+  @Test
+  void maxNegativeValueConstantIsParseable() {
+    IouTokenAmount amount = IouTokenAmount.builder()
+      .amount(IouAmount.of(IouTokenAmount.MAX_NEGATIVE_VALUE))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+    assertThat(amount.amount().isNegative()).isTrue();
+  }
+
+  // -------------------------------------------------------------------------
+  // equality
+  // -------------------------------------------------------------------------
+
+  @Test
+  void equalAmountsAreEqual() {
+    IouTokenAmount a = IouTokenAmount.builder()
+      .amount(IouAmount.of("100.50"))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+    IouTokenAmount b = IouTokenAmount.builder()
+      .amount(IouAmount.of("100.50"))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+    assertThat(a).isEqualTo(b);
+  }
+
+  @Test
+  void differentCurrenciesAreNotEqual() {
+    IouTokenAmount a = IouTokenAmount.builder()
+      .amount(IouAmount.of("100.50"))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+    IouTokenAmount b = IouTokenAmount.builder()
+      .amount(IouAmount.of("100.50"))
+      .currency("EUR")
+      .issuer(Address.of(ISSUER))
+      .build();
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  // -------------------------------------------------------------------------
+  // implements TokenAmount
+  // -------------------------------------------------------------------------
+
+  @Test
+  void isInstanceOfTokenAmount() {
+    IouTokenAmount amount = IouTokenAmount.builder()
+      .amount(IouAmount.of("1"))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+    assertThat(amount).isInstanceOf(TokenAmount.class);
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/MptAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/MptAmountTest.java
@@ -1,0 +1,154 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link MptAmount} — factory methods and accessor helpers.
+ */
+class MptAmountTest {
+
+  // -------------------------------------------------------------------------
+  // of(UnsignedLong) — non-negative factory
+  // -------------------------------------------------------------------------
+
+  @Test
+  void ofPositive() {
+    MptAmount amount = MptAmount.of(UnsignedLong.valueOf(1_000L));
+    assertThat(amount.value()).isEqualTo("1000");
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(1_000L));
+  }
+
+  @Test
+  void ofZero() {
+    MptAmount amount = MptAmount.of(UnsignedLong.ZERO);
+    assertThat(amount.value()).isEqualTo("0");
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.ZERO);
+  }
+
+  @Test
+  void ofMaxLong() {
+    UnsignedLong maxLong = UnsignedLong.valueOf(Long.MAX_VALUE);
+    MptAmount amount = MptAmount.of(maxLong);
+    assertThat(amount.value()).isEqualTo(maxLong.toString());
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(maxLong);
+  }
+
+  @Test
+  void ofNullThrows() {
+    assertThatThrownBy(() -> MptAmount.of(null))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // of(UnsignedLong, boolean) — signed factory (e.g. from metadata)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void ofWithSignFalse() {
+    MptAmount amount = MptAmount.of(UnsignedLong.valueOf(500L), false);
+    assertThat(amount.value()).isEqualTo("500");
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(500L));
+  }
+
+  @Test
+  void ofWithSignTrue() {
+    MptAmount amount = MptAmount.of(UnsignedLong.valueOf(500L), true);
+    assertThat(amount.value()).isEqualTo("-500");
+    assertThat(amount.isNegative()).isTrue();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(500L));
+  }
+
+  @Test
+  void ofNegativeZero() {
+    // isNegative=true with magnitude 0 — unusual but must not throw
+    MptAmount amount = MptAmount.of(UnsignedLong.ZERO, true);
+    assertThat(amount.value()).isEqualTo("-0");
+    assertThat(amount.isNegative()).isTrue();
+  }
+
+  @Test
+  void ofSignedNullThrows() {
+    assertThatThrownBy(() -> MptAmount.of(null, true))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // isNegative()
+  // -------------------------------------------------------------------------
+
+  @Test
+  void isNegativeFalseForPositive() {
+    assertThat(MptAmount.of(UnsignedLong.ONE).isNegative()).isFalse();
+  }
+
+  @Test
+  void isNegativeTrueForNegative() {
+    assertThat(MptAmount.of(UnsignedLong.ONE, true).isNegative()).isTrue();
+  }
+
+  // -------------------------------------------------------------------------
+  // unsignedLongValue() — magnitude extraction
+  // -------------------------------------------------------------------------
+
+  @Test
+  void unsignedLongValueStripsSign() {
+    MptAmount amount = MptAmount.of(UnsignedLong.valueOf(12345L), true);
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(12345L));
+  }
+
+  @Test
+  void unsignedLongValuePositivePassthrough() {
+    MptAmount amount = MptAmount.of(UnsignedLong.valueOf(12345L));
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(12345L));
+  }
+
+  // -------------------------------------------------------------------------
+  // equality
+  // -------------------------------------------------------------------------
+
+  @Test
+  void equalAmountsAreEqual() {
+    assertThat(MptAmount.of(UnsignedLong.valueOf(1_000L)))
+      .isEqualTo(MptAmount.of(UnsignedLong.valueOf(1_000L)));
+  }
+
+  @Test
+  void differentMagnitudesAreNotEqual() {
+    assertThat(MptAmount.of(UnsignedLong.valueOf(1_000L)))
+      .isNotEqualTo(MptAmount.of(UnsignedLong.valueOf(2_000L)));
+  }
+
+  @Test
+  void positiveAndNegativeAreNotEqual() {
+    assertThat(MptAmount.of(UnsignedLong.valueOf(1_000L)))
+      .isNotEqualTo(MptAmount.of(UnsignedLong.valueOf(1_000L), true));
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/MptTokenAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/MptTokenAmountTest.java
@@ -1,0 +1,220 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.transactions.MpTokenIssuanceId;
+
+/**
+ * Unit tests for {@link MptTokenAmount} — builders, accessors, and derived helpers.
+ */
+class MptTokenAmountTest {
+
+  private static final String ISSUANCE_ID = "00000143A58DCB491FD36A15A7D3172E6A9F088A5478BA41";
+
+  // -------------------------------------------------------------------------
+  // builder() — raw builder with explicit MptAmount
+  // -------------------------------------------------------------------------
+
+  @Test
+  void builderWithExplicitAmount() {
+    MptTokenAmount amount = MptTokenAmount.builder()
+      .amount(MptAmount.of(UnsignedLong.valueOf(1_000L)))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+
+    assertThat(amount.amount().value()).isEqualTo("1000");
+    assertThat(amount.mptIssuanceId()).isEqualTo(MpTokenIssuanceId.of(ISSUANCE_ID));
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(1_000L));
+  }
+
+  @Test
+  void builderWithZeroAmount() {
+    MptTokenAmount amount = MptTokenAmount.builder()
+      .amount(MptAmount.of(UnsignedLong.ZERO))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+
+    assertThat(amount.amount().value()).isEqualTo("0");
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.ZERO);
+  }
+
+  @Test
+  void builderWithNegativeAmount() {
+    // Negative MPT values appear in transaction metadata
+    MptTokenAmount amount = MptTokenAmount.builder()
+      .amount(MptAmount.of(UnsignedLong.valueOf(500L), true))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+
+    assertThat(amount.amount().value()).isEqualTo("-500");
+    assertThat(amount.isNegative()).isTrue();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(500L));
+  }
+
+  // -------------------------------------------------------------------------
+  // builder(UnsignedLong) — convenience factory
+  // -------------------------------------------------------------------------
+
+  @Test
+  void convenienceBuilderSetsAmount() {
+    MptTokenAmount amount = MptTokenAmount.builder(UnsignedLong.valueOf(1_000L))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+
+    assertThat(amount.amount().value()).isEqualTo("1000");
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(1_000L));
+  }
+
+  @Test
+  void convenienceBuilderWithZero() {
+    MptTokenAmount amount = MptTokenAmount.builder(UnsignedLong.ZERO)
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+
+    assertThat(amount.amount().value()).isEqualTo("0");
+    assertThat(amount.isNegative()).isFalse();
+  }
+
+  @Test
+  void convenienceBuilderProducesSameResultAsExplicitBuilder() {
+    MptTokenAmount fromConvenience = MptTokenAmount.builder(UnsignedLong.valueOf(1_000L))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    MptTokenAmount fromExplicit = MptTokenAmount.builder()
+      .amount(MptAmount.of(UnsignedLong.valueOf(1_000L)))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+
+    assertThat(fromConvenience).isEqualTo(fromExplicit);
+  }
+
+  // -------------------------------------------------------------------------
+  // isNegative() — delegates to MptAmount
+  // -------------------------------------------------------------------------
+
+  @Test
+  void isNegativeFalseForPositiveAmount() {
+    MptTokenAmount amount = MptTokenAmount.builder(UnsignedLong.valueOf(1_000L))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    assertThat(amount.isNegative()).isFalse();
+  }
+
+  @Test
+  void isNegativeTrueForNegativeAmount() {
+    MptTokenAmount amount = MptTokenAmount.builder()
+      .amount(MptAmount.of(UnsignedLong.valueOf(500L), true))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    assertThat(amount.isNegative()).isTrue();
+  }
+
+  // -------------------------------------------------------------------------
+  // unsignedLongValue() — delegates to MptAmount, strips sign
+  // -------------------------------------------------------------------------
+
+  @Test
+  void unsignedLongValueForPositive() {
+    MptTokenAmount amount = MptTokenAmount.builder(UnsignedLong.valueOf(99_999L))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(99_999L));
+  }
+
+  @Test
+  void unsignedLongValueStripsSignForNegative() {
+    MptTokenAmount amount = MptTokenAmount.builder()
+      .amount(MptAmount.of(UnsignedLong.valueOf(500L), true))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(500L));
+  }
+
+  // -------------------------------------------------------------------------
+  // mptIssuanceId() accessor
+  // -------------------------------------------------------------------------
+
+  @Test
+  void mptIssuanceIdAccessor() {
+    MpTokenIssuanceId id = MpTokenIssuanceId.of(ISSUANCE_ID);
+    MptTokenAmount amount = MptTokenAmount.builder(UnsignedLong.ONE)
+      .mptIssuanceId(id)
+      .build();
+    assertThat(amount.mptIssuanceId()).isEqualTo(id);
+  }
+
+  // -------------------------------------------------------------------------
+  // equality
+  // -------------------------------------------------------------------------
+
+  @Test
+  void equalAmountsAreEqual() {
+    MptTokenAmount a = MptTokenAmount.builder(UnsignedLong.valueOf(1_000L))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    MptTokenAmount b = MptTokenAmount.builder(UnsignedLong.valueOf(1_000L))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    assertThat(a).isEqualTo(b);
+  }
+
+  @Test
+  void differentAmountsAreNotEqual() {
+    MptTokenAmount a = MptTokenAmount.builder(UnsignedLong.valueOf(1_000L))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    MptTokenAmount b = MptTokenAmount.builder(UnsignedLong.valueOf(2_000L))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  @Test
+  void positiveAndNegativeAreNotEqual() {
+    MptTokenAmount positive = MptTokenAmount.builder(UnsignedLong.valueOf(500L))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    MptTokenAmount negative = MptTokenAmount.builder()
+      .amount(MptAmount.of(UnsignedLong.valueOf(500L), true))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    assertThat(positive).isNotEqualTo(negative);
+  }
+
+  // -------------------------------------------------------------------------
+  // implements TokenAmount
+  // -------------------------------------------------------------------------
+
+  @Test
+  void isInstanceOfTokenAmount() {
+    MptTokenAmount amount = MptTokenAmount.builder(UnsignedLong.ONE)
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+    assertThat(amount).isInstanceOf(TokenAmount.class);
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/TokenAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/TokenAmountTest.java
@@ -1,0 +1,237 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.transactions.Address;
+import org.xrpl.xrpl4j.model.transactions.MpTokenIssuanceId;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Unit tests for {@link TokenAmount} — {@link TokenAmount#handle} and {@link TokenAmount#map}.
+ *
+ * <p>Because {@link TokenAmount} is an interface, each test exercises it through one of its three
+ * concrete subtypes ({@link XrpTokenAmount}, {@link IouTokenAmount}, {@link MptTokenAmount}).
+ */
+class TokenAmountTest {
+
+  private static final String ISSUER = "rJbVo4xrsGN8o3vLKGXe1s1uW8mAMYHamV";
+  private static final String ISSUANCE_ID = "00000143A58DCB491FD36A15A7D3172E6A9F088A5478BA41";
+
+  private XrpTokenAmount xrp() {
+    return XrpTokenAmount.ofDrops(1_000_000L);
+  }
+
+  private IouTokenAmount iou() {
+    return IouTokenAmount.builder()
+      .amount(IouAmount.of("100.50"))
+      .currency("USD")
+      .issuer(Address.of(ISSUER))
+      .build();
+  }
+
+  private MptTokenAmount mpt() {
+    return MptTokenAmount.builder(UnsignedLong.valueOf(1_000L))
+      .mptIssuanceId(MpTokenIssuanceId.of(ISSUANCE_ID))
+      .build();
+  }
+
+  // -------------------------------------------------------------------------
+  // handle() — correct branch dispatched
+  // -------------------------------------------------------------------------
+
+  @Test
+  void handleDispatchesToXrpHandler() {
+    AtomicBoolean xrpCalled = new AtomicBoolean(false);
+    xrp().handle(
+      xrp -> xrpCalled.set(true),
+      iou -> {
+        throw new AssertionError("iou handler called for XrpTokenAmount");
+      },
+      mpt -> {
+        throw new AssertionError("mpt handler called for XrpTokenAmount");
+      }
+    );
+    assertThat(xrpCalled).isTrue();
+  }
+
+  @Test
+  void handleDispatchesToIouHandler() {
+    AtomicBoolean iouCalled = new AtomicBoolean(false);
+    iou().handle(
+      xrp -> {
+        throw new AssertionError("xrp handler called for IouTokenAmount");
+      },
+      iou -> iouCalled.set(true),
+      mpt -> {
+        throw new AssertionError("mpt handler called for IouTokenAmount");
+      }
+    );
+    assertThat(iouCalled).isTrue();
+  }
+
+  @Test
+  void handleDispatchesToMptHandler() {
+    AtomicBoolean mptCalled = new AtomicBoolean(false);
+    mpt().handle(
+      xrp -> {
+        throw new AssertionError("xrp handler called for MptTokenAmount");
+      },
+      iou -> {
+        throw new AssertionError("iou handler called for MptTokenAmount");
+      },
+      mpt -> mptCalled.set(true)
+    );
+    assertThat(mptCalled).isTrue();
+  }
+
+  @Test
+  void handlePassesCorrectXrpInstance() {
+    XrpTokenAmount expected = xrp();
+    expected.handle(
+      received -> assertThat(received).isEqualTo(expected),
+      iou -> {
+      },
+      mpt -> {
+      }
+    );
+  }
+
+  @Test
+  void handlePassesCorrectIouInstance() {
+    IouTokenAmount expected = iou();
+    expected.handle(
+      xrp -> {
+      },
+      received -> assertThat(received).isEqualTo(expected),
+      mpt -> {
+      }
+    );
+  }
+
+  @Test
+  void handlePassesCorrectMptInstance() {
+    MptTokenAmount expected = mpt();
+    expected.handle(
+      xrp -> {
+      },
+      iou -> {
+      },
+      received -> assertThat(received).isEqualTo(expected)
+    );
+  }
+
+  @Test
+  void handleNullXrpHandlerThrows() {
+    assertThatThrownBy(() -> xrp().handle(null, iou -> {
+    }, mpt -> {
+    }))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void handleNullIouHandlerThrows() {
+    assertThatThrownBy(() -> xrp().handle(xrp -> {
+    }, null, mpt -> {
+    }))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void handleNullMptHandlerThrows() {
+    assertThatThrownBy(() -> xrp().handle(xrp -> {
+    }, iou -> {
+    }, null))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // map() — correct branch and return value
+  // -------------------------------------------------------------------------
+
+  @Test
+  void mapDispatchesToXrpMapper() {
+    assertThat(xrp().map(xrp -> "xrp", iou -> "iou", mpt -> "mpt").toString()).isEqualTo("xrp");
+  }
+
+  @Test
+  void mapDispatchesToIouMapper() {
+    assertThat(iou().map(xrp -> "xrp", iou -> "iou", mpt -> "mpt").toString()).isEqualTo("iou");
+  }
+
+  @Test
+  void mapDispatchesToMptMapper() {
+    assertThat(mpt().map(xrp -> "xrp", iou -> "iou", mpt -> "mpt").toString()).isEqualTo("mpt");
+  }
+
+  @Test
+  void mapReturnsValueFromXrpMapper() {
+    Long drops = xrp().map(
+      x -> x.amount().unsignedLongValue().longValue(),
+      iou -> -1L,
+      mpt -> -1L
+    );
+    assertThat(drops).isEqualTo(1_000_000L);
+  }
+
+  @Test
+  void mapReturnsValueFromIouMapper() {
+    String currency = iou().map(
+      xrp -> "wrong",
+      i -> i.currency(),
+      mpt -> "wrong"
+    );
+    assertThat(currency).isEqualTo("USD");
+  }
+
+  @Test
+  void mapReturnsValueFromMptMapper() {
+    MpTokenIssuanceId id = mpt().map(
+      xrp -> null,
+      iou -> null,
+      m -> m.mptIssuanceId()
+    );
+    assertThat(id).isEqualTo(MpTokenIssuanceId.of(ISSUANCE_ID));
+  }
+
+  @Test
+  void mapNullXrpMapperThrows() {
+    assertThatThrownBy(() -> xrp().map(null, iou -> "iou", mpt -> "mpt"))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void mapNullIouMapperThrows() {
+    assertThatThrownBy(() -> xrp().map(xrp -> "xrp", null, mpt -> "mpt"))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void mapNullMptMapperThrows() {
+    assertThatThrownBy(() -> xrp().map(xrp -> "xrp", iou -> "iou", null))
+      .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/XrpAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/XrpAmountTest.java
@@ -1,0 +1,270 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+/**
+ * Unit tests for {@link XrpAmount} — factory methods, arithmetic, and conversion helpers.
+ */
+class XrpAmountTest {
+
+  // -------------------------------------------------------------------------
+  // ofDrops(long)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void ofDropsLongPositive() {
+    XrpAmount amount = XrpAmount.ofDrops(1_000_000L);
+    assertThat(amount.value()).isEqualTo("1000000");
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(1_000_000L));
+  }
+
+  @Test
+  void ofDropsLongZero() {
+    XrpAmount amount = XrpAmount.ofDrops(0L);
+    assertThat(amount.value()).isEqualTo("0");
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.ZERO);
+  }
+
+  @Test
+  void ofDropsLongNegative() {
+    XrpAmount amount = XrpAmount.ofDrops(-500L);
+    assertThat(amount.value()).isEqualTo("-500");
+    assertThat(amount.isNegative()).isTrue();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(500L));
+  }
+
+  // -------------------------------------------------------------------------
+  // ofDrops(UnsignedLong)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void ofDropsUnsignedLong() {
+    XrpAmount amount = XrpAmount.ofDrops(UnsignedLong.valueOf(1_000_000L));
+    assertThat(amount.value()).isEqualTo("1000000");
+    assertThat(amount.isNegative()).isFalse();
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(1_000_000L));
+  }
+
+  @Test
+  void ofDropsUnsignedLongNullThrows() {
+    assertThatThrownBy(() -> XrpAmount.ofDrops((UnsignedLong) null))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // ofXrp(BigDecimal)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void ofXrpOneXrp() {
+    XrpAmount amount = XrpAmount.ofXrp(new BigDecimal("1"));
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(1_000_000L));
+    assertThat(amount.isNegative()).isFalse();
+  }
+
+  @Test
+  void ofXrpFractionalXrp() {
+    // 1.5 XRP = 1,500,000 drops
+    XrpAmount amount = XrpAmount.ofXrp(new BigDecimal("1.5"));
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(1_500_000L));
+    assertThat(amount.isNegative()).isFalse();
+  }
+
+  @Test
+  void ofXrpOneDrop() {
+    // 0.000001 XRP = 1 drop (minimum positive value)
+    XrpAmount amount = XrpAmount.ofXrp(XrpAmount.MIN_XRP_BD);
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.ONE);
+    assertThat(amount.isNegative()).isFalse();
+  }
+
+  @Test
+  void ofXrpZero() {
+    XrpAmount amount = XrpAmount.ofXrp(BigDecimal.ZERO);
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.ZERO);
+    assertThat(amount.isNegative()).isFalse();
+  }
+
+  @Test
+  void ofXrpMaxXrp() {
+    XrpAmount amount = XrpAmount.ofXrp(XrpAmount.MAX_XRP_BD);
+    assertThat(amount.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(XrpAmount.MAX_XRP_IN_DROPS));
+    assertThat(amount.isNegative()).isFalse();
+  }
+
+  @Test
+  void ofXrpBelowMinThrows() {
+    // 0.0000001 XRP = 0.1 drops — sub-drop precision is illegal
+    assertThatThrownBy(() -> XrpAmount.ofXrp(new BigDecimal("0.0000001")))
+      .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void ofXrpAboveMaxThrows() {
+    assertThatThrownBy(() -> XrpAmount.ofXrp(XrpAmount.MAX_XRP_BD.add(BigDecimal.ONE)))
+      .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void ofXrpNullThrows() {
+    assertThatThrownBy(() -> XrpAmount.ofXrp(null))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // toXrp()
+  // -------------------------------------------------------------------------
+
+  @Test
+  void toXrpOneMillion() {
+    assertThat(XrpAmount.ofDrops(1_000_000L).toXrp()).isEqualByComparingTo(BigDecimal.ONE);
+  }
+
+  @Test
+  void toXrpZero() {
+    assertThat(XrpAmount.ofDrops(0L).toXrp()).isEqualByComparingTo(BigDecimal.ZERO);
+  }
+
+  @Test
+  void toXrpNegative() {
+    BigDecimal result = XrpAmount.ofDrops(-1_500_000L).toXrp();
+    assertThat(result).isEqualByComparingTo(new BigDecimal("-1.5"));
+  }
+
+  @Test
+  void toXrpRoundTrip() {
+    BigDecimal original = new BigDecimal("1.5");
+    assertThat(XrpAmount.ofXrp(original).toXrp()).isEqualByComparingTo(original);
+  }
+
+  // -------------------------------------------------------------------------
+  // plus()
+  // -------------------------------------------------------------------------
+
+  @Test
+  void plusTwoPositive() {
+    XrpAmount sum = XrpAmount.ofDrops(1_000_000L).plus(XrpAmount.ofDrops(500_000L));
+    assertThat(sum.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(1_500_000L));
+    assertThat(sum.isNegative()).isFalse();
+  }
+
+  @Test
+  void plusPositiveAndNegative() {
+    // 1,000,000 + (-300,000) = 700,000
+    XrpAmount sum = XrpAmount.ofDrops(1_000_000L).plus(XrpAmount.ofDrops(-300_000L));
+    assertThat(sum.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(700_000L));
+    assertThat(sum.isNegative()).isFalse();
+  }
+
+  @Test
+  void plusResultNegative() {
+    // 300,000 + (-1,000,000) = -700,000
+    XrpAmount sum = XrpAmount.ofDrops(300_000L).plus(XrpAmount.ofDrops(-1_000_000L));
+    assertThat(sum.isNegative()).isTrue();
+    assertThat(sum.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(700_000L));
+  }
+
+  @Test
+  void plusNullThrows() {
+    assertThatThrownBy(() -> XrpAmount.ofDrops(1L).plus(null))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // minus()
+  // -------------------------------------------------------------------------
+
+  @Test
+  void minusLargerFromSmaller() {
+    XrpAmount diff = XrpAmount.ofDrops(1_000_000L).minus(XrpAmount.ofDrops(400_000L));
+    assertThat(diff.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(600_000L));
+    assertThat(diff.isNegative()).isFalse();
+  }
+
+  @Test
+  void minusSmallerFromLarger() {
+    // 400,000 - 1,000,000 = -600,000
+    XrpAmount diff = XrpAmount.ofDrops(400_000L).minus(XrpAmount.ofDrops(1_000_000L));
+    assertThat(diff.isNegative()).isTrue();
+    assertThat(diff.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(600_000L));
+  }
+
+  @Test
+  void minusEqualAmounts() {
+    XrpAmount diff = XrpAmount.ofDrops(1_000_000L).minus(XrpAmount.ofDrops(1_000_000L));
+    assertThat(diff.unsignedLongValue()).isEqualTo(UnsignedLong.ZERO);
+    assertThat(diff.isNegative()).isFalse();
+  }
+
+  @Test
+  void minusNullThrows() {
+    assertThatThrownBy(() -> XrpAmount.ofDrops(1L).minus(null))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // times()
+  // -------------------------------------------------------------------------
+
+  @Test
+  void timesPositiveByPositive() {
+    XrpAmount product = XrpAmount.ofDrops(1_000L).times(XrpAmount.ofDrops(3L));
+    assertThat(product.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(3_000L));
+    assertThat(product.isNegative()).isFalse();
+  }
+
+  @Test
+  void timesPositiveByNegative() {
+    XrpAmount product = XrpAmount.ofDrops(1_000L).times(XrpAmount.ofDrops(-3L));
+    assertThat(product.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(3_000L));
+    assertThat(product.isNegative()).isTrue();
+  }
+
+  @Test
+  void timesNegativeByNegative() {
+    // negative × negative = positive
+    XrpAmount product = XrpAmount.ofDrops(-1_000L).times(XrpAmount.ofDrops(-3L));
+    assertThat(product.unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(3_000L));
+    assertThat(product.isNegative()).isFalse();
+  }
+
+  @Test
+  void timesByZero() {
+    XrpAmount product = XrpAmount.ofDrops(1_000_000L).times(XrpAmount.ofDrops(0L));
+    assertThat(product.unsignedLongValue()).isEqualTo(UnsignedLong.ZERO);
+  }
+
+  @Test
+  void timesNullThrows() {
+    assertThatThrownBy(() -> XrpAmount.ofDrops(1L).times(null))
+      .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/XrpTokenAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/amount/XrpTokenAmountTest.java
@@ -1,0 +1,129 @@
+package org.xrpl.xrpl4j.model.transactions.amount;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link XrpTokenAmount} — factory methods and the {@link XrpTokenAmount#amount()} accessor.
+ */
+class XrpTokenAmountTest {
+
+  // -------------------------------------------------------------------------
+  // ofDrops(long)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void ofDropsLongPositive() {
+    XrpTokenAmount amount = XrpTokenAmount.ofDrops(1_000_000L);
+    assertThat(amount.amount().value()).isEqualTo("1000000");
+    assertThat(amount.amount().isNegative()).isFalse();
+    assertThat(amount.amount().unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(1_000_000L));
+  }
+
+  @Test
+  void ofDropsLongZero() {
+    XrpTokenAmount amount = XrpTokenAmount.ofDrops(0L);
+    assertThat(amount.amount().value()).isEqualTo("0");
+    assertThat(amount.amount().isNegative()).isFalse();
+  }
+
+  @Test
+  void ofDropsLongNegative() {
+    // Negative values appear in transaction metadata
+    XrpTokenAmount amount = XrpTokenAmount.ofDrops(-500L);
+    assertThat(amount.amount().value()).isEqualTo("-500");
+    assertThat(amount.amount().isNegative()).isTrue();
+    assertThat(amount.amount().unsignedLongValue()).isEqualTo(UnsignedLong.valueOf(500L));
+  }
+
+  // -------------------------------------------------------------------------
+  // ofDrops(UnsignedLong)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void ofDropsUnsignedLong() {
+    XrpTokenAmount amount = XrpTokenAmount.ofDrops(UnsignedLong.valueOf(1_000_000L));
+    assertThat(amount.amount().value()).isEqualTo("1000000");
+    assertThat(amount.amount().isNegative()).isFalse();
+  }
+
+  @Test
+  void ofDropsUnsignedLongNullThrows() {
+    assertThatThrownBy(() -> XrpTokenAmount.ofDrops((UnsignedLong) null))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // of(XrpAmount) — wrap factory
+  // -------------------------------------------------------------------------
+
+  @Test
+  void ofXrpAmountWrapsCorrectly() {
+    XrpAmount xrpAmount = XrpAmount.ofDrops(42_000L);
+    XrpTokenAmount wrapped = XrpTokenAmount.of(xrpAmount);
+    assertThat(wrapped.amount()).isEqualTo(xrpAmount);
+    assertThat(wrapped.amount().value()).isEqualTo("42000");
+  }
+
+  @Test
+  void ofXrpAmountWrapsNegative() {
+    XrpAmount xrpAmount = XrpAmount.ofDrops(-300L);
+    XrpTokenAmount wrapped = XrpTokenAmount.of(xrpAmount);
+    assertThat(wrapped.amount()).isEqualTo(xrpAmount);
+    assertThat(wrapped.amount().isNegative()).isTrue();
+  }
+
+  @Test
+  void ofXrpAmountNullThrows() {
+    assertThatThrownBy(() -> XrpTokenAmount.of((XrpAmount) null))
+      .isInstanceOf(NullPointerException.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // equality
+  // -------------------------------------------------------------------------
+
+  @Test
+  void equalAmountsAreEqual() {
+    assertThat(XrpTokenAmount.ofDrops(1_000_000L))
+      .isEqualTo(XrpTokenAmount.ofDrops(1_000_000L));
+  }
+
+  @Test
+  void differentDropCountsAreNotEqual() {
+    assertThat(XrpTokenAmount.ofDrops(1_000_000L))
+      .isNotEqualTo(XrpTokenAmount.ofDrops(2_000_000L));
+  }
+
+  // -------------------------------------------------------------------------
+  // implements TokenAmount
+  // -------------------------------------------------------------------------
+
+  @Test
+  void isInstanceOfTokenAmount() {
+    assertThat(XrpTokenAmount.ofDrops(1L)).isInstanceOf(TokenAmount.class);
+  }
+}


### PR DESCRIPTION
The Single Asset Vault (SAV) PR requires the concept of a tokenized `Amount` that does not have any other token-identifying information in it (i.e., just a scalar). Because the scalar amounts for the three token types (IOU, MPT, XRP) are slightly different, we re-purpose `CurrencyAmount` into a similar heirarchy of `Amount` (provides a numeric amount only) and `TokenAmount` (provides currency/id information). `TokenAmount` contains an `Amount`.