### PR TITLE
Xrp currency amt isnegative

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -393,7 +393,7 @@ public class Wrappers {
     @Override
     public boolean equals(Object obj) {
       if (obj instanceof XrpCurrencyAmount) {
-        XrpCurrencyAmount other = (XrpCurrencyAmount) obj;
+        XrpCurrencyAmount other = (XrpCurrencyAmount) obj; // <-- Can't be null due to Immutables
         return this.value().equals(other.value()) && this.isNegative() == other.isNegative();
       }
       return false;

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -393,15 +393,15 @@ public class Wrappers {
     @Override
     public boolean equals(Object obj) {
       if (obj instanceof XrpCurrencyAmount) {
-        UnsignedLong otherValue = ((XrpCurrencyAmount) obj).value(); // <-- Can't be null due to Immutables
-        return this.value().equals(otherValue);
+        XrpCurrencyAmount other = (XrpCurrencyAmount) obj;
+        return this.value().equals(other.value()) && this.isNegative() == other.isNegative();
       }
       return false;
     }
 
     @Override
     public int hashCode() {
-      return this.value().hashCode();
+      return Objects.hash(this.value(), this.isNegative());
     }
 
     /**

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/Wrappers.java
@@ -211,6 +211,12 @@ public class Wrappers {
      */
     public static XrpCurrencyAmount ofDrops(final long drops) {
       if (drops < 0) {
+        if (drops == Long.MIN_VALUE) {
+          throw new IllegalArgumentException(
+            "drops value of Long.MIN_VALUE is not supported because Math.abs(Long.MIN_VALUE) overflows to " +
+              "Long.MIN_VALUE"
+          );
+        }
         // Normalize the drops value to be a positive number; indicate negativity via property.
         return ofDrops(UnsignedLong.valueOf(Math.abs(drops)), true);
       } else {

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
@@ -86,6 +86,15 @@ public class XrpCurrencyAmountTest {
   }
 
   @Test
+  public void ofDropsLongMinValueThrowsIllegalArgumentException() {
+    IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class,
+      () -> XrpCurrencyAmount.ofDrops(Long.MIN_VALUE)
+    );
+    assertThat(exception.getMessage()).contains("Long.MIN_VALUE");
+  }
+
+  @Test
   public void ofDropsLongNegative() {
     XrpCurrencyAmount xrpCurrencyAmount = XrpCurrencyAmount.ofDrops(-1L);
     assertThat(xrpCurrencyAmount.value()).isEqualTo(UnsignedLong.ONE);

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/model/transactions/XrpCurrencyAmountTest.java
@@ -310,7 +310,7 @@ public class XrpCurrencyAmountTest {
       .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("+0.000001")))).isEqualTo(XrpCurrencyAmount.ofDrops(0L));
     // Decimals (first negative, second negative)
     assertThat(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001"))
-      .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001")))).isEqualTo(XrpCurrencyAmount.ofDrops(2L));
+      .plus(XrpCurrencyAmount.ofXrp(new BigDecimal("-0.000001")))).isEqualTo(XrpCurrencyAmount.ofDrops(-2L));
 
     // Overflow
     assertThrows(IllegalStateException.class, () -> {
@@ -460,6 +460,20 @@ public class XrpCurrencyAmountTest {
 
     // Different values should have different hashCodes
     assertThat(amount1.hashCode()).isNotEqualTo(amount3.hashCode());
+  }
+
+  @Test
+  public void bug02_equalsIgnoresNegativeFlag() {
+    final XrpCurrencyAmount positive = XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(1_000_000L), false);
+    final XrpCurrencyAmount negative = XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(1_000_000L), true);
+    assertThat(positive).isNotEqualTo(negative);
+  }
+
+  @Test
+  public void bug02_hashCodeIgnoresNegativeFlag() {
+    final XrpCurrencyAmount positive = XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(1_000_000L), false);
+    final XrpCurrencyAmount negative = XrpCurrencyAmount.ofDrops(UnsignedLong.valueOf(1_000_000L), true);
+    assertThat(positive.hashCode()).isNotEqualTo(negative.hashCode());
   }
 
   @Test


### PR DESCRIPTION
Currently, the equals logic in `Wrappers.java` only checks the value of an `XrpCurrencyAmount`. However, the true amount is stored in both value and `isNegative`. Two values that are opposites of each other (ie. 1 and -1) would return true when equals is called. This PR adds the `isNegative` flag for comparison.

hashCode()` also treated opposite values as the same which this PR now fixes. 

The associated `XrpCurrencyAmount` unit test file (`XrpCurrencyAmountTest.java`) was updated to reflect this fix. A preexisting incorrect test was also passing due to this error. That test has now been corrected.