### PR TITLE
chore(coderabbit): add CodeRabbit review config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+
+# Short steer toward useful feedback for open-source contributors; skip style nits (max 250 chars).
+tone_instructions: "Be concise and encouraging to open-source contributors. Flag correctness, security, and API-contract issues; skip style and formatting nits."
+
+reviews:
+  # chill = fewer, higher-signal comments (assertive is nitpicky).
+  profile: "chill"
+  # Keep the bot's review non-blocking; don't gate a contributor's merge on nitpicks.
+  request_changes_workflow: false
+  # Don't let the bot append a summary to the contributor's PR description.
+  high_level_summary: false
+  # poem is noise.
+  poem: false
+  # "Fortune" text while reviewing is noise.
+  in_progress_fortune: false
+  # Post a status note (incl. when a review is skipped).
+  review_status: true
+  # Walkthrough shown expanded.
+  collapse_walkthrough: false
+  # Generate sequence diagrams in the walkthrough.
+  sequence_diagrams: false
+  # Cancel an in-progress review if the PR closes/merges.
+  abort_on_close: true
+  # Flag spam / low-effort PRs on public repos.
+  slop_detection:
+    enabled: true
+  auto_review:
+    # Auto-review every PR.
+    enabled: true
+    # Don't review drafts contributors are still iterating on.
+    drafts: false
+    # Skip dependency/release bumps.
+    ignore_title_keywords:
+      - "build("
+    # Skip dependency-bump bots regardless of title convention (exact, case-sensitive match).
+    ignore_usernames:
+      - "dependabot[bot]"
+  tools:
+    # Grammar/spell nits on comments and prose are false-positive noise.
+    languagetool:
+      enabled: false
+
+chat:
+  # Let contributors ask follow-ups without @-mentioning the bot.
+  auto_reply: true
+  # No ASCII/emoji art.
+  art: false
+  # Required for external (non-org) contributors to interact with the bot.
+  allow_non_org_members: true
+
+knowledge_base:
+  # Give the bot our XRPL-specific review grounding.
+  # applyTo: "**" makes .ai-review/instructions.md apply repo-wide (a guideline file
+  # otherwise scopes only to its own directory).
+  code_guidelines:
+    filePatterns:
+      - files: ".ai-review/instructions.md"
+        applyTo: "**"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,8 +1,9 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-US"
 
-# Short steer toward useful feedback for open-source contributors; skip style nits (max 250 chars).
-tone_instructions: "Be concise and encouraging to open-source contributors. Flag correctness, security, and API-contract issues; skip style and formatting nits."
+# Short steer toward useful feedback for open-source contributors (max 250 chars). Formatting is
+# already enforced deterministically by checkstyle.xml in the Maven build, so the bot skips it.
+tone_instructions: "Be concise and encouraging to open-source contributors. Flag correctness, security, and API-contract issues; skip formatting and whitespace nits already covered by checkstyle."
 
 reviews:
   # chill = fewer, higher-signal comments (assertive is nitpicky).


### PR DESCRIPTION
## What

Adds a `.coderabbit.yaml` so CodeRabbit auto-reviews all PRs on this repo, grounded in the repo's own review guidelines.

- Auto-reviews every PR (`profile: chill`, non-blocking, drafts skipped, dependency bumps skipped).
- Loads `.ai-review/instructions.md` as a code guideline (`applyTo: "**"`).
- Short `tone_instructions`: flag correctness, security, and API-contract issues; skip style nits.
- Noise off by default: `poem`, `in_progress_fortune`, `chat.art`, `sequence_diagrams`, and the `languagetool` grammar linter.
- `slop_detection` on to flag spam / low-effort PRs.
- `chat.allow_non_org_members: true` so external contributors can interact with the bot.

## Why

External contributors get useful first-pass feedback before a maintainer reviews, grounded in this repo's conventions, without boilerplate noise.

## Dependencies

1. The CodeRabbit GitHub App must be added to this repo in the XRPLF org installation (org-owner action, handled separately). This config is inert until then, with no failure state.
2. The guideline load activates once the `.ai-review/instructions.md` PR merges (#815).

## Verify

Once the App is installed, comment `@coderabbitai configuration` on a PR to confirm the resolved config, and check the review reflects the guidelines.
