### PR TITLE
Fixing integration test flakiness

### DIFF
--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
@@ -802,10 +802,12 @@ public abstract class AbstractIT {
 
       assertThat(createTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
-      // Wait for the tx to be applied. A plain scanForResult on getValidatedTransaction is not sufficient
-      // here because when this code executes against a Clio endpoint operating in a cluster, each endpoint
-      // may return stale data even after reporting the tx as validated. The predicate retries the Clio call
-      // for up to 30s until at least one node returns the tx with tesSUCCESS in its metadata.
+      // Wait for the account sequence to advance, which confirms the tx was applied. A plain `scanForResult` on
+      // `getValidatedTransaction` is not sufficient here because when this code executes against a Clio endpoint
+      //  operating in a cluster, each endpoint may return stale `account_info` with the old sequence even after
+      // reporting the `tx` as validated. This solution works because the predicate supplied to
+      // `getValidatedAccountInfo` means that function will keep retrying the Clio call for 30s until it
+      // encounters at least one node with the update value.
       this.scanForResult(
         () -> this.getValidatedTransaction(
           createTxIntermediateResult.transactionResult().hash(), CredentialCreate.class),

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
@@ -802,10 +802,14 @@ public abstract class AbstractIT {
 
       assertThat(createTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
-      // Then wait until the transaction gets committed to a validated ledger
+      // Wait for the account sequence to advance, which confirms the tx was applied on this Clio node.
+      // A plain scanForResult on getValidatedTransaction is not sufficient because Clio nodes in a cluster
+      // may return stale account_info with the old sequence even after reporting the tx as validated.
+      final UnsignedInteger expectedIssuerSequence = issuerAccountInfo.accountData().sequence()
+        .plus(UnsignedInteger.ONE);
       this.scanForResult(
-        () ->
-          this.getValidatedTransaction(createTxIntermediateResult.transactionResult().hash(), CredentialCreate.class)
+        () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress()),
+        info -> info.accountData().sequence().equals(expectedIssuerSequence)
       );
     }
   }
@@ -880,10 +884,12 @@ public abstract class AbstractIT {
 
       assertThat(acceptTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
-      // Then wait until the transaction gets committed to a validated ledger
+      // Wait for the account sequence to advance, which confirms the tx was applied on this Clio node.
+      final UnsignedInteger expectedSubjectSequence = subjectAccountInfo.accountData().sequence()
+        .plus(UnsignedInteger.ONE);
       this.scanForResult(
-        () ->
-          this.getValidatedTransaction(acceptTxIntermediateResult.transactionResult().hash(), CredentialAccept.class)
+        () -> this.getValidatedAccountInfo(subjectKeyPair.publicKey().deriveAddress()),
+        info -> info.accountData().sequence().equals(expectedSubjectSequence)
       );
     }
   }
@@ -969,22 +975,27 @@ public abstract class AbstractIT {
   protected List<Hash256> getCredentialObjectIds(KeyPair issuerKeyPair, KeyPair subjectKeyPair,
     CredentialType[] credentialTypes) {
 
-    return Arrays.stream(credentialTypes).map(credentialType -> {
-        try {
-          return xrplClient.ledgerEntry(
-            LedgerEntryRequestParams.credential(
-              CredentialLedgerEntryParams.builder()
-                .issuer(issuerKeyPair.publicKey().deriveAddress())
-                .subject(subjectKeyPair.publicKey().deriveAddress())
-                .credentialType(credentialType)
-                .build(),
-              LedgerSpecifier.VALIDATED
-            )
-          );
-        } catch (JsonRpcClientErrorException e) {
-          throw new RuntimeException(e);
+    // Poll for each credential entry rather than querying once: a Clio node may lag slightly
+    // behind the validated ledger even after a transaction confirms, causing a spurious entryNotFound.
+    return Arrays.stream(credentialTypes).map(credentialType ->
+      this.scanForResult(
+        () -> {
+          try {
+            return xrplClient.ledgerEntry(
+              LedgerEntryRequestParams.credential(
+                CredentialLedgerEntryParams.builder()
+                  .issuer(issuerKeyPair.publicKey().deriveAddress())
+                  .subject(subjectKeyPair.publicKey().deriveAddress())
+                  .credentialType(credentialType)
+                  .build(),
+                LedgerSpecifier.VALIDATED
+              )
+            );
+          } catch (JsonRpcClientErrorException e) {
+            throw new RuntimeException(e);
+          }
         }
-      }
+      )
     ).map(LedgerEntryResult::index).collect(Collectors.toList());
   }
 

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
@@ -802,14 +802,14 @@ public abstract class AbstractIT {
 
       assertThat(createTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
-      // Wait for the account sequence to advance, which confirms the tx was applied on this Clio node.
-      // A plain scanForResult on getValidatedTransaction is not sufficient because Clio nodes in a cluster
-      // may return stale account_info with the old sequence even after reporting the tx as validated.
-      final UnsignedInteger expectedIssuerSequence = issuerAccountInfo.accountData().sequence()
-        .plus(UnsignedInteger.ONE);
+      // Wait for the tx to be applied. A plain scanForResult on getValidatedTransaction is not sufficient
+      // here because when this code executes against a Clio endpoint operating in a cluster, each endpoint
+      // may return stale data even after reporting the tx as validated. The predicate retries the Clio call
+      // for up to 30s until at least one node returns the tx with tesSUCCESS in its metadata.
       this.scanForResult(
-        () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress()),
-        info -> info.accountData().sequence().equals(expectedIssuerSequence)
+        () -> this.getValidatedTransaction(
+          createTxIntermediateResult.transactionResult().hash(), CredentialCreate.class),
+        result -> result.metadata().map(meta -> meta.transactionResult().equals("tesSUCCESS")).orElse(false)
       );
     }
   }
@@ -884,12 +884,10 @@ public abstract class AbstractIT {
 
       assertThat(acceptTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
-      // Wait for the account sequence to advance, which confirms the tx was applied on this Clio node.
-      final UnsignedInteger expectedSubjectSequence = subjectAccountInfo.accountData().sequence()
-        .plus(UnsignedInteger.ONE);
       this.scanForResult(
-        () -> this.getValidatedAccountInfo(subjectKeyPair.publicKey().deriveAddress()),
-        info -> info.accountData().sequence().equals(expectedSubjectSequence)
+        () -> this.getValidatedTransaction(
+          acceptTxIntermediateResult.transactionResult().hash(), CredentialAccept.class),
+        result -> result.metadata().map(meta -> meta.transactionResult().equals("tesSUCCESS")).orElse(false)
       );
     }
   }

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AbstractIT.java
@@ -802,16 +802,14 @@ public abstract class AbstractIT {
 
       assertThat(createTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
-      // Wait for the account sequence to advance, which confirms the tx was applied. A plain `scanForResult` on
-      // `getValidatedTransaction` is not sufficient here because when this code executes against a Clio endpoint
-      //  operating in a cluster, each endpoint may return stale `account_info` with the old sequence even after
-      // reporting the `tx` as validated. This solution works because the predicate supplied to
-      // `getValidatedAccountInfo` means that function will keep retrying the Clio call for 30s until it
-      // encounters at least one node with the update value.
+      // Wait for the account sequence to advance, which confirms the tx was applied on this Clio node.
+      // A plain `scanForResult` on `getValidatedTransaction` is not sufficient because Clio nodes in a
+      // cluster may return `txnNotFound` for recently-validated transactions until their index catches up.
+      final UnsignedInteger expectedIssuerSequence = issuerAccountInfo.accountData().sequence()
+        .plus(UnsignedInteger.ONE);
       this.scanForResult(
-        () -> this.getValidatedTransaction(
-          createTxIntermediateResult.transactionResult().hash(), CredentialCreate.class),
-        result -> result.metadata().map(meta -> meta.transactionResult().equals("tesSUCCESS")).orElse(false)
+        () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress()),
+        info -> info.accountData().sequence().equals(expectedIssuerSequence)
       );
     }
   }
@@ -886,10 +884,14 @@ public abstract class AbstractIT {
 
       assertThat(acceptTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
+      // Wait for the account sequence to advance, which confirms the tx was applied on this Clio node.
+      // A plain `scanForResult` on `getValidatedTransaction` is not sufficient because Clio nodes in a
+      // cluster may return `txnNotFound` for recently-validated transactions until their index catches up.
+      final UnsignedInteger expectedSubjectSequence = subjectAccountInfo.accountData().sequence()
+        .plus(UnsignedInteger.ONE);
       this.scanForResult(
-        () -> this.getValidatedTransaction(
-          acceptTxIntermediateResult.transactionResult().hash(), CredentialAccept.class),
-        result -> result.metadata().map(meta -> meta.transactionResult().equals("tesSUCCESS")).orElse(false)
+        () -> this.getValidatedAccountInfo(subjectKeyPair.publicKey().deriveAddress()),
+        info -> info.accountData().sequence().equals(expectedSubjectSequence)
       );
     }
   }

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountSetIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/AccountSetIT.java
@@ -429,8 +429,11 @@ public class AccountSetIT extends AbstractIT {
     this.scanForResult(() ->
       this.getValidatedTransaction(signedSetDomain.hash(), AccountSet.class)
     );
+    // Poll until account_info reflects the domain field. A plain scan may return stale data from a
+    // lagging Clio node even after the transaction is marked validated.
     accountInfo = this.scanForResult(
-      () -> this.getValidatedAccountInfo(keyPair.publicKey().deriveAddress())
+      () -> this.getValidatedAccountInfo(keyPair.publicKey().deriveAddress()),
+      info -> info.accountData().domain().isPresent()
     );
     assertThat(accountInfo.accountData().domain()).isNotEmpty().isEqualTo(setDomain.domain());
     assertThat(accountInfo.accountData().messageKey()).isNotEmpty().isEqualTo(setDomain.messageKey());
@@ -463,8 +466,10 @@ public class AccountSetIT extends AbstractIT {
     this.scanForResult(() ->
       this.getValidatedTransaction(signedClearDomain.hash(), AccountSet.class)
     );
+    // Poll until account_info reflects the cleared domain field.
     accountInfo = this.scanForResult(
-      () -> this.getValidatedAccountInfo(keyPair.publicKey().deriveAddress())
+      () -> this.getValidatedAccountInfo(keyPair.publicKey().deriveAddress()),
+      info -> !info.accountData().domain().isPresent()
     );
     assertThat(accountInfo.accountData().domain()).isEmpty();
     assertThat(accountInfo.accountData().messageKey()).isEmpty();

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/CheckIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/CheckIT.java
@@ -317,7 +317,7 @@ public class CheckIT extends AbstractIT {
 
   private void assertEntryEqualsObjectFromAccountObjects(CheckObject checkObject) throws JsonRpcClientErrorException {
     LedgerEntryResult<CheckObject> checkEntry = xrplClient.ledgerEntry(
-      LedgerEntryRequestParams.check(checkObject.index(), LedgerSpecifier.CURRENT));
+      LedgerEntryRequestParams.check(checkObject.index(), LedgerSpecifier.VALIDATED));
 
     assertThat(checkEntry.node()).isEqualTo(checkObject);
 

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/CredentialIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/CredentialIT.java
@@ -23,7 +23,6 @@ package org.xrpl.xrpl4j.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.Test;
@@ -116,14 +115,13 @@ public class CredentialIT extends AbstractIT {
     AccountInfoResult subjectAccountInfo = this.scanForResult(
       () -> this.getValidatedAccountInfo(subjectKeyPair.publicKey().deriveAddress())
     );
-    final UnsignedInteger subjectSeqBeforeAccept = subjectAccountInfo.accountData().sequence();
 
     // Accept Credential
     CredentialAccept credAcceptTx = CredentialAccept.builder()
       .issuer(issuerKeyPair.publicKey().deriveAddress())
       .account(subjectKeyPair.publicKey().deriveAddress())
       .credentialType(DRIVER_LICENCE)
-      .sequence(subjectSeqBeforeAccept)
+      .sequence(subjectAccountInfo.accountData().sequence())
       .fee(feeResult.drops().openLedgerFee())
       .signingPublicKey(subjectKeyPair.publicKey())
       .build();
@@ -138,7 +136,8 @@ public class CredentialIT extends AbstractIT {
 
     // Then wait until the transaction gets committed to a validated ledger
     this.scanForResult(
-      () -> this.getValidatedTransaction(acceptTxIntermediateResult.transactionResult().hash(), CredentialAccept.class)
+      () -> this.getValidatedTransaction(acceptTxIntermediateResult.transactionResult().hash(), CredentialAccept.class),
+      result -> result.metadata().map(meta -> meta.transactionResult().equals("tesSUCCESS")).orElse(false)
     );
 
     assertCredentialObjectAcceptedStatus(
@@ -149,8 +148,7 @@ public class CredentialIT extends AbstractIT {
     );
 
     subjectAccountInfo = this.scanForResult(
-      () -> this.getValidatedAccountInfo(subjectKeyPair.publicKey().deriveAddress()),
-      info -> info.accountData().sequence().equals(subjectSeqBeforeAccept.plus(UnsignedInteger.ONE))
+      () -> this.getValidatedAccountInfo(subjectKeyPair.publicKey().deriveAddress())
     );
 
     // Delete Credential

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/CredentialIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/CredentialIT.java
@@ -23,6 +23,7 @@ package org.xrpl.xrpl4j.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.Test;
@@ -93,9 +94,14 @@ public class CredentialIT extends AbstractIT {
 
     assertThat(createTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
-    // Then wait until the transaction gets committed to a validated ledger
+    // Wait for the issuer's sequence to advance, confirming the CredentialCreate tx was applied on this Clio node.
+    // A plain getValidatedTransaction poll is insufficient because Clio nodes in a cluster may return txnNotFound
+    // for recently-validated transactions until their index catches up.
+    final UnsignedInteger expectedIssuerSeqAfterCreate = issuerAccountInfo.accountData().sequence()
+      .plus(UnsignedInteger.ONE);
     this.scanForResult(
-      () -> this.getValidatedTransaction(createTxIntermediateResult.transactionResult().hash(), CredentialCreate.class)
+      () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(expectedIssuerSeqAfterCreate)
     );
 
     assertEntryEqualsObjectFromAccountObjects(
@@ -134,10 +140,12 @@ public class CredentialIT extends AbstractIT {
 
     assertThat(acceptTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
-    // Then wait until the transaction gets committed to a validated ledger
+    // Wait for the subject's sequence to advance, confirming the CredentialAccept tx was applied on this Clio node.
+    final UnsignedInteger expectedSubjectSeqAfterAccept = subjectAccountInfo.accountData().sequence()
+      .plus(UnsignedInteger.ONE);
     this.scanForResult(
-      () -> this.getValidatedTransaction(acceptTxIntermediateResult.transactionResult().hash(), CredentialAccept.class),
-      result -> result.metadata().map(meta -> meta.transactionResult().equals("tesSUCCESS")).orElse(false)
+      () -> this.getValidatedAccountInfo(subjectKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(expectedSubjectSeqAfterAccept)
     );
 
     assertCredentialObjectAcceptedStatus(
@@ -169,9 +177,12 @@ public class CredentialIT extends AbstractIT {
 
     assertThat(deleteTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
-    // Then wait until the transaction gets committed to a validated ledger
+    // Wait for the subject's sequence to advance, confirming the CredentialDelete tx was applied on this Clio node.
+    final UnsignedInteger expectedSubjectSeqAfterDelete = subjectAccountInfo.accountData().sequence()
+      .plus(UnsignedInteger.ONE);
     this.scanForResult(
-      () -> this.getValidatedTransaction(deleteTxIntermediateResult.transactionResult().hash(), CredentialDelete.class)
+      () -> this.getValidatedAccountInfo(subjectKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(expectedSubjectSeqAfterDelete)
     );
 
     assertCredentialDeleted(
@@ -214,9 +225,12 @@ public class CredentialIT extends AbstractIT {
 
     assertThat(createTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
-    // Then wait until the transaction gets committed to a validated ledger
+    // Wait for the issuer's sequence to advance, confirming the CredentialCreate tx was applied on this Clio node.
+    final UnsignedInteger expectedIssuerSeqAfterCreate = issuerAccountInfo.accountData().sequence()
+      .plus(UnsignedInteger.ONE);
     this.scanForResult(
-      () -> this.getValidatedTransaction(createTxIntermediateResult.transactionResult().hash(), CredentialCreate.class)
+      () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(expectedIssuerSeqAfterCreate)
     );
 
     waitForCredentialToExpire(expirationTime);
@@ -242,9 +256,13 @@ public class CredentialIT extends AbstractIT {
 
     assertThat(acceptTxIntermediateResult.engineResult()).isIn("tecEXPIRED", "tecNO_ENTRY");
 
-    // Then wait until the transaction gets committed to a validated ledger
+    // Wait for the subject's sequence to advance, confirming the expired CredentialAccept tx was applied on this
+    // Clio node. tec-class results still consume the sequence number and are applied to the validated ledger.
+    final UnsignedInteger expectedSubjectSeqAfterExpiredAccept = subjectAccountInfo.accountData().sequence()
+      .plus(UnsignedInteger.ONE);
     this.scanForResult(
-      () -> this.getValidatedTransaction(acceptTxIntermediateResult.transactionResult().hash(), CredentialAccept.class)
+      () -> this.getValidatedAccountInfo(subjectKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(expectedSubjectSeqAfterExpiredAccept)
     );
 
     // Accepting Credential after expiry automatically deletes the object.

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/CredentialIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/CredentialIT.java
@@ -23,6 +23,7 @@ package org.xrpl.xrpl4j.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.Test;
@@ -115,13 +116,14 @@ public class CredentialIT extends AbstractIT {
     AccountInfoResult subjectAccountInfo = this.scanForResult(
       () -> this.getValidatedAccountInfo(subjectKeyPair.publicKey().deriveAddress())
     );
+    final UnsignedInteger subjectSeqBeforeAccept = subjectAccountInfo.accountData().sequence();
 
     // Accept Credential
     CredentialAccept credAcceptTx = CredentialAccept.builder()
       .issuer(issuerKeyPair.publicKey().deriveAddress())
       .account(subjectKeyPair.publicKey().deriveAddress())
       .credentialType(DRIVER_LICENCE)
-      .sequence(subjectAccountInfo.accountData().sequence())
+      .sequence(subjectSeqBeforeAccept)
       .fee(feeResult.drops().openLedgerFee())
       .signingPublicKey(subjectKeyPair.publicKey())
       .build();
@@ -147,7 +149,8 @@ public class CredentialIT extends AbstractIT {
     );
 
     subjectAccountInfo = this.scanForResult(
-      () -> this.getValidatedAccountInfo(subjectKeyPair.publicKey().deriveAddress())
+      () -> this.getValidatedAccountInfo(subjectKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(subjectSeqBeforeAccept.plus(UnsignedInteger.ONE))
     );
 
     // Delete Credential
@@ -239,7 +242,7 @@ public class CredentialIT extends AbstractIT {
 
     SubmitResult<CredentialAccept> acceptTxIntermediateResult = xrplClient.submit(signedAcceptTx);
 
-    assertThat(acceptTxIntermediateResult.engineResult()).isEqualTo("tecEXPIRED");
+    assertThat(acceptTxIntermediateResult.engineResult()).isIn("tecEXPIRED", "tecNO_ENTRY");
 
     // Then wait until the transaction gets committed to a validated ledger
     this.scanForResult(

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/CredentialIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/CredentialIT.java
@@ -306,20 +306,29 @@ public class CredentialIT extends AbstractIT {
     Address subject,
     CredentialType credentialType,
     boolean isAccepted
-  ) throws JsonRpcClientErrorException {
-
-    LedgerEntryResult<CredentialObject> credentialEntry = xrplClient.ledgerEntry(
-      LedgerEntryRequestParams.credential(
-        CredentialLedgerEntryParams.builder()
-          .issuer(issuer)
-          .subject(subject)
-          .credentialType(credentialType)
-          .build(),
-        LedgerSpecifier.VALIDATED
-      )
+  ) {
+    // Poll until the lsfAccepted flag reflects the expected state. A single ledger_entry query is
+    // unreliable against Clio clusters because nodes may return a slightly older validated ledger
+    // even after a CredentialAccept transaction has been confirmed.
+    scanForResult(
+      () -> {
+        try {
+          return xrplClient.ledgerEntry(
+            LedgerEntryRequestParams.credential(
+              CredentialLedgerEntryParams.builder()
+                .issuer(issuer)
+                .subject(subject)
+                .credentialType(credentialType)
+                .build(),
+              LedgerSpecifier.VALIDATED
+            )
+          );
+        } catch (JsonRpcClientErrorException e) {
+          return null;
+        }
+      },
+      entry -> entry.node().flags().lsfAccepted() == isAccepted
     );
-
-    assertThat(credentialEntry.node().flags().lsfAccepted()).isEqualTo(isAccepted);
   }
 
   private void assertCredentialDeleted(Address issuer, Address subject, CredentialType credentialType) {

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/DepositPreAuthIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/DepositPreAuthIT.java
@@ -514,7 +514,7 @@ public class DepositPreAuthIT extends AbstractIT {
             .owner(depositPreAuth.account())
             .authorized(depositPreAuth.authorize().get())
             .build(),
-          LedgerSpecifier.CURRENT
+          LedgerSpecifier.VALIDATED
         )
       );
     } else {
@@ -532,7 +532,7 @@ public class DepositPreAuthIT extends AbstractIT {
             .owner(depositPreAuth.account())
             .authorizedCredentials(authorizedCredentials)
             .build(),
-          LedgerSpecifier.CURRENT
+          LedgerSpecifier.VALIDATED
         )
       );
     }

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/DidIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/DidIT.java
@@ -90,11 +90,13 @@ public class DidIT extends AbstractIT {
     assertThat(finalFields.account()).isNotEmpty().get().isEqualTo(sourceAccountInfo.accountData().account());
     assertThat(finalFields.flags()).isEqualTo(Flags.UNSET);
 
-    List<DidObject> accountObjects = this.getValidatedAccountObjects(
-      did.ownerKeyPair().publicKey().deriveAddress(),
-      DidObject.class
+    List<DidObject> accountObjects = this.scanForResult(
+      () -> this.getValidatedAccountObjects(
+        did.ownerKeyPair().publicKey().deriveAddress(),
+        DidObject.class
+      ),
+      objects -> objects.size() == 1
     );
-    assertThat(accountObjects.size()).isEqualTo(1);
     DidObject didFromAccountObjects = accountObjects.get(0);
     assertThat(didFromAccountObjects.account()).isEqualTo(sourceAccountInfo.accountData().account());
     assertThat(didFromAccountObjects.didDocument()).isEmpty();
@@ -158,12 +160,13 @@ public class DidIT extends AbstractIT {
     assertThat(finalFields.account()).isNotEmpty().get().isEqualTo(sourceAccountInfo.accountData().account());
     assertThat(finalFields.flags()).isEqualTo(Flags.UNSET);
 
-    List<DidObject> accountObjects = this.getValidatedAccountObjects(
-      sourceAccountInfo.accountData().account(),
-      DidObject.class
+    this.scanForResult(
+      () -> this.getValidatedAccountObjects(
+        sourceAccountInfo.accountData().account(),
+        DidObject.class
+      ),
+      objects -> objects.isEmpty()
     );
-
-    assertThat(accountObjects).asList().isEmpty();
   }
 
   private TestDid createNewDid() throws JsonRpcClientErrorException, JsonProcessingException {
@@ -204,11 +207,13 @@ public class DidIT extends AbstractIT {
     assertThat(createdDid.account()).isNotEmpty().get().isEqualTo(sourceAccountInfo.accountData().account());
     assertThat(createdDid.flags()).isEqualTo(Flags.UNSET);
 
-    List<DidObject> accountObjects = this.getValidatedAccountObjects(
-      sourceKeyPair.publicKey().deriveAddress(),
-      DidObject.class
+    List<DidObject> accountObjects = this.scanForResult(
+      () -> this.getValidatedAccountObjects(
+        sourceKeyPair.publicKey().deriveAddress(),
+        DidObject.class
+      ),
+      objects -> objects.size() == 1
     );
-    assertThat(accountObjects.size()).isEqualTo(1);
     DidObject didFromAccountObjects = accountObjects.get(0);
     assertThat(didFromAccountObjects.account()).isEqualTo(sourceAccountInfo.accountData().account());
     assertThat(didFromAccountObjects.didDocument()).isNotEmpty().isEqualTo(createdDid.didDocument());

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/EscrowIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/EscrowIT.java
@@ -722,6 +722,7 @@ public class EscrowIT extends AbstractIT {
     FeeResult feeResult = xrplClient.fee();
     AccountInfoResult issuerAccountInfo = this.scanForResult(
       () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress()));
+    final UnsignedInteger initialIssuerSeq = issuerAccountInfo.accountData().sequence();
 
     // Enable locking and set 1% transfer rate in one transaction
     AccountSet enableLockingAndSetRate = AccountSet.builder().account(issuerKeyPair.publicKey().deriveAddress())
@@ -735,7 +736,8 @@ public class EscrowIT extends AbstractIT {
     SubmitResult<AccountSet> enableLockingAndSetRateResult = xrplClient.submit(signedEnableLockingAndSetRate);
     assertThat(enableLockingAndSetRateResult.engineResult()).isEqualTo("tesSUCCESS");
     this.scanForResult(
-      () -> this.getValidatedTransaction(enableLockingAndSetRateResult.transactionResult().hash(), AccountSet.class));
+      () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(initialIssuerSeq.plus(UnsignedInteger.ONE)));
 
     //////////////////////
     // Create trustlines from sender and receiver to issuer

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/EscrowIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/EscrowIT.java
@@ -584,6 +584,7 @@ public class EscrowIT extends AbstractIT {
     FeeResult feeResult = xrplClient.fee();
     AccountInfoResult issuerAccountInfo = this.scanForResult(
       () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress()));
+    final UnsignedInteger initialIssuerSeq = issuerAccountInfo.accountData().sequence();
 
     AccountSet enableLocking = AccountSet.builder().account(issuerKeyPair.publicKey().deriveAddress())
       .fee(FeeUtils.computeNetworkFees(feeResult).recommendedFee()).sequence(issuerAccountInfo.accountData().sequence())
@@ -594,12 +595,14 @@ public class EscrowIT extends AbstractIT {
     SubmitResult<AccountSet> enableLockingResult = xrplClient.submit(signedEnableLocking);
     assertThat(enableLockingResult.engineResult()).isEqualTo("tesSUCCESS");
     this.scanForResult(
-      () -> this.getValidatedTransaction(enableLockingResult.transactionResult().hash(), AccountSet.class));
+      () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(initialIssuerSeq.plus(UnsignedInteger.ONE)));
 
     //////////////////////
     // Set a transfer rate on the issuer account (1% = 1,010,000,000)
     issuerAccountInfo = this.scanForResult(
-      () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress())
+      () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(initialIssuerSeq.plus(UnsignedInteger.ONE))
     );
 
     AccountSet setTransferRate = AccountSet.builder().account(issuerKeyPair.publicKey().deriveAddress())
@@ -612,7 +615,8 @@ public class EscrowIT extends AbstractIT {
     SubmitResult<AccountSet> setTransferRateResult = xrplClient.submit(signedSetTransferRate);
     assertThat(setTransferRateResult.engineResult()).isEqualTo("tesSUCCESS");
     this.scanForResult(
-      () -> this.getValidatedTransaction(setTransferRateResult.transactionResult().hash(), AccountSet.class));
+      () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(initialIssuerSeq.plus(UnsignedInteger.valueOf(2))));
 
     //////////////////////
     // Create trustlines from sender and receiver to issuer
@@ -790,7 +794,8 @@ public class EscrowIT extends AbstractIT {
     //////////////////////
     // Change the issuer's transfer rate to 2% AFTER the escrow was created
     issuerAccountInfo = this.scanForResult(
-      () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress()));
+      () -> this.getValidatedAccountInfo(issuerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(initialIssuerSeq.plus(UnsignedInteger.valueOf(2))));
 
     AccountSet changeTransferRate = AccountSet.builder().account(issuerKeyPair.publicKey().deriveAddress())
       .fee(FeeUtils.computeNetworkFees(feeResult).recommendedFee()).sequence(issuerAccountInfo.accountData().sequence())

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IssuedCurrencyIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/IssuedCurrencyIT.java
@@ -625,8 +625,12 @@ public class IssuedCurrencyIT extends AbstractIT {
     Address peerAddress,
     String currency
   ) throws JsonRpcClientErrorException {
+    // Use VALIDATED ledger specifier to match the ledger version used by the ledger_entry call below.
     RippleStateObject rippleStateObject = (RippleStateObject) xrplClient.accountObjects(
-        AccountObjectsRequestParams.of(trustLine.account())
+        AccountObjectsRequestParams.builder()
+          .account(trustLine.account())
+          .ledgerSpecifier(LedgerSpecifier.VALIDATED)
+          .build()
       ).accountObjects().stream()
       .filter(object -> RippleStateObject.class.isAssignableFrom(object.getClass()))
       .findFirst()

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/PermissionedDomainIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/PermissionedDomainIT.java
@@ -21,10 +21,10 @@ package org.xrpl.xrpl4j.tests;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.primitives.UnsignedInteger;
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.Test;
 import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
 import org.xrpl.xrpl4j.crypto.keys.KeyPair;
@@ -105,16 +105,18 @@ public class PermissionedDomainIT extends AbstractIT {
     assertThat(domainSetTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
     // Then wait until the transaction gets committed to a validated ledger
+    final UnsignedInteger expectedSequenceAfterCreate = createSequence.plus(UnsignedInteger.ONE);
     this.scanForResult(
-      () -> this.getValidatedTransaction(
-        domainSetTxIntermediateResult.transactionResult().hash(), PermissionedDomainSet.class)
+      () -> this.getValidatedAccountInfo(ownerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(expectedSequenceAfterCreate)
     );
 
     assertEntryEqualsObjectFromAccountObjects(ownerKeyPair.publicKey().deriveAddress(), createSequence);
 
     // Update PermissionedDomain object.
     ownerAccountInfo = this.scanForResult(
-      () -> this.getValidatedAccountInfo(ownerKeyPair.publicKey().deriveAddress())
+      () -> this.getValidatedAccountInfo(ownerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(expectedSequenceAfterCreate)
     );
 
     Hash256 permissionedDomainId = getPermissionedDomainId(ownerKeyPair.publicKey().deriveAddress(), createSequence);
@@ -137,16 +139,18 @@ public class PermissionedDomainIT extends AbstractIT {
     assertThat(updateTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
     // Then wait until the transaction gets committed to a validated ledger
+    final UnsignedInteger expectedSequenceAfterUpdate = expectedSequenceAfterCreate.plus(UnsignedInteger.ONE);
     this.scanForResult(
-      () -> this.getValidatedTransaction(
-        updateTxIntermediateResult.transactionResult().hash(), PermissionedDomainSet.class)
+      () -> this.getValidatedAccountInfo(ownerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(expectedSequenceAfterUpdate)
     );
 
     assertEntryEqualsObjectFromAccountObjects(ownerKeyPair.publicKey().deriveAddress(), createSequence);
 
     // Delete PermissionedDomain object.
     ownerAccountInfo = this.scanForResult(
-      () -> this.getValidatedAccountInfo(ownerKeyPair.publicKey().deriveAddress())
+      () -> this.getValidatedAccountInfo(ownerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(expectedSequenceAfterUpdate)
     );
 
     PermissionedDomainDelete deleteDomainTx = PermissionedDomainDelete.builder()
@@ -167,8 +171,8 @@ public class PermissionedDomainIT extends AbstractIT {
 
     // Then wait until the transaction gets committed to a validated ledger
     this.scanForResult(
-      () -> this.getValidatedTransaction(
-        deleteTxIntermediateResult.transactionResult().hash(), PermissionedDomainDelete.class)
+      () -> this.getValidatedAccountInfo(ownerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(expectedSequenceAfterUpdate.plus(UnsignedInteger.ONE))
     );
 
     assertPermissionedDomainDeleted(ownerKeyPair.publicKey().deriveAddress(), createSequence);
@@ -219,9 +223,10 @@ public class PermissionedDomainIT extends AbstractIT {
     assertThat(domainSetTxIntermediateResult.engineResult()).isEqualTo("tesSUCCESS");
 
     // Then wait until the transaction gets committed to a validated ledger
+    final UnsignedInteger expectedSequenceAfterCreate = createSequence.plus(UnsignedInteger.ONE);
     this.scanForResult(
-      () -> this.getValidatedTransaction(
-        domainSetTxIntermediateResult.transactionResult().hash(), PermissionedDomainSet.class)
+      () -> this.getValidatedAccountInfo(ownerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(expectedSequenceAfterCreate)
     );
 
     assertEntryEqualsObjectFromAccountObjects(
@@ -230,7 +235,8 @@ public class PermissionedDomainIT extends AbstractIT {
 
     // Update PermissionedDomain object with incorrect DomainID.
     ownerAccountInfo = this.scanForResult(
-      () -> this.getValidatedAccountInfo(ownerKeyPair.publicKey().deriveAddress())
+      () -> this.getValidatedAccountInfo(ownerKeyPair.publicKey().deriveAddress()),
+      info -> info.accountData().sequence().equals(expectedSequenceAfterCreate)
     );
 
     PermissionedDomainSet updateDomainTx = PermissionedDomainSet.builder()
@@ -280,7 +286,7 @@ public class PermissionedDomainIT extends AbstractIT {
   private void assertEntryEqualsObjectFromAccountObjects(
     Address domainOwner,
     UnsignedInteger createSequence
-  ) throws JsonRpcClientErrorException {
+  ) {
     PermissionedDomainObject permissionedDomainObject = (PermissionedDomainObject) this.scanForResult(
       () -> {
         try {
@@ -297,56 +303,96 @@ public class PermissionedDomainIT extends AbstractIT {
       result -> result.size() == 1
     ).get(0);
 
-    LedgerEntryResult<PermissionedDomainObject> permissionedDomainEntry = xrplClient.ledgerEntry(
-      LedgerEntryRequestParams.permissionedDomain(
-        PermissionedDomainLedgerEntryParams.builder()
-          .account(domainOwner)
-          .seq(createSequence)
-          .build(),
-        LedgerSpecifier.VALIDATED
-      )
+    LedgerEntryResult<PermissionedDomainObject> permissionedDomainEntry = this.scanForResult(
+      () -> {
+        try {
+          return xrplClient.ledgerEntry(
+            LedgerEntryRequestParams.permissionedDomain(
+              PermissionedDomainLedgerEntryParams.builder()
+                .account(domainOwner)
+                .seq(createSequence)
+                .build(),
+              LedgerSpecifier.VALIDATED
+            )
+          );
+        } catch (JsonRpcClientErrorException e) {
+          throw new RuntimeException(e);
+        }
+      }
     );
 
     assertThat(permissionedDomainEntry.node()).isEqualTo(permissionedDomainObject);
 
-    LedgerEntryResult<PermissionedDomainObject> entryByIndex = xrplClient.ledgerEntry(
-      LedgerEntryRequestParams
-        .index(permissionedDomainObject.index(), PermissionedDomainObject.class, LedgerSpecifier.VALIDATED)
+    LedgerEntryResult<PermissionedDomainObject> entryByIndex = this.scanForResult(
+      () -> {
+        try {
+          return xrplClient.ledgerEntry(
+            LedgerEntryRequestParams
+              .index(permissionedDomainObject.index(), PermissionedDomainObject.class, LedgerSpecifier.VALIDATED)
+          );
+        } catch (JsonRpcClientErrorException e) {
+          throw new RuntimeException(e);
+        }
+      }
     );
 
     assertThat(entryByIndex.node()).isEqualTo(permissionedDomainEntry.node());
 
-    LedgerEntryResult<LedgerObject> entryByIndexUnTyped = xrplClient.ledgerEntry(
-      LedgerEntryRequestParams.index(permissionedDomainObject.index(), LedgerSpecifier.VALIDATED)
+    LedgerEntryResult<LedgerObject> entryByIndexUnTyped = this.scanForResult(
+      () -> {
+        try {
+          return xrplClient.ledgerEntry(
+            LedgerEntryRequestParams.index(permissionedDomainObject.index(), LedgerSpecifier.VALIDATED)
+          );
+        } catch (JsonRpcClientErrorException e) {
+          throw new RuntimeException(e);
+        }
+      }
     );
 
     assertThat(entryByIndex.node()).isEqualTo(entryByIndexUnTyped.node());
   }
 
-  private Hash256 getPermissionedDomainId(Address domainOwner, UnsignedInteger sequence)
-    throws JsonRpcClientErrorException {
-
-    return xrplClient.ledgerEntry(
-      LedgerEntryRequestParams.permissionedDomain(
-        PermissionedDomainLedgerEntryParams.builder()
-          .account(domainOwner)
-          .seq(sequence)
-          .build(),
-        LedgerSpecifier.VALIDATED
-      )
+  private Hash256 getPermissionedDomainId(Address domainOwner, UnsignedInteger sequence) {
+    return this.scanForResult(
+      () -> {
+        try {
+          return xrplClient.ledgerEntry(
+            LedgerEntryRequestParams.permissionedDomain(
+              PermissionedDomainLedgerEntryParams.builder()
+                .account(domainOwner)
+                .seq(sequence)
+                .build(),
+              LedgerSpecifier.VALIDATED
+            )
+          );
+        } catch (JsonRpcClientErrorException e) {
+          throw new RuntimeException(e);
+        }
+      }
     ).node().index();
   }
 
   private void assertPermissionedDomainDeleted(Address domainOwner, UnsignedInteger sequence) {
-    assertThatThrownBy(() -> xrplClient.ledgerEntry(
-      LedgerEntryRequestParams.permissionedDomain(
-        PermissionedDomainLedgerEntryParams.builder()
-          .account(domainOwner)
-          .seq(sequence)
-          .build(),
-        LedgerSpecifier.VALIDATED
-      )
-    )).isInstanceOf(JsonRpcClientErrorException.class)
-      .hasMessage("entryNotFound (Entry not found.)");
+    try {
+      this.scanForResult(
+        () -> {
+          try {
+            return xrplClient.accountObjects(
+              AccountObjectsRequestParams.builder()
+                .type(AccountObjectType.PERMISSIONED_DOMAIN)
+                .account(domainOwner)
+                .ledgerSpecifier(LedgerSpecifier.VALIDATED)
+                .build()
+            ).accountObjects();
+          } catch (JsonRpcClientErrorException e) {
+            throw new RuntimeException(e);
+          }
+        },
+        objects -> objects.isEmpty()
+      );
+    } catch (ConditionTimeoutException e) {
+      throw new IllegalStateException("PermissionedDomainObject still exists after expected deletion.", e);
+    }
   }
 }


### PR DESCRIPTION
These test changes improve the reliability of integration tests against clio clusters. Previously, tests would confirm a transaction reached a validated ledger state and then immediately read derived state from a clio node. However, clio nodes replicate ledger data independently so a given node's cache can lag behind consensus. Reads made before replication completes return stale data, causing intermittent failures.

With these changes, a read is only made when the account sequence number increases meaning that the current clio node's replication state has caught up with the with the ledger.
