### PR TITLE
Drop Java 16 CI runs (EoL)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         # test against each major Java version (Java 8 built separately above for codecov upload)
-        java: [ 11, 16, 17, 21 ]
+        java: [ 11, 17, 21 ]
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v5


### PR DESCRIPTION
XRPL testnet and faucet recently renewed their SSL certificate with a new CA chain (Gandi CA 4 → Sectigo Public Server Authentication Root R46). JDK 16's cacerts truststore doesn't include this root CA, causing all integration tests to fail that talks to https://s.altnet.rippletest.net:51234/ and https://apex-faucet.altnet.rippletest.net/accounts.

JDK 16 has reached [EoL](https://endoflife.date/oracle-jdk), it's no more receiving security or CA updates.

Failing CI run - https://github.com/XRPLF/xrpl4j/actions/runs/25437558274