### PR TITLE
AffectedNodeDeserializer NPE on missing LedgerEntryType (Issue #750)

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/AffectedNodeDeserializer.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/jackson/modules/AffectedNodeDeserializer.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import org.xrpl.xrpl4j.model.transactions.metadata.AffectedNode;
 import org.xrpl.xrpl4j.model.transactions.metadata.CreatedNode;
 import org.xrpl.xrpl4j.model.transactions.metadata.DeletedNode;
@@ -56,9 +57,13 @@ public class AffectedNodeDeserializer extends StdDeserializer<AffectedNode> {
     Map.Entry<String, JsonNode> nodeFieldAndValue = jsonNode.fields().next();
     String affectedNodeType = nodeFieldAndValue.getKey();
 
-    MetaLedgerEntryType ledgerEntryType = MetaLedgerEntryType.of(
-      nodeFieldAndValue.getValue().get("LedgerEntryType").asText()
-    );
+    JsonNode ledgerEntryTypeNode = nodeFieldAndValue.getValue().get("LedgerEntryType");
+    if (ledgerEntryTypeNode == null || ledgerEntryTypeNode.isNull()) {
+      throw MismatchedInputException.from(
+        jsonParser, AffectedNode.class, "AffectedNode is missing required 'LedgerEntryType' field"
+      );
+    }
+    MetaLedgerEntryType ledgerEntryType = MetaLedgerEntryType.of(ledgerEntryTypeNode.asText());
     Class<? extends MetaLedgerObject> ledgerObjectClass = ledgerEntryType.ledgerObjectType();
 
     switch (affectedNodeType) {

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/AffectedNodeDeserializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/AffectedNodeDeserializerTest.java
@@ -1,0 +1,49 @@
+package org.xrpl.xrpl4j.model.jackson.modules;
+
+/*-
+ * ========================LICENSE_START=================================
+ * xrpl4j :: model
+ * %%
+ * Copyright (C) 2020 - 2022 XRPL Foundation and its contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xrpl.xrpl4j.model.jackson.ObjectMapperFactory;
+import org.xrpl.xrpl4j.model.transactions.metadata.AffectedNode;
+
+class AffectedNodeDeserializerTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = ObjectMapperFactory.create();
+  }
+
+  @Test
+  void affectedNodeDeserializerNpeOnMissingLedgerEntryType() {
+    String json = "{\"CreatedNode\":{\"SomeOtherField\":\"value\"}}";
+    assertThatThrownBy(() -> objectMapper.readValue(json, AffectedNode.class))
+      .isInstanceOf(MismatchedInputException.class)
+      .hasMessageContaining("LedgerEntryType");
+  }
+}

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/AffectedNodeDeserializerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/jackson/modules/AffectedNodeDeserializerTest.java
@@ -46,4 +46,12 @@ class AffectedNodeDeserializerTest {
       .isInstanceOf(MismatchedInputException.class)
       .hasMessageContaining("LedgerEntryType");
   }
+
+  @Test
+  void affectedNodeDeserializerThrowsOnNullLedgerEntryType() {
+    String json = "{\"CreatedNode\":{\"LedgerEntryType\":null}}";
+    assertThatThrownBy(() -> objectMapper.readValue(json, AffectedNode.class))
+      .isInstanceOf(MismatchedInputException.class)
+      .hasMessageContaining("LedgerEntryType");
+  }
 }


### PR DESCRIPTION
Updated exception use case so that `MismatchedInputException` is thrown instead of a `NullPointerException` when `LedgerEntryType` is absent from a `CreatedNode`, `ModifiedNode`, or `DeletedNode` payload. There was previously no associated unit tests for `AffectedNodeDeserializerTest.java` so `AffectedNodeDeserializer.java` was added.