### PR TITLE
Add LockedAmount to BASE_10_UINT64_FIELD_NAMES (Issue #792)

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/types/UInt64Type.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/types/UInt64Type.java
@@ -38,7 +38,7 @@ public class UInt64Type extends UIntType<UInt64Type> {
    * These fields are represented as base 10 Strings in JSON, whereas all other STUInt64s are represented in base16.
    */
   protected static final Set<String> BASE_10_UINT64_FIELD_NAMES = Sets.newHashSet(
-    "MaximumAmount", "OutstandingAmount", "MPTAmount"
+    "MaximumAmount", "OutstandingAmount", "MPTAmount", "LockedAmount"
   );
 
   public UInt64Type() {

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/types/UInt64TypeUnitTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/types/UInt64TypeUnitTest.java
@@ -77,6 +77,17 @@ public class UInt64TypeUnitTest {
   }
 
   @Test
+  void lockedAmountUsesBase10() {
+    FieldInstance fieldInstance = mock(FieldInstance.class);
+    when(fieldInstance.name()).thenReturn("LockedAmount");
+    // Decimal "1000" must encode to 0x00000000000003E8, not 0x0000000000001000 (base-16 misinterpretation)
+    assertThat(type.fromJson(new TextNode("1000"), fieldInstance).toHex())
+      .isEqualTo("00000000000003E8");
+    assertThat(type.fromJson(new TextNode("1000"), fieldInstance).toJson(fieldInstance))
+      .isEqualTo(new TextNode("1000"));
+  }
+
+  @Test
   void fromJsonThrowsWithoutFieldInstance() {
     assertThatThrownBy(() -> type.fromJson(new TextNode("0")))
       .isInstanceOf(UnsupportedOperationException.class);


### PR DESCRIPTION
This PR covers a missed `LockedAmount` from `UInt64Type.BASE_10_UINT64_FIELD_NAMES` which caused the binary codec to treat the value as base-16 instead of base-10 and includes a unit test to cover this change.