### PR TITLE
Fix Math.abs(Long.MIN_VALUE) overflow in XrpCurrencyAmount.ofDrops(long)

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -210,12 +210,13 @@ public class Wrappers {
      * @return An {@link XrpCurrencyAmount} of {@code drops}.
      */
     public static XrpCurrencyAmount ofDrops(final long drops) {
-      if (drops == Long.MIN_VALUE) {
-        throw new IllegalArgumentException(
-          "drops value of Long.MIN_VALUE is not supported because Math.abs(Long.MIN_VALUE) overflows to Long.MIN_VALUE"
-        );
-      }
       if (drops < 0) {
+        if (drops == Long.MIN_VALUE) {
+          throw new IllegalArgumentException(
+            "drops value of Long.MIN_VALUE is not supported because Math.abs(Long.MIN_VALUE) overflows to " +
+              "Long.MIN_VALUE"
+          );
+        }
         // Normalize the drops value to be a positive number; indicate negativity via property.
         return ofDrops(UnsignedLong.valueOf(Math.abs(drops)), true);
       } else {

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -210,6 +210,11 @@ public class Wrappers {
      * @return An {@link XrpCurrencyAmount} of {@code drops}.
      */
     public static XrpCurrencyAmount ofDrops(final long drops) {
+      if (drops == Long.MIN_VALUE) {
+        throw new IllegalArgumentException(
+          "drops value of Long.MIN_VALUE is not supported because Math.abs(Long.MIN_VALUE) overflows to Long.MIN_VALUE"
+        );
+      }
       if (drops < 0) {
         // Normalize the drops value to be a positive number; indicate negativity via property.
         return ofDrops(UnsignedLong.valueOf(Math.abs(drops)), true);

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
@@ -86,6 +86,15 @@ public class XrpCurrencyAmountTest {
   }
 
   @Test
+  public void ofDropsLongMinValueThrowsIllegalArgumentException() {
+    IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class,
+      () -> XrpCurrencyAmount.ofDrops(Long.MIN_VALUE)
+    );
+    assertThat(exception.getMessage()).contains("Long.MIN_VALUE");
+  }
+
+  @Test
   public void ofDropsLongNegative() {
     XrpCurrencyAmount xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(-1L);
     assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.ONE);


### PR DESCRIPTION
Within the `ofDrops` function, when the value of drops is negative, this value is normalized through `UnsignedLong.valueOf(Math.abs(drops))`. When the value of drops is equal to `Long.MIN_VALUE` (`-9,223,372,036,854,775,808`), then `Math.abs(drops)` should return `9,223,372,036,854,775,808`. However, `Long.MAX_VALUE` is equal to `9,223,372,036,854,775,807` so any value larger than this is outside the range of a Long value. Additionally, this value is outside the range of the total number of drops in existence (`100,000,000,000,000,000`).

Other large values outside of the max amount of drops allowed are caught by `@Value.Check` so we only need to fix this special edge case.
