### PR TITLE
Fix secp256k1 deriveScalar accumu0lating bytes across iterations (Issu…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,8 @@
                   <!-- As part of SkyStreamer, but only for test scope-->
                   <ignoredDependency>com.vaadin.external.google:android-json</ignoredDependency>
                   <ignoredDependency>org.junit.jupiter:junit-jupiter-engine</ignoredDependency>
+                  <!-- mockito-inline works as a Java agent; no classes are directly imported -->
+                  <ignoredDependency>org.mockito:mockito-inline</ignoredDependency>
                 </ignoredDependencies>
               </configuration>
             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <version>3.7.7</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.immutables</groupId>
         <artifactId>value-annotations</artifactId>
         <version>${immutables.version}</version>

--- a/xrpl4j-core/pom.xml
+++ b/xrpl4j-core/pom.xml
@@ -84,6 +84,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
@@ -475,8 +475,8 @@ public interface Seed extends javax.security.auth.Destroyable {
         Objects.requireNonNull(discriminator);
 
         BigInteger key = null;
-        UnsignedByteArray seedCopy = UnsignedByteArray.of(seed.toByteArray());
         for (long i = 0; i <= 0xFFFFFFFFL; i++) {
+          UnsignedByteArray seedCopy = UnsignedByteArray.of(seed.toByteArray());
           discriminator.map(d -> HashingUtils.addUInt32(seedCopy, d));
           HashingUtils.addUInt32(seedCopy, (int) i);
           UnsignedByteArray hash = HashingUtils.sha512Half(seedCopy);

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/keys/Seed.java
@@ -476,6 +476,8 @@ public interface Seed extends javax.security.auth.Destroyable {
 
         BigInteger key = null;
         for (long i = 0; i <= 0xFFFFFFFFL; i++) {
+          // Rarely loops (secp256k1 order ≈ 2^256, so iteration is needed with negligible probability),
+          // but seedCopy must be recreated each iteration to avoid accumulating bytes across retries.
           UnsignedByteArray seedCopy = UnsignedByteArray.of(seed.toByteArray());
           discriminator.map(d -> HashingUtils.addUInt32(seedCopy, d));
           HashingUtils.addUInt32(seedCopy, (int) i);

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/SeedTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/SeedTest.java
@@ -364,4 +364,27 @@ public class SeedTest {
       "rByLcEZ7iwTBAK8FfjtpFuT7fCzt4kF4r2"
     );
   }
+
+  @Test
+  void deriveScalarDoesNotAccumulateBytesAcrossIterations() {
+    // addUInt32 mutates its UnsignedByteArray argument in-place by appending 4 bytes.
+    // Before the fix, seedCopy was created once outside the loop so every iteration
+    // appended onto the previous iteration's bytes, corrupting the hash input.
+    // This test confirms addUInt32 grows the array and that the fix (re-creating
+    // seedCopy on each iteration) prevents that accumulation.
+    UnsignedByteArray original = UnsignedByteArray.of(new byte[]{1, 2, 3, 4});
+    int originalLength = original.length();
+    org.xrpl.xrpl4j.crypto.HashingUtils.addUInt32(original, 0);
+    // addUInt32 appends 4 bytes in-place — length must grow, proving mutation.
+    assertThat(original.length()).isEqualTo(originalLength + 4);
+
+    // Derive the same secp256k1 key pair twice from the same seed to confirm
+    // deriveScalar is idempotent (would fail before the fix if iteration > 0 was reached).
+    Entropy entropy = Entropy.of(BaseEncoding.base16().decode("CC4E55BC556DD561CBE990E3D4EF7069"));
+    Seed seed = Seed.secp256k1SeedFromEntropy(entropy);
+    KeyPair first = seed.deriveKeyPair();
+    KeyPair second = seed.deriveKeyPair();
+    assertThat(first.publicKey()).isEqualTo(second.publicKey());
+    assertThat(first.privateKey()).isEqualTo(second.privateKey());
+  }
 }

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/SeedTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/keys/SeedTest.java
@@ -22,16 +22,24 @@ package org.xrpl.xrpl4j.crypto.keys;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 
 import com.google.common.io.BaseEncoding;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.xrpl.xrpl4j.codec.addresses.Base58;
 import org.xrpl.xrpl4j.codec.addresses.KeyType;
 import org.xrpl.xrpl4j.codec.addresses.UnsignedByteArray;
 import org.xrpl.xrpl4j.codec.addresses.exceptions.DecodeException;
+import org.xrpl.xrpl4j.crypto.HashingUtils;
 import org.xrpl.xrpl4j.crypto.keys.Seed.DefaultSeed;
 
 import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
 import javax.security.auth.DestroyFailedException;
 
 /**
@@ -367,24 +375,47 @@ public class SeedTest {
 
   @Test
   void deriveScalarDoesNotAccumulateBytesAcrossIterations() {
-    // addUInt32 mutates its UnsignedByteArray argument in-place by appending 4 bytes.
-    // Before the fix, seedCopy was created once outside the loop so every iteration
-    // appended onto the previous iteration's bytes, corrupting the hash input.
-    // This test confirms addUInt32 grows the array and that the fix (re-creating
-    // seedCopy on each iteration) prevents that accumulation.
-    UnsignedByteArray original = UnsignedByteArray.of(new byte[]{1, 2, 3, 4});
-    int originalLength = original.length();
-    org.xrpl.xrpl4j.crypto.HashingUtils.addUInt32(original, 0);
-    // addUInt32 appends 4 bytes in-place — length must grow, proving mutation.
-    assertThat(original.length()).isEqualTo(originalLength + 4);
+    // Force deriveScalar's loop to iterate twice by making the first sha512Half call return a value
+    // >= N (an invalid scalar). The second call's argument reveals whether seedCopy was re-created
+    // inside the loop (correct: seed + [i=1] = 20 bytes) or accumulated outside it
+    // (broken: seed + [i=0] + [i=1] = 24 bytes).
+    //
+    // Rarely loops (secp256k1 order ≈ 2^256, so iteration is needed with negligible probability),
+    // but seedCopy must be recreated each iteration to avoid accumulating bytes across retries.
 
-    // Derive the same secp256k1 key pair twice from the same seed to confirm
-    // deriveScalar is idempotent (would fail before the fix if iteration > 0 was reached).
+    // All-0xFF as a BigInteger is >> N, so the loop rejects it and advances to i=1.
+    byte[] aboveN = new byte[32];
+    Arrays.fill(aboveN, (byte) 0xFF);
+    UnsignedByteArray invalidScalar = UnsignedByteArray.of(aboveN);
+
+    // BigInteger(1) is a valid scalar (> 0 and < N).
+    byte[] belowN = new byte[32];
+    belowN[31] = 1;
+    UnsignedByteArray validScalar = UnsignedByteArray.of(belowN);
+
+    ArgumentCaptor<UnsignedByteArray> captor = ArgumentCaptor.forClass(UnsignedByteArray.class);
+
     Entropy entropy = Entropy.of(BaseEncoding.base16().decode("CC4E55BC556DD561CBE990E3D4EF7069"));
-    Seed seed = Seed.secp256k1SeedFromEntropy(entropy);
-    KeyPair first = seed.deriveKeyPair();
-    KeyPair second = seed.deriveKeyPair();
-    assertThat(first.publicKey()).isEqualTo(second.publicKey());
-    assertThat(first.privateKey()).isEqualTo(second.privateKey());
+    Seed ecSeed = Seed.secp256k1SeedFromEntropy(entropy);
+
+    try (MockedStatic<HashingUtils> mocked = mockStatic(HashingUtils.class)) {
+      mocked.when(() -> HashingUtils.addUInt32(any(), any())).thenCallRealMethod();
+      // Call 1: deriveScalar(seed), i=0 → rejected (>= N), forces loop to i=1
+      // Call 2: deriveScalar(seed), i=1 → accepted
+      // Call 3: deriveScalar(publicGen, accountIndex=0), i=0 → accepted
+      mocked.when(() -> HashingUtils.sha512Half(any(UnsignedByteArray.class)))
+        .thenReturn(invalidScalar)
+        .thenReturn(validScalar)
+        .thenReturn(validScalar);
+
+      ecSeed.deriveKeyPair();
+
+      mocked.verify(() -> HashingUtils.sha512Half(captor.capture()), times(3));
+    }
+
+    List<UnsignedByteArray> args = captor.getAllValues();
+    // The seed entropy is 16 bytes. With correct code, the second sha512Half call receives
+    // seed + [0,0,0,1] = 20 bytes. With broken code it would receive seed + [0,0,0,0] + [0,0,0,1] = 24 bytes.
+    assertThat(args.get(1).length()).isEqualTo(16 + 4);
   }
 }


### PR DESCRIPTION
`HashingUtils.addUInt32()` appends 4 bytes in-place to its UnsignedByteArray argument. Because `seedCopy` was created once outside the loop, each iteration kept appending its counter onto the bytes from the previous iteration. This PR updates the implementation to match the [rippled implementation](https://github.com/XRPLF/rippled/blob/70d5c624e8cf732a362335642b2f5125ce4b43c1/src/libxrpl/protocol/SecretKey.cpp#L103-L114), which hashes on each iteration using the original seed bytes as the base.