### PR TITLE
ci: support private xrpld images via committed config file

### DIFF
--- a/.github/actions/xrpld-login/action.yml
+++ b/.github/actions/xrpld-login/action.yml
@@ -1,0 +1,25 @@
+name: 'Log in to private xrpld registry'
+description: 'Logs in to the private GitLab registry if a private xrpld image is in use'
+inputs:
+  is_private:
+    description: 'Whether a private image is being used'
+    required: true
+  username:
+    description: 'GitLab registry username'
+    required: true
+  token:
+    description: 'GitLab registry token'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Log in to the private GitLab registry
+      if: ${{ inputs.is_private == 'true' }}
+      shell: bash
+      env:
+        GITLAB_REGISTRY_USERNAME: ${{ inputs.username }}
+        GITLAB_REGISTRY_TOKEN: ${{ inputs.token }}
+      run: |
+        printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
+          --username "${GITLAB_REGISTRY_USERNAME}" \
+          --password-stdin

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,8 +5,66 @@ on:
   pull_request:
     types: [ assigned ]
 jobs:
-  build_jdk_temurin_8:
+  resolve_xrpld_image:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      image: ${{ steps.resolve.outputs.image }}
+      is_private: ${{ steps.resolve.outputs.is_private }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Resolve xrpld image
+        id: resolve
+        env:
+          IMAGE_CONFIG_FILE: .github/xrpld-image.env
+          DEFAULT_IMAGE: rippleci/xrpld:develop
+          PRIVATE_IMAGE_REPO: registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private
+          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Read the requested private version from the committed config file.
+          # The file is never sourced: on fork pull requests its contents are
+          # untrusted, so we only extract the value and validate it strictly.
+          PRIVATE_VERSION=""
+          if [[ -f "${IMAGE_CONFIG_FILE}" ]]; then
+            RAW_LINE="$(grep -E '^[[:space:]]*XRPLD_PRIVATE_VERSION[[:space:]]*=' "${IMAGE_CONFIG_FILE}" | tail -n1 || true)"
+            PRIVATE_VERSION="$(printf '%s' "${RAW_LINE#*=}" | tr -d "[:space:]\"'")"
+          fi
+
+          if [[ -z "${PRIVATE_VERSION}" ]]; then
+            echo "No private xrpld version configured in ${IMAGE_CONFIG_FILE}; using default image ${DEFAULT_IMAGE}."
+            {
+              echo "image=${DEFAULT_IMAGE}"
+              echo "is_private=false"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if ! [[ "${PRIVATE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(b|rc)[0-9]+)?$ ]]; then
+            echo "XRPLD_PRIVATE_VERSION in ${IMAGE_CONFIG_FILE} must use X.Y.Z, X.Y.Z-bN, or X.Y.Z-rcN format (got '${PRIVATE_VERSION}')." >&2
+            exit 1
+          fi
+
+          if [[ -z "${GITLAB_REGISTRY_USERNAME}" || -z "${GITLAB_REGISTRY_TOKEN}" ]]; then
+            echo "A private xrpld version (${PRIVATE_VERSION}) is configured but the GITLAB_REGISTRY_USERNAME variable and GITLAB_REGISTRY_TOKEN secret are unavailable. These are not exposed to fork pull requests; run the private build from a branch in this repository, or clear XRPLD_PRIVATE_VERSION to use the default image." >&2
+            exit 1
+          fi
+
+          echo "Using private xrpld image for version ${PRIVATE_VERSION}."
+          {
+            echo "image=${PRIVATE_IMAGE_REPO}:private-${PRIVATE_VERSION}"
+            echo "is_private=true"
+          } >> "${GITHUB_OUTPUT}"
+
+  build_jdk_temurin_8:
+    needs: resolve_xrpld_image
+    runs-on: ubuntu-latest
+    env:
+      XRPLD_DOCKER_IMAGE: ${{ needs.resolve_xrpld_image.outputs.image }}
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v6
@@ -17,6 +75,15 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
           cache: 'maven'
+      - name: Log in to the private GitLab registry
+        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
+        env:
+          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+        run: |
+          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
+            --username "${GITLAB_REGISTRY_USERNAME}" \
+            --password-stdin
       - name: Build
         run: mvn clean install
       - name: Upload to Codecov
@@ -26,7 +93,10 @@ jobs:
           fail_ci_if_error: true
 
   build_jdk_semeru_8:
+    needs: resolve_xrpld_image
     runs-on: ubuntu-latest
+    env:
+      XRPLD_DOCKER_IMAGE: ${{ needs.resolve_xrpld_image.outputs.image }}
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v6
@@ -37,11 +107,23 @@ jobs:
           distribution: 'semeru'
           java-version: '8'
           cache: 'maven'
+      - name: Log in to the private GitLab registry
+        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
+        env:
+          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+        run: |
+          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
+            --username "${GITLAB_REGISTRY_USERNAME}" \
+            --password-stdin
       - name: Build
         run: mvn clean install
 
   build_jdk_zulu_8:
+    needs: resolve_xrpld_image
     runs-on: ubuntu-latest
+    env:
+      XRPLD_DOCKER_IMAGE: ${{ needs.resolve_xrpld_image.outputs.image }}
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v6
@@ -52,11 +134,23 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
           cache: 'maven'
+      - name: Log in to the private GitLab registry
+        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
+        env:
+          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+        run: |
+          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
+            --username "${GITLAB_REGISTRY_USERNAME}" \
+            --password-stdin
       - name: Build
         run: mvn clean install
 
   build_jdk_temurin_other:
+    needs: resolve_xrpld_image
     runs-on: ubuntu-latest
+    env:
+      XRPLD_DOCKER_IMAGE: ${{ needs.resolve_xrpld_image.outputs.image }}
     strategy:
       matrix:
         # test against each major Java version (Java 8 built separately above for codecov upload)
@@ -71,11 +165,23 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
+      - name: Log in to the private GitLab registry
+        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
+        env:
+          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+        run: |
+          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
+            --username "${GITLAB_REGISTRY_USERNAME}" \
+            --password-stdin
       - name: Build
         run: mvn clean install -Dmaven.javadoc.skip=true
 
   build_jdk_temurin_non_us:
+    needs: resolve_xrpld_image
     runs-on: ubuntu-latest
+    env:
+      XRPLD_DOCKER_IMAGE: ${{ needs.resolve_xrpld_image.outputs.image }}
     steps:
       - uses: actions/checkout@v6
       # Set up Temurin 21
@@ -85,12 +191,24 @@ jobs:
           distribution: 'temurin'
           java-version: 21
           cache: 'maven'
+      - name: Log in to the private GitLab registry
+        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
+        env:
+          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+        run: |
+          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
+            --username "${GITLAB_REGISTRY_USERNAME}" \
+            --password-stdin
       # Maven install with JVM locale = de_DE
       - name: Build
         run: mvn clean install -Dmaven.javadoc.skip=true -DargLine="-Duser.language=de -Duser.country=DE"
 
   build_android:
+    needs: resolve_xrpld_image
     runs-on: ubuntu-latest
+    env:
+      XRPLD_DOCKER_IMAGE: ${{ needs.resolve_xrpld_image.outputs.image }}
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v6
@@ -104,6 +222,15 @@ jobs:
       # Set up Android
       - name: Setup Android SDK
         uses: android-actions/setup-android@v4
+      - name: Log in to the private GitLab registry
+        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
+        env:
+          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+        run: |
+          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
+            --username "${GITLAB_REGISTRY_USERNAME}" \
+            --password-stdin
       - name: Build
         run: mvn clean install -Dmaven.javadoc.skip=true -Pandroid
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -75,15 +75,12 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
           cache: 'maven'
-      - name: Log in to the private GitLab registry
-        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
-        env:
-          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
-          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
-        run: |
-          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
-            --username "${GITLAB_REGISTRY_USERNAME}" \
-            --password-stdin
+      - name: Log in to private registry
+        uses: ./.github/actions/xrpld-login
+        with:
+          is_private: ${{ needs.resolve_xrpld_image.outputs.is_private }}
+          username: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          token: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
       - name: Build
         run: mvn clean install
       - name: Upload to Codecov
@@ -107,15 +104,12 @@ jobs:
           distribution: 'semeru'
           java-version: '8'
           cache: 'maven'
-      - name: Log in to the private GitLab registry
-        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
-        env:
-          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
-          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
-        run: |
-          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
-            --username "${GITLAB_REGISTRY_USERNAME}" \
-            --password-stdin
+      - name: Log in to private registry
+        uses: ./.github/actions/xrpld-login
+        with:
+          is_private: ${{ needs.resolve_xrpld_image.outputs.is_private }}
+          username: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          token: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
       - name: Build
         run: mvn clean install
 
@@ -134,15 +128,12 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
           cache: 'maven'
-      - name: Log in to the private GitLab registry
-        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
-        env:
-          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
-          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
-        run: |
-          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
-            --username "${GITLAB_REGISTRY_USERNAME}" \
-            --password-stdin
+      - name: Log in to private registry
+        uses: ./.github/actions/xrpld-login
+        with:
+          is_private: ${{ needs.resolve_xrpld_image.outputs.is_private }}
+          username: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          token: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
       - name: Build
         run: mvn clean install
 
@@ -165,15 +156,12 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'maven'
-      - name: Log in to the private GitLab registry
-        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
-        env:
-          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
-          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
-        run: |
-          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
-            --username "${GITLAB_REGISTRY_USERNAME}" \
-            --password-stdin
+      - name: Log in to private registry
+        uses: ./.github/actions/xrpld-login
+        with:
+          is_private: ${{ needs.resolve_xrpld_image.outputs.is_private }}
+          username: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          token: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
       - name: Build
         run: mvn clean install -Dmaven.javadoc.skip=true
 
@@ -191,15 +179,12 @@ jobs:
           distribution: 'temurin'
           java-version: 21
           cache: 'maven'
-      - name: Log in to the private GitLab registry
-        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
-        env:
-          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
-          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
-        run: |
-          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
-            --username "${GITLAB_REGISTRY_USERNAME}" \
-            --password-stdin
+      - name: Log in to private registry
+        uses: ./.github/actions/xrpld-login
+        with:
+          is_private: ${{ needs.resolve_xrpld_image.outputs.is_private }}
+          username: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          token: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
       # Maven install with JVM locale = de_DE
       - name: Build
         run: mvn clean install -Dmaven.javadoc.skip=true -DargLine="-Duser.language=de -Duser.country=DE"
@@ -222,15 +207,12 @@ jobs:
       # Set up Android
       - name: Setup Android SDK
         uses: android-actions/setup-android@v4
-      - name: Log in to the private GitLab registry
-        if: ${{ needs.resolve_xrpld_image.outputs.is_private == 'true' }}
-        env:
-          GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
-          GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
-        run: |
-          printf '%s' "${GITLAB_REGISTRY_TOKEN}" | docker login registry.gitlab.com \
-            --username "${GITLAB_REGISTRY_USERNAME}" \
-            --password-stdin
+      - name: Log in to private registry
+        uses: ./.github/actions/xrpld-login
+        with:
+          is_private: ${{ needs.resolve_xrpld_image.outputs.is_private }}
+          username: ${{ vars.GITLAB_REGISTRY_USERNAME }}
+          token: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
       - name: Build
         run: mvn clean install -Dmaven.javadoc.skip=true -Pandroid
 

--- a/.github/xrpld-image.env
+++ b/.github/xrpld-image.env
@@ -1,0 +1,17 @@
+# xrpld image selection for the local integration tests (Testcontainers).
+#
+# Set XRPLD_PRIVATE_VERSION to a private xrpld release (for example, 3.3.0-rc2
+# or 3.3.0-b1) to run the local integration tests against the private image:
+#   registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private:private-<version>
+#
+# Leave it empty to use the default public image rippleci/xrpld:develop.
+#
+# The resolved image is passed to Maven via the XRPLD_DOCKER_IMAGE environment
+# variable, which RippledContainer reads when starting the Testcontainers node.
+#
+# Private pulls require the repository variable GITLAB_REGISTRY_USERNAME and the
+# repository secret GITLAB_REGISTRY_TOKEN (a GitLab deploy token with
+# read_registry access). These credentials are not exposed to fork pull
+# requests, so a private version must be tested from a branch in this
+# repository; a fork pull request with a private version set will fail fast.
+XRPLD_PRIVATE_VERSION=

--- a/README.md
+++ b/README.md
@@ -259,6 +259,27 @@ To build the project while skipping Unit and Integration tests, use the followin
 mvn clean install -DskipITs -DskipTests
 ```
 
+### Running integration tests against a private xrpld image
+
+By default the local integration tests start an `xrpld` node via Testcontainers using the public image
+`rippleci/xrpld:develop`. To run them against a private xrpld image, set the `XRPLD_DOCKER_IMAGE` environment variable
+before invoking Maven:
+
+```
+XRPLD_DOCKER_IMAGE=registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private:private-3.3.0-rc2 mvn clean install
+```
+
+`RippledContainer` reads `XRPLD_DOCKER_IMAGE` (falling back to the public image when it is unset). For a private
+registry, run `docker login` first so Testcontainers can reuse the credentials when pulling.
+
+In CI the image is selected from a committed config file, `.github/xrpld-image.env`. Set `XRPLD_PRIVATE_VERSION` to a
+version (without the `private-` prefix, for example `XRPLD_PRIVATE_VERSION=3.3.0-rc2`) and every workflow run — including
+pull request runs — resolves the private image, logs into the GitLab registry, and exports `XRPLD_DOCKER_IMAGE` to the
+local-integration-test jobs. Leave it empty to use the default public image. Private pulls require the repository
+variable `GITLAB_REGISTRY_USERNAME` and repository secret `GITLAB_REGISTRY_TOKEN` (a GitLab deploy token with
+`read_registry` access); these are not exposed to fork pull requests, so a private version must be tested from a branch
+in this repository.
+
 [codecov-image]: https://codecov.io/gh/XRPLF/xrpl4j/branch/main/graph/badge.svg
 
 [codecov-url]: https://codecov.io/gh/XRPLF/xrpl4j

--- a/README.md
+++ b/README.md
@@ -274,7 +274,8 @@ registry, run `docker login` first so Testcontainers can reuse the credentials w
 
 In CI the image is selected from a committed config file, `.github/xrpld-image.env`. Set `XRPLD_PRIVATE_VERSION` to a
 version (without the `private-` prefix, for example `XRPLD_PRIVATE_VERSION=3.3.0-rc2`) and every workflow run — including
-pull request runs — resolves the private image, logs into the GitLab registry, and exports `XRPLD_DOCKER_IMAGE` to the
+pull request runs — resolves the private image, logs into the GitLab registry (via the `.github/actions/xrpld-login`
+composite action, shared by all of those jobs), and exports `XRPLD_DOCKER_IMAGE` to the
 local-integration-test jobs. Leave it empty to use the default public image. Private pulls require the repository
 variable `GITLAB_REGISTRY_USERNAME` and repository secret `GITLAB_REGISTRY_TOKEN` (a GitLab deploy token with
 `read_registry` access); these are not exposed to fork pull requests, so a private version must be tested from a branch

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/RippledContainer.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/RippledContainer.java
@@ -56,8 +56,29 @@ public class RippledContainer {
 
   // Seed for the Master/Root wallet in the rippled docker container.
   public static final String MASTER_WALLET_SEED = "snoPBrXtMeMyMHUVTgbuqAfg1SUTb";
+
+  // Default public xrpld image. Overridden via the XRPLD_DOCKER_IMAGE environment variable so CI can
+  // run the local integration tests against a private xrpld image (see .github/xrpld-image.env). When a
+  // private image is used, CI performs a `docker login` beforehand; Testcontainers reuses those Docker
+  // credentials from the default Docker config when pulling.
+  private static final String DEFAULT_DOCKER_IMAGE = "rippleci/xrpld:develop";
+
   private static final Logger LOGGER = getLogger(RippledContainer.class);
   private static ScheduledExecutorService ledgerAcceptor = null;
+
+  /**
+   * Resolves the xrpld Docker image to run, preferring the {@code XRPLD_DOCKER_IMAGE} environment variable and falling
+   * back to the default public image when it is unset or blank.
+   *
+   * @return The fully-qualified xrpld Docker image reference.
+   */
+  private static String resolveDockerImage() {
+    String configuredImage = System.getenv("XRPLD_DOCKER_IMAGE");
+    if (configuredImage == null || configuredImage.trim().isEmpty()) {
+      return DEFAULT_DOCKER_IMAGE;
+    }
+    return configuredImage.trim();
+  }
 
   /**
    * Advances the ledger by one on each call.
@@ -81,7 +102,9 @@ public class RippledContainer {
    * No-args constructor.
    */
   public RippledContainer() {
-    try (GenericContainer<?> container = new GenericContainer<>("rippleci/xrpld:develop")) {
+    String dockerImage = resolveDockerImage();
+    LOGGER.info("Using xrpld Docker image '{}' for local integration tests.", dockerImage);
+    try (GenericContainer<?> container = new GenericContainer<>(dockerImage)) {
       this.rippledContainer = container
         .withCommand("--standalone")
         .withExposedPorts(5005)


### PR DESCRIPTION
## High Level Overview of Change

- Make the local integration tests select the xrpld Docker image from the `XRPLD_DOCKER_IMAGE` environment variable (default `rippleci/xrpld:develop`) instead of a hardcoded value in `RippledContainer`.
- Add a committed config file, `.github/xrpld-image.env`, plus a `resolve_xrpld_image` CI job that reads `XRPLD_PRIVATE_VERSION` from it: when set, the local integration tests run against the private GitLab xrpld image; when empty, they use the default public image.
- Wire all six local-integration-test jobs (`build_jdk_temurin_8`, `build_jdk_semeru_8`, `build_jdk_zulu_8`, `build_jdk_temurin_other`, `build_jdk_temurin_non_us`, `build_android`) to the resolver: they export `XRPLD_DOCKER_IMAGE` and log into the GitLab registry when a private image is configured.
- Define the registry login once, in a `.github/actions/xrpld-login` composite action, rather than repeating the `docker login` block in each of those six jobs.
- Document the mechanism in `README.md`.

### Context of Change

`xrpl4j` starts a local `xrpld` node for integration tests via Testcontainers (`RippledContainer`), with the image hardcoded as `rippleci/xrpld:develop`. To validate against xrpld builds published only to the Ripple GitLab registry, the image needs to be selectable. Selecting it from a committed config file means a branch (including a PR branch in this repository) can opt into a private image by setting `XRPLD_PRIVATE_VERSION`, with no manual dispatch.

`RippledContainer` now reads `XRPLD_DOCKER_IMAGE` (falling back to the public image when unset/blank). In CI, `resolve_xrpld_image` validates the configured version against a strict `X.Y.Z`, `X.Y.Z-bN`, or `X.Y.Z-rcN` pattern before constructing `private-<version>` (the config file is never sourced, avoiding arbitrary image references and shell injection), and the local-IT jobs `docker login` to the registry so Testcontainers reuses those credentials when pulling. When a private version is configured but the registry credentials are unavailable — as on fork pull requests, where GitHub withholds secrets — the resolver fails fast rather than silently falling back.

That login is factored into the `xrpld-login` composite action, which takes `is_private`, `username`, and `token` inputs and owns the `docker login` invocation plus the `is_private` guard. Each job calls it with a single `uses:` step, so the registry host, credential handling (token piped via `--password-stdin`, never in argv), and skip condition are defined in one file instead of six. Passing the credentials as inputs is required, not stylistic: composite actions have no `secrets` context. The action is referenced by local path, which resolves because `actions/checkout` is the first step of every job that uses it.

The remote-network jobs (`build_devnet_its`, `build_testnet_reporting_its`, `build_testnet_clio_its`) do not use the local container and are unchanged, and so have no login step.

This mirrors the same mechanism added to `xrpl.js` (XRPLF/xrpl.js#3416), `xrpl-py` (XRPLF/xrpl-py#1019), and `xrpl-rust` (XRPLF/xrpl-rust#355), so all four libraries select the CI xrpld image the same way.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates

## Test Plan

- Validated `.github/workflows/workflow.yml` and `.github/actions/xrpld-login/action.yml` with a YAML loader.
- Confirmed each of the six local-IT jobs passes exactly the three inputs the composite action declares, and that `actions/checkout` precedes the login step in all of them, so the local action path resolves.
- Ran the resolver's config-file parsing locally against empty, quoted, whitespace-padded, and commented values.
- Verified the version regex accepts `X.Y.Z`, `X.Y.Z-bN`, and `X.Y.Z-rcN` and rejects malformed versions and shell-injection attempts.
- With `XRPLD_PRIVATE_VERSION` empty (as committed here), `resolve_xrpld_image` resolves to the default `rippleci/xrpld:develop`, `XRPLD_DOCKER_IMAGE` is set to that value, and `RippledContainer` starts the same public image as before — so the existing build jobs are unaffected.

> Notes:
> - To test the private image, set `XRPLD_PRIVATE_VERSION` on a branch pushed directly to this repository (not a fork), so the `GITLAB_REGISTRY_TOKEN` secret is available.
> - The `GITLAB_REGISTRY_USERNAME` variable and `GITLAB_REGISTRY_TOKEN` secret have not yet been configured on this repository; they must be added before the private-image path can authenticate. The private-pull path has therefore not been exercised end to end.
