### PR TITLE
Fix XrpCurrencyAmount.times() sign logic (Issue #721)

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -381,7 +381,7 @@ public class Wrappers {
 
       return XrpCurrencyAmount.ofDrops(
         this.value().times(other.value()),
-        this.isNegative() || other.isNegative()
+        this.isNegative() ^ other.isNegative()
       );
     }
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
@@ -428,7 +428,7 @@ public class XrpCurrencyAmountTest {
       final XrpCurrencyAmount value = XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(2L), true)
         .times(XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(3L), true));
       assertThat(value.value()).isEqualTo(UnsignedLong.valueOf(6L));
-      assertThat(value.isNegative()).isTrue();
+      assertThat(value.isNegative()).isFalse();
     }
   }
 


### PR DESCRIPTION
`XrpCurrencyAmount.times()` was using `||` (logical OR) to determine the sign of the result, causing an incorrect sign. Fixed by replacing `||` with ^ (XOR). Change is demonstrated in a test that changed from negative x negative is negative to negative x negative is positive.