### PR TITLE
Add NFT_OFFER to AccountObjectsRequestParams

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsRequestParams.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsRequestParams.java
@@ -138,6 +138,18 @@ public interface AccountObjectsRequestParams extends XrplRequestParams {
      */
     ESCROW("escrow"),
     /**
+     * MPToken Issuance object type.
+     */
+    MPT_ISSUANCE("mpt_issuance"),
+    /**
+     * MPToken object type.
+     */
+    MP_TOKEN("mptoken"),
+    /**
+     * NFT offer object type.
+     */
+    NFT_OFFER("nft_offer"),
+    /**
      * Offer account object type.
      */
     OFFER("offer"),
@@ -164,15 +176,7 @@ public interface AccountObjectsRequestParams extends XrplRequestParams {
     /**
      * Vault account object type.
      */
-    VAULT("vault"),
-    /**
-     * MPToken Issuance object type.
-     */
-    MPT_ISSUANCE("mpt_issuance"),
-    /**
-     * MPToken object type.
-     */
-    MP_TOKEN("mptoken");
+    VAULT("vault");
 
     private final String value;
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsRequestParamsJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/accounts/AccountObjectsRequestParamsJsonTests.java
@@ -24,11 +24,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
+import org.xrpl.xrpl4j.model.client.accounts.AccountObjectsRequestParams.AccountObjectType;
 import org.xrpl.xrpl4j.model.client.common.LedgerIndex;
 import org.xrpl.xrpl4j.model.client.common.LedgerSpecifier;
 import org.xrpl.xrpl4j.model.transactions.Address;
 import org.xrpl.xrpl4j.model.transactions.Hash256;
+import org.xrpl.xrpl4j.model.transactions.Marker;
 
 public class AccountObjectsRequestParamsJsonTests extends AbstractJsonTest {
   
@@ -94,6 +98,81 @@ public class AccountObjectsRequestParamsJsonTests extends AbstractJsonTest {
       "            \"type\": \"state\",\n" +
       "            \"deletion_blockers_only\": false,\n" +
       "            \"limit\": 10\n" +
+      "        }";
+
+    assertCanSerializeAndDeserialize(params, json);
+  }
+
+  @ParameterizedTest
+  @EnumSource(AccountObjectType.class)
+  public void testAllAccountObjectTypes(AccountObjectType type) throws JsonProcessingException, JSONException {
+    AccountObjectsRequestParams params = AccountObjectsRequestParams.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerSpecifier(LedgerSpecifier.VALIDATED)
+      .type(type)
+      .deletionBlockersOnly(false)
+      .limit(UnsignedInteger.valueOf(10))
+      .build();
+
+    String json = "{\n" +
+      "            \"account\": \"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\n" +
+      "            \"ledger_index\": \"validated\",\n" +
+      "            \"type\": \"" + type.value() + "\",\n" +
+      "            \"deletion_blockers_only\": false,\n" +
+      "            \"limit\": 10\n" +
+      "        }";
+
+    assertCanSerializeAndDeserialize(params, json);
+  }
+
+  @Test
+  public void testWithDeletionBlockersOnly() throws JsonProcessingException, JSONException {
+    AccountObjectsRequestParams params = AccountObjectsRequestParams.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerSpecifier(LedgerSpecifier.VALIDATED)
+      .deletionBlockersOnly(true)
+      .build();
+
+    String json = "{\n" +
+      "            \"account\": \"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\n" +
+      "            \"ledger_index\": \"validated\",\n" +
+      "            \"deletion_blockers_only\": true\n" +
+      "        }";
+
+    assertCanSerializeAndDeserialize(params, json);
+  }
+
+  @Test
+  public void testWithStringMarker() throws JsonProcessingException, JSONException {
+    AccountObjectsRequestParams params = AccountObjectsRequestParams.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerSpecifier(LedgerSpecifier.VALIDATED)
+      .marker(Marker.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59,1234"))
+      .build();
+
+    String json = "{\n" +
+      "            \"account\": \"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\n" +
+      "            \"ledger_index\": \"validated\",\n" +
+      "            \"deletion_blockers_only\": false,\n" +
+      "            \"marker\": \"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59,1234\"\n" +
+      "        }";
+
+    assertCanSerializeAndDeserialize(params, json);
+  }
+
+  @Test
+  public void testWithJsonObjectMarker() throws JsonProcessingException, JSONException {
+    AccountObjectsRequestParams params = AccountObjectsRequestParams.builder()
+      .account(Address.of("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"))
+      .ledgerSpecifier(LedgerSpecifier.VALIDATED)
+      .marker(Marker.of("{\"ledger\":38766212,\"seq\":0}"))
+      .build();
+
+    String json = "{\n" +
+      "            \"account\": \"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59\",\n" +
+      "            \"ledger_index\": \"validated\",\n" +
+      "            \"deletion_blockers_only\": false,\n" +
+      "            \"marker\": {\"ledger\":38766212,\"seq\":0}\n" +
       "        }";
 
     assertCanSerializeAndDeserialize(params, json);

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NfTokenOfferObjectJsonTests.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/client/nft/NfTokenOfferObjectJsonTests.java
@@ -22,6 +22,7 @@ package org.xrpl.xrpl4j.model.client.nft;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
+import com.google.common.primitives.UnsignedLong;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.model.AbstractJsonTest;
@@ -75,6 +76,8 @@ public class NfTokenOfferObjectJsonTests extends AbstractJsonTest {
       )
       .destination(Address.of("rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"))
       .owner(Address.of("rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"))
+      .offerNode("1")
+      .ownerNode("2")
       .previousTransactionId(Hash256.of("E3FE6EA3D48F0C2B639448020EA4F03D4F4F8FFDB243A852A0F59177921B4879"))
       .previousTransactionLedgerSequence(UnsignedInteger.valueOf(14090896))
       .nfTokenId(NfTokenId.of("000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65"))
@@ -90,6 +93,8 @@ public class NfTokenOfferObjectJsonTests extends AbstractJsonTest {
       "       \"value\": \"10\"" +
       "    },\n" +
       "    \"Owner\": \"rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW\",\n" +
+      "    \"NFTokenOfferNode\": \"1\",\n" +
+      "    \"OwnerNode\": \"2\",\n" +
       "    \"NFTokenID\": \"000B013A95F14B0044F78A264E41713C64B5F89242540EE208C3098E00000D65\",\n" +
       "    \"Destination\": \"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn\",\n" +
       "    \"PreviousTxnID\": \"E3FE6EA3D48F0C2B639448020EA4F03D4F4F8FFDB243A852A0F59177921B4879\",\n" +


### PR DESCRIPTION
* Add NFT_OFFER to AccountObjectsRequestParams
* Rearrange enum values (alphabetical order)
* Add unit test coverge for all enum values
* Improve JSON unit test coverage for NfTokenOfferObject
* Subsumes PR #545

Credit to @psy2848048 for instigating this fix via #545 