### PR TITLE
temporarily use rippleci/xrpld:3.3.0 for CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
         id: resolve
         env:
           IMAGE_CONFIG_FILE: .github/xrpld-image.env
-          DEFAULT_IMAGE: rippleci/xrpld:develop
+          DEFAULT_IMAGE: rippleci/xrpld:3.3.0
           PRIVATE_IMAGE_REPO: registry.gitlab.com/ripple/xrpledger/xrpld_package_deploy/xrpld-private
           GITLAB_REGISTRY_USERNAME: ${{ vars.GITLAB_REGISTRY_USERNAME }}
           GITLAB_REGISTRY_TOKEN: ${{ secrets.GITLAB_REGISTRY_TOKEN }}

--- a/.github/xrpld-image.env
+++ b/.github/xrpld-image.env
@@ -14,4 +14,4 @@
 # read_registry access). These credentials are not exposed to fork pull
 # requests, so a private version must be tested from a branch in this
 # repository; a fork pull request with a private version set will fail fast.
-XRPLD_PRIVATE_VERSION=3.3.0-rc2
+XRPLD_PRIVATE_VERSION=

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/RippledContainer.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/environment/RippledContainer.java
@@ -61,7 +61,7 @@ public class RippledContainer {
   // run the local integration tests against a private xrpld image (see .github/xrpld-image.env). When a
   // private image is used, CI performs a `docker login` beforehand; Testcontainers reuses those Docker
   // credentials from the default Docker config when pulling.
-  private static final String DEFAULT_DOCKER_IMAGE = "rippleci/xrpld:develop";
+  private static final String DEFAULT_DOCKER_IMAGE = "rippleci/xrpld:3.3.0";
 
   private static final Logger LOGGER = getLogger(RippledContainer.class);
   private static ScheduledExecutorService ledgerAcceptor = null;


### PR DESCRIPTION
### Why
This is to unblock pull requests opened from forked xrpl4j that doesn't support running CI jobs against private xrpld docker container. We will revert the default image from `rippleci/xrpld:3.3.0` to `rippleci/xrpld:develop` after 3.3.0 changes are merged into the `xrpld` `develop` branch