### PR TITLE
Improve error handling in SerializedType.getTypeByName for unknown wire types

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/types/SerializedType.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/types/SerializedType.java
@@ -76,12 +76,16 @@ public abstract class SerializedType<T extends SerializedType<T>> {
    *
    * @return A {@link SerializedType} for the supplied {@code name}.
    */
-  public static SerializedType<?> getTypeByName(String name) {
-    try {
-      return typeMap.get(name).get();
-    } catch (NullPointerException e) {
-      throw e;
+  public static SerializedType<?> getTypeByName(final String name) {
+    Objects.requireNonNull(name);
+
+    if (!typeMap.containsKey(name)) {
+      throw new IllegalArgumentException(
+        String.format("Unknown serialized type '%s'. This likely means xrpl4j is out of date and does not yet " +
+          "support a new field type introduced by a rippled amendment.", name)
+      );
     }
+    return typeMap.get(name).get();
   }
 
   /**

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/types/SerializedType.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/types/SerializedType.java
@@ -31,6 +31,7 @@ import org.xrpl.xrpl4j.codec.binary.serdes.BinaryParser;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -77,15 +78,12 @@ public abstract class SerializedType<T extends SerializedType<T>> {
    * @return A {@link SerializedType} for the supplied {@code name}.
    */
   public static SerializedType<?> getTypeByName(final String name) {
-    Objects.requireNonNull(name);
-
-    if (!typeMap.containsKey(name)) {
-      throw new IllegalArgumentException(
+    return Optional.ofNullable(typeMap.get(name))
+      .map(Supplier::get)
+      .orElseThrow(() -> new IllegalArgumentException(
         String.format("Unknown serialized type '%s'. This likely means xrpl4j is out of date and does not yet " +
           "support a new field type introduced by a rippled amendment.", name)
-      );
-    }
-    return typeMap.get(name).get();
+      ));
   }
 
   /**

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/types/SerializedTypeTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/types/SerializedTypeTest.java
@@ -1,0 +1,51 @@
+package org.xrpl.xrpl4j.codec.binary.types;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: binary-codec
+ * %%
+ * Copyright (C) 2020 - 2026 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class SerializedTypeTest {
+
+  @Test
+  void getTypeByNameReturnsKnownTypes() {
+    assertThat(SerializedType.getTypeByName("AccountID")).isInstanceOf(AccountIdType.class);
+    assertThat(SerializedType.getTypeByName("Amount")).isInstanceOf(AmountType.class);
+    assertThat(SerializedType.getTypeByName("UInt32")).isInstanceOf(UInt32Type.class);
+    assertThat(SerializedType.getTypeByName("Hash256")).isInstanceOf(Hash256Type.class);
+  }
+
+  @Test
+  void getTypeByNameThrowsOnUnknownType() {
+    assertThatThrownBy(() -> SerializedType.getTypeByName("TEST32"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Unknown serialized type 'TEST32'")
+      .hasMessageContaining("xrpl4j is out of date");
+  }
+
+  @Test
+  void getTypeByNameThrowsOnNull() {
+    assertThatThrownBy(() -> SerializedType.getTypeByName(null))
+      .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/types/SerializedTypeTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/types/SerializedTypeTest.java
@@ -46,6 +46,7 @@ class SerializedTypeTest {
   @Test
   void getTypeByNameThrowsOnNull() {
     assertThatThrownBy(() -> SerializedType.getTypeByName(null))
-      .isInstanceOf(NullPointerException.class);
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Unknown serialized type 'null'");
   }
 }


### PR DESCRIPTION
### Summary

Fixes #775 

Replaced the no-op `catch (NullPointerException e) { throw e; }` in SerializedType.getTypeByName() with explicit validation that throws a descriptive `IllegalArgumentException` when an unknown serialized type is encountered.

### Test plan

Added unit tests to verify known types resolves correctly, unknown types throw a descriptive  `IllegalArgumentException`.
All other existing tests should pass.

