### PR TITLE
Bind Counterparty and Sponsor signatures to role-specific hash prefixes

### DIFF
--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodec.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodec.java
@@ -55,9 +55,9 @@ public class XrplBinaryCodec {
   public static final String PAYMENT_CHANNEL_CLAIM_SIGNATURE_PREFIX = "434C4D00";
   public static final String BATCH_SIGNATURE_PREFIX = "42434800"; // "BCH\0" per XLS-0056
 
-  // Role-specific signing prefixes introduced by rippled's fixCleanup3_4_0 amendment (PR #8162). Each role signs a
-  // distinct prefix so a signature made for one role cannot be replayed in another. These signatures are only valid
-  // on a network where fixCleanup3_4_0 is enabled.
+  // Role-specific signing prefixes introduced by the fixCleanup3_4_0 amendment. Each role signs under a distinct
+  // prefix so a signature made for one role cannot be replayed in another, and is only valid on a network where that
+  // amendment is enabled.
   public static final String COUNTERPARTY_SIGNATURE_PREFIX = "43505400"; // "CPT\0" - CounterpartySignature single-sign
   public static final String COUNTERPARTY_MULTI_SIGNATURE_PREFIX = "43504D00"; // "CPM\0" - CounterpartySignature multi
   public static final String SPONSOR_SIGNATURE_PREFIX = "53504E00"; // "SPN\0" - SponsorSignature single-sign
@@ -143,7 +143,7 @@ public class XrplBinaryCodec {
    * Encodes JSON to canonical XRPL binary as a hex string for signing a {@code CounterpartySignature} (e.g. the
    * lender's signature on a {@code LoanSet}). Identical to {@link #encodeForSigning(String)} except that the payload is
    * bound to the counterparty role via the {@code CPT\0} prefix, so the resulting signature cannot be replayed as any
-   * other role. Requires the {@code fixCleanup3_4_0} amendment (rippled PR #8162).
+   * other role. Requires the {@code fixCleanup3_4_0} amendment.
    *
    * @param json String containing JSON to be encoded.
    *
@@ -159,7 +159,7 @@ public class XrplBinaryCodec {
    * Encodes JSON to canonical XRPL binary as a hex string for signing a {@code SponsorSignature}. Identical to
    * {@link #encodeForSigning(String)} except that the payload is bound to the sponsor role via the {@code SPN\0}
    * prefix, so the resulting signature cannot be replayed as any other role. Requires the {@code fixCleanup3_4_0}
-   * amendment (rippled PR #8162).
+   * amendment.
    *
    * @param json String containing JSON to be encoded.
    *
@@ -299,8 +299,7 @@ public class XrplBinaryCodec {
   /**
    * Encodes JSON to canonical XRPL binary as a hex string for a counterparty multi-signature (e.g. a multi-signing
    * lender on a {@code LoanSet}). The payload is bound to the counterparty role via the {@code CPM\0} prefix, so the
-   * resulting signature cannot be replayed as any other role. Requires the {@code fixCleanup3_4_0} amendment (rippled
-   * PR #8162).
+   * resulting signature cannot be replayed as any other role. Requires the {@code fixCleanup3_4_0} amendment.
    *
    * <p>Like sponsor multi-signing (and unlike {@link #encodeForMultiSigning(String, String)}), this preserves the
    * first-party signer's {@code SigningPubKey} in the signed data rather than clearing it.</p>
@@ -319,7 +318,7 @@ public class XrplBinaryCodec {
   /**
    * Encodes JSON to canonical XRPL binary as a hex string for a sponsor multi-signature. The payload is bound to the
    * sponsor role via the {@code SPM\0} prefix, so the resulting signature cannot be replayed as any other role.
-   * Requires the {@code fixCleanup3_4_0} amendment (rippled PR #8162).
+   * Requires the {@code fixCleanup3_4_0} amendment.
    *
    * <p>Like counterparty multi-signing (and unlike {@link #encodeForMultiSigning(String, String)}), this preserves the
    * first-party signer's {@code SigningPubKey} in the signed data rather than clearing it.</p>
@@ -419,8 +418,7 @@ public class XrplBinaryCodec {
   }
 
   // Every signing prefix is a 4-byte (8 hex char) value with no suffix on single-sign payloads, so they can be
-  // stripped uniformly. The counterparty/sponsor role prefixes (fixCleanup3_4_0, PR #8162) are handled alongside the
-  // plain transaction prefix.
+  // stripped uniformly. The counterparty/sponsor role prefixes are handled alongside the plain transaction prefix.
   private boolean isSingleSignPrefix(String encodedTransaction) {
     return encodedTransaction.startsWith(TRX_SIGNATURE_PREFIX) ||
       encodedTransaction.startsWith(COUNTERPARTY_SIGNATURE_PREFIX) ||

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodec.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodec.java
@@ -55,6 +55,14 @@ public class XrplBinaryCodec {
   public static final String PAYMENT_CHANNEL_CLAIM_SIGNATURE_PREFIX = "434C4D00";
   public static final String BATCH_SIGNATURE_PREFIX = "42434800"; // "BCH\0" per XLS-0056
 
+  // Role-specific signing prefixes introduced by rippled's fixCleanup3_4_0 amendment (PR #8162). Each role signs a
+  // distinct prefix so a signature made for one role cannot be replayed in another. These signatures are only valid
+  // on a network where fixCleanup3_4_0 is enabled.
+  public static final String COUNTERPARTY_SIGNATURE_PREFIX = "43505400"; // "CPT\0" - CounterpartySignature single-sign
+  public static final String COUNTERPARTY_MULTI_SIGNATURE_PREFIX = "43504D00"; // "CPM\0" - CounterpartySignature multi
+  public static final String SPONSOR_SIGNATURE_PREFIX = "53504E00"; // "SPN\0" - SponsorSignature single-sign
+  public static final String SPONSOR_MULTI_SIGNATURE_PREFIX = "53504D00"; // "SPM\0" - SponsorSignature multi-sign
+
   public static final String CHANNEL_FIELD_NAME = "Channel";
   public static final String AMOUNT_FIELD_NAME = "Amount";
 
@@ -111,8 +119,56 @@ public class XrplBinaryCodec {
    * @throws JsonProcessingException if JSON is not valid.
    */
   public String encodeForSigning(String json) throws JsonProcessingException {
+    return encodeForSigning(json, TRX_SIGNATURE_PREFIX);
+  }
+
+  /**
+   * Encodes JSON to canonical XRPL binary as a hex string, prepending the supplied single-signing {@code prefix}. Only
+   * the 4-byte prefix distinguishes the role-specific signing payloads; the encoded signing fields are otherwise
+   * identical.
+   *
+   * @param json   String containing JSON to be encoded.
+   * @param prefix The hex-encoded 4-byte signing prefix to prepend (e.g. {@link #TRX_SIGNATURE_PREFIX}).
+   *
+   * @return hex encoded representation
+   *
+   * @throws JsonProcessingException if JSON is not valid.
+   */
+  private String encodeForSigning(String json, String prefix) throws JsonProcessingException {
     JsonNode node = BINARY_CODEC_OBJECT_MAPPER.readTree(json);
-    return TRX_SIGNATURE_PREFIX + encode(removeNonSigningFields(node));
+    return prefix + encode(removeNonSigningFields(node));
+  }
+
+  /**
+   * Encodes JSON to canonical XRPL binary as a hex string for signing a {@code CounterpartySignature} (e.g. the
+   * lender's signature on a {@code LoanSet}). Identical to {@link #encodeForSigning(String)} except that the payload is
+   * bound to the counterparty role via the {@code CPT\0} prefix, so the resulting signature cannot be replayed as any
+   * other role. Requires the {@code fixCleanup3_4_0} amendment (rippled PR #8162).
+   *
+   * @param json String containing JSON to be encoded.
+   *
+   * @return hex encoded representation
+   *
+   * @throws JsonProcessingException if JSON is not valid.
+   */
+  public String encodeForSigningCounterparty(String json) throws JsonProcessingException {
+    return encodeForSigning(json, COUNTERPARTY_SIGNATURE_PREFIX);
+  }
+
+  /**
+   * Encodes JSON to canonical XRPL binary as a hex string for signing a {@code SponsorSignature}. Identical to
+   * {@link #encodeForSigning(String)} except that the payload is bound to the sponsor role via the {@code SPN\0}
+   * prefix, so the resulting signature cannot be replayed as any other role. Requires the {@code fixCleanup3_4_0}
+   * amendment (rippled PR #8162).
+   *
+   * @param json String containing JSON to be encoded.
+   *
+   * @return hex encoded representation
+   *
+   * @throws JsonProcessingException if JSON is not valid.
+   */
+  public String encodeForSigningSponsor(String json) throws JsonProcessingException {
+    return encodeForSigning(json, SPONSOR_SIGNATURE_PREFIX);
   }
 
   /**
@@ -241,14 +297,13 @@ public class XrplBinaryCodec {
   }
 
   /**
-   * Encodes JSON to canonical XRPL binary as a hex string for multi-signing purposes, preserving the existing
-   * {@code SigningPubKey} field. Unlike {@link #encodeForMultiSigning(String, String)}, this method does <b>not</b>
-   * clear the {@code SigningPubKey} field. This is necessary when a co-signer multi-signs a transaction where the
-   * first-party signer's {@code SigningPubKey} must remain intact in the signed data (e.g., counterparty multi-signing
-   * in dual-signed transactions such as {@code LoanSet}).
+   * Encodes JSON to canonical XRPL binary as a hex string for a counterparty multi-signature (e.g. a multi-signing
+   * lender on a {@code LoanSet}). The payload is bound to the counterparty role via the {@code CPM\0} prefix, so the
+   * resulting signature cannot be replayed as any other role. Requires the {@code fixCleanup3_4_0} amendment (rippled
+   * PR #8162).
    *
-   * <p>The resulting bytes use the same multi-signing prefix ({@code SMT\0}) and account ID suffix as
-   * {@link #encodeForMultiSigning(String, String)}.</p>
+   * <p>Like sponsor multi-signing (and unlike {@link #encodeForMultiSigning(String, String)}), this preserves the
+   * first-party signer's {@code SigningPubKey} in the signed data rather than clearing it.</p>
    *
    * @param json         A {@link String} containing JSON to be encoded.
    * @param xrpAccountId A {@link String} containing the XRPL AccountId of the signer.
@@ -257,8 +312,47 @@ public class XrplBinaryCodec {
    *
    * @throws JsonProcessingException if JSON is not valid.
    */
-  public String encodeForMultiSigningWithSigningPubKey(
-    String json, String xrpAccountId
+  public String encodeForMultiSigningCounterparty(String json, String xrpAccountId) throws JsonProcessingException {
+    return encodeForMultiSigningWithSigningPubKey(json, xrpAccountId, COUNTERPARTY_MULTI_SIGNATURE_PREFIX);
+  }
+
+  /**
+   * Encodes JSON to canonical XRPL binary as a hex string for a sponsor multi-signature. The payload is bound to the
+   * sponsor role via the {@code SPM\0} prefix, so the resulting signature cannot be replayed as any other role.
+   * Requires the {@code fixCleanup3_4_0} amendment (rippled PR #8162).
+   *
+   * <p>Like counterparty multi-signing (and unlike {@link #encodeForMultiSigning(String, String)}), this preserves the
+   * first-party signer's {@code SigningPubKey} in the signed data rather than clearing it.</p>
+   *
+   * @param json         A {@link String} containing JSON to be encoded.
+   * @param xrpAccountId A {@link String} containing the XRPL AccountId of the signer.
+   *
+   * @return hex encoded representation
+   *
+   * @throws JsonProcessingException if JSON is not valid.
+   */
+  public String encodeForMultiSigningSponsor(String json, String xrpAccountId) throws JsonProcessingException {
+    return encodeForMultiSigningWithSigningPubKey(json, xrpAccountId, SPONSOR_MULTI_SIGNATURE_PREFIX);
+  }
+
+  /**
+   * Encodes JSON to canonical XRPL binary as a hex string for multi-signing purposes, preserving the existing
+   * {@code SigningPubKey} field and prepending the supplied multi-signing {@code prefix}. Unlike
+   * {@link #encodeForMultiSigning(String, String)}, this does <b>not</b> clear the {@code SigningPubKey} field, which
+   * is necessary when a co-signer (counterparty or sponsor) multi-signs a transaction where the first-party signer's
+   * {@code SigningPubKey} must remain intact in the signed data. Only the 4-byte prefix distinguishes the
+   * role-specific payloads; the encoded signing fields and account ID suffix are otherwise identical.
+   *
+   * @param json         A {@link String} containing JSON to be encoded.
+   * @param xrpAccountId A {@link String} containing the XRPL AccountId of the signer.
+   * @param prefix       The hex-encoded 4-byte multi-signing prefix to prepend.
+   *
+   * @return hex encoded representation
+   *
+   * @throws JsonProcessingException if JSON is not valid.
+   */
+  private String encodeForMultiSigningWithSigningPubKey(
+    String json, String xrpAccountId, String prefix
   ) throws JsonProcessingException {
     JsonNode node = BINARY_CODEC_OBJECT_MAPPER.readTree(json);
     if (!node.isObject()) {
@@ -266,7 +360,7 @@ public class XrplBinaryCodec {
     }
     // NOTE: Unlike encodeForMultiSigning, we do NOT clear SigningPubKey here.
     String suffix = new AccountIdType().fromJson(new TextNode(xrpAccountId)).toHex();
-    return TRX_MULTI_SIGNATURE_PREFIX + encode(removeNonSigningFields(node)) + suffix;
+    return prefix + encode(removeNonSigningFields(node)) + suffix;
   }
 
   /**
@@ -308,9 +402,9 @@ public class XrplBinaryCodec {
    */
   public String decode(String encodedTransaction) {
     final String nonSignPrefixHex;
-    if (encodedTransaction.startsWith(TRX_SIGNATURE_PREFIX)) {
+    if (isSingleSignPrefix(encodedTransaction)) {
       nonSignPrefixHex = encodedTransaction.substring(TRX_SIGNATURE_PREFIX.length());
-    } else if (encodedTransaction.startsWith(TRX_MULTI_SIGNATURE_PREFIX)) {
+    } else if (isMultiSignPrefix(encodedTransaction)) {
       // The suffix is always a Hash160, which is 160 bits/20 bytes, which is 40 HEX chars.
       final int suffixLength = 40;
       nonSignPrefixHex = encodedTransaction.substring(
@@ -322,6 +416,22 @@ public class XrplBinaryCodec {
     return new BinaryParser(nonSignPrefixHex).readType(STObjectType.class)
       .toJson()
       .toString();
+  }
+
+  // Every signing prefix is a 4-byte (8 hex char) value with no suffix on single-sign payloads, so they can be
+  // stripped uniformly. The counterparty/sponsor role prefixes (fixCleanup3_4_0, PR #8162) are handled alongside the
+  // plain transaction prefix.
+  private boolean isSingleSignPrefix(String encodedTransaction) {
+    return encodedTransaction.startsWith(TRX_SIGNATURE_PREFIX) ||
+      encodedTransaction.startsWith(COUNTERPARTY_SIGNATURE_PREFIX) ||
+      encodedTransaction.startsWith(SPONSOR_SIGNATURE_PREFIX);
+  }
+
+  // Multi-sign payloads carry a trailing 20-byte signer account ID suffix regardless of role prefix.
+  private boolean isMultiSignPrefix(String encodedTransaction) {
+    return encodedTransaction.startsWith(TRX_MULTI_SIGNATURE_PREFIX) ||
+      encodedTransaction.startsWith(COUNTERPARTY_MULTI_SIGNATURE_PREFIX) ||
+      encodedTransaction.startsWith(SPONSOR_MULTI_SIGNATURE_PREFIX);
   }
 
   /**

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/AbstractTransactionSigner.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/AbstractTransactionSigner.java
@@ -128,8 +128,8 @@ public abstract class AbstractTransactionSigner<P extends PrivateKeyable> implem
     Objects.requireNonNull(privateKeyable);
     Objects.requireNonNull(transaction);
 
-    // Per fixCleanup3_4_0 (rippled PR #8162), the counterparty signs the CPT-prefixed payload so its signature is
-    // bound to the counterparty role and cannot be replayed as the transaction's own or the sponsor's signature.
+    // The counterparty signs a payload bound to its own role, so its signature cannot be replayed as the
+    // transaction's own or the sponsor's signature.
     final UnsignedByteArray signableBytes = this.signatureUtils.toCounterpartySignableBytes(transaction);
     return this.signatureHelper(privateKeyable, signableBytes);
   }
@@ -151,9 +151,8 @@ public abstract class AbstractTransactionSigner<P extends PrivateKeyable> implem
     Objects.requireNonNull(privateKeyable);
     Objects.requireNonNull(transaction);
 
-    // Per fixCleanup3_4_0 (rippled PR #8162), the sponsor signs the SPN-prefixed payload so its signature is bound to
-    // the sponsor role and cannot be replayed as the transaction's own or the counterparty's signature. Before this
-    // fix all roles shared HashPrefix::txSign, which let a role signature be copied into another role.
+    // The sponsor signs a payload bound to its own role, so its signature cannot be replayed as the transaction's
+    // own or the counterparty's signature.
     final UnsignedByteArray signableBytes = this.signatureUtils.toSponsorSignableBytes(transaction);
     return this.signatureHelper(privateKeyable, signableBytes);
   }

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/AbstractTransactionSigner.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/AbstractTransactionSigner.java
@@ -128,7 +128,10 @@ public abstract class AbstractTransactionSigner<P extends PrivateKeyable> implem
     Objects.requireNonNull(privateKeyable);
     Objects.requireNonNull(transaction);
 
-    return signatureHelper(privateKeyable, transaction);
+    // Per fixCleanup3_4_0 (rippled PR #8162), the counterparty signs the CPT-prefixed payload so its signature is
+    // bound to the counterparty role and cannot be replayed as the transaction's own or the sponsor's signature.
+    final UnsignedByteArray signableBytes = this.signatureUtils.toCounterpartySignableBytes(transaction);
+    return this.signatureHelper(privateKeyable, signableBytes);
   }
 
   @Override
@@ -148,12 +151,11 @@ public abstract class AbstractTransactionSigner<P extends PrivateKeyable> implem
     Objects.requireNonNull(privateKeyable);
     Objects.requireNonNull(transaction);
 
-    // Per the rippled implementation of the Sponsorship amendment, sponsor single-signing uses the same
-    // HashPrefix::txSign (STX, 0x53545800) prefix and serialization as regular single-signing. Domain separation
-    // between the account-owner and sponsor roles is not required at the signing-bytes level because the resulting
-    // signatures are placed in distinct transaction fields (TxnSignature vs SponsorSignature.TxnSignature), and the
-    // account-owner and sponsor use different key pairs. So this can safely reuse the regular signing path.
-    return this.signatureHelper(privateKeyable, transaction);
+    // Per fixCleanup3_4_0 (rippled PR #8162), the sponsor signs the SPN-prefixed payload so its signature is bound to
+    // the sponsor role and cannot be replayed as the transaction's own or the counterparty's signature. Before this
+    // fix all roles shared HashPrefix::txSign, which let a role signature be copied into another role.
+    final UnsignedByteArray signableBytes = this.signatureUtils.toSponsorSignableBytes(transaction);
+    return this.signatureHelper(privateKeyable, signableBytes);
   }
 
   @Override

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtils.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtils.java
@@ -176,8 +176,8 @@ public class SignatureUtils {
    * role via the {@code CPT\0} prefix, so the resulting signature cannot be replayed as any other role.
    *
    * <p>This method will be marked {@link Beta} until the LendingProtocol amendment is enabled on mainnet. The produced
-   * signature is only valid on a network where the {@code fixCleanup3_4_0} amendment (rippled PR #8162) is enabled. Its
-   * API is subject to change.</p>
+   * signature is only valid on a network where the {@code fixCleanup3_4_0} amendment is enabled. Its API is subject to
+   * change.</p>
    *
    * @param transaction A {@link LoanSet} to be counterparty single-signed.
    *
@@ -202,8 +202,8 @@ public class SignatureUtils {
    * cannot be replayed as any other role.
    *
    * <p>This method will be marked {@link Beta} until the LendingProtocol amendment is enabled on mainnet. The produced
-   * signature is only valid on a network where the {@code fixCleanup3_4_0} amendment (rippled PR #8162) is enabled. Its
-   * API is subject to change.</p>
+   * signature is only valid on a network where the {@code fixCleanup3_4_0} amendment is enabled. Its API is subject to
+   * change.</p>
    *
    * @param transaction   A {@link LoanSet} to be counterparty multi-signed.
    * @param signerAddress The {@link Address} of the counterparty signer.
@@ -253,8 +253,8 @@ public class SignatureUtils {
    * the resulting signature cannot be replayed as any other role.
    *
    * <p>This method will be marked {@link Beta} until the featureSponsorship amendment is enabled on mainnet. The
-   * produced signature is only valid on a network where the {@code fixCleanup3_4_0} amendment (rippled PR #8162) is
-   * enabled. Its API is subject to change.</p>
+   * produced signature is only valid on a network where the {@code fixCleanup3_4_0} amendment is enabled. Its API is
+   * subject to change.</p>
    *
    * @param transaction A {@link Transaction} to be sponsor single-signed.
    *
@@ -283,8 +283,8 @@ public class SignatureUtils {
    * where the first-party signer's {@code SigningPubKey} must remain intact in the signed data.</p>
    *
    * <p>This method will be marked {@link Beta} until the featureSponsorship amendment is enabled on mainnet. The
-   * produced signature is only valid on a network where the {@code fixCleanup3_4_0} amendment (rippled PR #8162) is
-   * enabled. Its API is subject to change.</p>
+   * produced signature is only valid on a network where the {@code fixCleanup3_4_0} amendment is enabled. Its API is
+   * subject to change.</p>
    *
    * @param transaction   A {@link Transaction} to be sponsor multi-signed.
    * @param signerAddress The {@link Address} of the sponsor signer.

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtils.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtils.java
@@ -171,11 +171,39 @@ public class SignatureUtils {
   }
 
   /**
-   * Helper method to convert a {@link LoanSet} transaction into bytes that can be multi-signed by a counterparty
-   * signer.
+   * Helper method to convert a {@link LoanSet} transaction into bytes that can be single-signed by a counterparty
+   * signer (e.g. the lender). Unlike {@link #toSignableBytes(Transaction)}, the payload is bound to the counterparty
+   * role via the {@code CPT\0} prefix, so the resulting signature cannot be replayed as any other role.
    *
-   * <p>This method will be marked {@link Beta} until the LendingProtocol amendment is enabled on mainnet. Its API
-   * is subject to change.</p>
+   * <p>This method will be marked {@link Beta} until the LendingProtocol amendment is enabled on mainnet. The produced
+   * signature is only valid on a network where the {@code fixCleanup3_4_0} amendment (rippled PR #8162) is enabled. Its
+   * API is subject to change.</p>
+   *
+   * @param transaction A {@link LoanSet} to be counterparty single-signed.
+   *
+   * @return An {@link UnsignedByteArray}.
+   */
+  @Beta
+  public UnsignedByteArray toCounterpartySignableBytes(final LoanSet transaction) {
+    Objects.requireNonNull(transaction);
+
+    try {
+      final String unsignedJson = objectMapper.writeValueAsString(transaction);
+      final String unsignedBinaryHex = binaryCodec.encodeForSigningCounterparty(unsignedJson);
+      return UnsignedByteArray.fromHex(unsignedBinaryHex);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Helper method to convert a {@link LoanSet} transaction into bytes that can be multi-signed by a counterparty
+   * signer. The payload is bound to the counterparty role via the {@code CPM\0} prefix, so the resulting signature
+   * cannot be replayed as any other role.
+   *
+   * <p>This method will be marked {@link Beta} until the LendingProtocol amendment is enabled on mainnet. The produced
+   * signature is only valid on a network where the {@code fixCleanup3_4_0} amendment (rippled PR #8162) is enabled. Its
+   * API is subject to change.</p>
    *
    * @param transaction   A {@link LoanSet} to be counterparty multi-signed.
    * @param signerAddress The {@link Address} of the counterparty signer.
@@ -189,7 +217,7 @@ public class SignatureUtils {
 
     try {
       final String unsignedJson = objectMapper.writeValueAsString(transaction);
-      final String unsignedBinaryHex = binaryCodec.encodeForMultiSigningWithSigningPubKey(
+      final String unsignedBinaryHex = binaryCodec.encodeForMultiSigningCounterparty(
         unsignedJson, signerAddress.value()
       );
       return UnsignedByteArray.fromHex(unsignedBinaryHex);
@@ -220,14 +248,43 @@ public class SignatureUtils {
   }
 
   /**
-   * Helper method to convert a {@link Transaction} into bytes that can be multi-signed by a sponsor.
+   * Helper method to convert a {@link Transaction} into bytes that can be single-signed by a sponsor. Unlike
+   * {@link #toSignableBytes(Transaction)}, the payload is bound to the sponsor role via the {@code SPN\0} prefix, so
+   * the resulting signature cannot be replayed as any other role.
+   *
+   * <p>This method will be marked {@link Beta} until the featureSponsorship amendment is enabled on mainnet. The
+   * produced signature is only valid on a network where the {@code fixCleanup3_4_0} amendment (rippled PR #8162) is
+   * enabled. Its API is subject to change.</p>
+   *
+   * @param transaction A {@link Transaction} to be sponsor single-signed.
+   *
+   * @return An {@link UnsignedByteArray}.
+   */
+  @Beta
+  public UnsignedByteArray toSponsorSignableBytes(final Transaction transaction) {
+    Objects.requireNonNull(transaction);
+
+    try {
+      final String unsignedJson = objectMapper.writeValueAsString(transaction);
+      final String unsignedBinaryHex = binaryCodec.encodeForSigningSponsor(unsignedJson);
+      return UnsignedByteArray.fromHex(unsignedBinaryHex);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Helper method to convert a {@link Transaction} into bytes that can be multi-signed by a sponsor. The payload is
+   * bound to the sponsor role via the {@code SPM\0} prefix, so the resulting signature cannot be replayed as any other
+   * role.
    *
    * <p>Unlike {@link #toMultiSignableBytes(Transaction, Address)}, this method preserves the existing
    * {@code SigningPubKey} field in the encoded bytes. This is necessary when a sponsor multi-signs a transaction
    * where the first-party signer's {@code SigningPubKey} must remain intact in the signed data.</p>
    *
-   * <p>This method will be marked {@link Beta} until the featureSponsorship amendment is enabled on mainnet.
-   * Its API is subject to change.</p>
+   * <p>This method will be marked {@link Beta} until the featureSponsorship amendment is enabled on mainnet. The
+   * produced signature is only valid on a network where the {@code fixCleanup3_4_0} amendment (rippled PR #8162) is
+   * enabled. Its API is subject to change.</p>
    *
    * @param transaction   A {@link Transaction} to be sponsor multi-signed.
    * @param signerAddress The {@link Address} of the sponsor signer.
@@ -241,7 +298,7 @@ public class SignatureUtils {
 
     try {
       final String unsignedJson = objectMapper.writeValueAsString(transaction);
-      final String unsignedBinaryHex = binaryCodec.encodeForMultiSigningWithSigningPubKey(
+      final String unsignedBinaryHex = binaryCodec.encodeForMultiSigningSponsor(
         unsignedJson, signerAddress.value()
       );
       return UnsignedByteArray.fromHex(unsignedBinaryHex);

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/TransactionSigner.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/TransactionSigner.java
@@ -145,11 +145,11 @@ public interface TransactionSigner<P extends PrivateKeyable> {
   Signature multiSignInner(P privateKeyable, Batch batchTransaction, Address batchSignerAddress);
 
   /**
-   * Obtain a counterparty single-signature for the supplied {@link LoanSet} transaction. Per {@code fixCleanup3_4_0}
-   * (rippled PR #8162), the counterparty signs a payload bound to the counterparty role via the {@code CPT\0} prefix,
-   * so its signature cannot be replayed as the transaction's own or the sponsor's signature. This method returns only
-   * the raw {@link Signature} rather than a {@link SingleSignedTransaction} wrapper, since the counterparty's signature
-   * is placed into the {@link org.xrpl.xrpl4j.model.transactions.CounterpartySignature} field, not the transaction's
+   * Obtain a counterparty single-signature for the supplied {@link LoanSet} transaction. The counterparty signs a
+   * payload bound to the counterparty role via the {@code CPT\0} prefix, so its signature cannot be replayed as the
+   * transaction's own or the sponsor's signature. This method returns only the raw {@link Signature} rather than a
+   * {@link SingleSignedTransaction} wrapper, since the counterparty's signature is placed into the
+   * {@link org.xrpl.xrpl4j.model.transactions.CounterpartySignature} field, not the transaction's
    * {@code TxnSignature}.
    *
    * <p>This method will be marked {@link Beta} until the LendingProtocol amendment is enabled on mainnet. The produced
@@ -164,9 +164,9 @@ public interface TransactionSigner<P extends PrivateKeyable> {
   Signature counterpartySign(P privateKeyable, LoanSet transaction);
 
   /**
-   * Obtain a counterparty multi-signature for the supplied {@link LoanSet} transaction. Per {@code fixCleanup3_4_0}
-   * (rippled PR #8162), the resulting bytes use the counterparty multi-signing prefix ({@code CPM\0}) so the signature
-   * cannot be replayed as any other role, followed by the counterparty signer's account ID suffix. Unlike
+   * Obtain a counterparty multi-signature for the supplied {@link LoanSet} transaction. The resulting bytes use the
+   * counterparty multi-signing prefix ({@code CPM\0}) so the signature cannot be replayed as any other role, followed
+   * by the counterparty signer's account ID suffix. Unlike
    * {@link #multiSign(PrivateKeyable, Transaction)}, this method does <b>not</b> clear the {@code SigningPubKey} field,
    * preserving the first-party signer's public key in the signed data.
    *
@@ -182,9 +182,9 @@ public interface TransactionSigner<P extends PrivateKeyable> {
   Signature counterpartyMultiSign(P privateKeyable, LoanSet transaction);
 
   /**
-   * Obtain a sponsor single-signature for the supplied transaction. Per {@code fixCleanup3_4_0} (rippled PR #8162),
-   * the sponsor signs a payload bound to the sponsor role via the {@code SPN\0} prefix, so its signature cannot be
-   * replayed as the transaction's own or the counterparty's signature. The sponsor's signature is placed into the
+   * Obtain a sponsor single-signature for the supplied transaction. The sponsor signs a payload bound to the sponsor
+   * role via the {@code SPN\0} prefix, so its signature cannot be replayed as the transaction's own or the
+   * counterparty's signature. The sponsor's signature is placed into the
    * {@link Transaction#sponsorSignature()} field rather than the transaction's {@code TxnSignature}.
    *
    * <p>This method returns only the raw {@link Signature} rather than a {@link SingleSignedTransaction}
@@ -204,9 +204,9 @@ public interface TransactionSigner<P extends PrivateKeyable> {
   <T extends Transaction> Signature sponsorSign(P privateKeyable, T transaction);
 
   /**
-   * Obtain a sponsor multi-signature for the supplied transaction. Per {@code fixCleanup3_4_0} (rippled PR #8162), the
-   * resulting bytes use the sponsor multi-signing prefix ({@code SPM\0}) so the signature cannot be replayed as any
-   * other role, followed by the sponsor signer's account ID suffix. Unlike
+   * Obtain a sponsor multi-signature for the supplied transaction. The resulting bytes use the sponsor multi-signing
+   * prefix ({@code SPM\0}) so the signature cannot be replayed as any other role, followed by the sponsor signer's
+   * account ID suffix. Unlike
    * {@link #multiSign(PrivateKeyable, Transaction)}, this method does <b>not</b> clear the {@code SigningPubKey}
    * field, preserving the first-party signer's public key in the signed data.
    *

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/TransactionSigner.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/crypto/signing/TransactionSigner.java
@@ -145,14 +145,15 @@ public interface TransactionSigner<P extends PrivateKeyable> {
   Signature multiSignInner(P privateKeyable, Batch batchTransaction, Address batchSignerAddress);
 
   /**
-   * Obtain a counterparty single-signature for the supplied {@link LoanSet} transaction. The counterparty signs the
-   * same bytes as the first-party signer, but this method returns only the raw {@link Signature} rather than a
-   * {@link SingleSignedTransaction} wrapper, since the counterparty's signature is placed into the
-   * {@link org.xrpl.xrpl4j.model.transactions.CounterpartySignature} field, not the transaction's
+   * Obtain a counterparty single-signature for the supplied {@link LoanSet} transaction. Per {@code fixCleanup3_4_0}
+   * (rippled PR #8162), the counterparty signs a payload bound to the counterparty role via the {@code CPT\0} prefix,
+   * so its signature cannot be replayed as the transaction's own or the sponsor's signature. This method returns only
+   * the raw {@link Signature} rather than a {@link SingleSignedTransaction} wrapper, since the counterparty's signature
+   * is placed into the {@link org.xrpl.xrpl4j.model.transactions.CounterpartySignature} field, not the transaction's
    * {@code TxnSignature}.
    *
-   * <p>This method will be marked {@link Beta} until the LendingProtocol amendment is enabled on mainnet. Its API
-   * is subject to change.</p>
+   * <p>This method will be marked {@link Beta} until the LendingProtocol amendment is enabled on mainnet. The produced
+   * signature is only valid on a network where {@code fixCleanup3_4_0} is enabled. Its API is subject to change.</p>
    *
    * @param privateKeyable The {@link P} used to sign {@code transaction}.
    * @param transaction    The {@link LoanSet} transaction to sign by counterparty.
@@ -163,13 +164,14 @@ public interface TransactionSigner<P extends PrivateKeyable> {
   Signature counterpartySign(P privateKeyable, LoanSet transaction);
 
   /**
-   * Obtain a counterparty multi-signature for the supplied {@link LoanSet} transaction. Unlike
+   * Obtain a counterparty multi-signature for the supplied {@link LoanSet} transaction. Per {@code fixCleanup3_4_0}
+   * (rippled PR #8162), the resulting bytes use the counterparty multi-signing prefix ({@code CPM\0}) so the signature
+   * cannot be replayed as any other role, followed by the counterparty signer's account ID suffix. Unlike
    * {@link #multiSign(PrivateKeyable, Transaction)}, this method does <b>not</b> clear the {@code SigningPubKey} field,
-   * preserving the first-party signer's public key in the signed data. The resulting bytes use the same multi-signing
-   * prefix ({@code SMT\0}) and the counterparty signer's account ID suffix.
+   * preserving the first-party signer's public key in the signed data.
    *
-   * <p>This method will be marked {@link Beta} until the LendingProtocol amendment is enabled on mainnet. Its API
-   * is subject to change.</p>
+   * <p>This method will be marked {@link Beta} until the LendingProtocol amendment is enabled on mainnet. The produced
+   * signature is only valid on a network where {@code fixCleanup3_4_0} is enabled. Its API is subject to change.</p>
    *
    * @param privateKeyable The {@link P} used to sign {@code transaction}.
    * @param transaction    The {@link LoanSet} transaction to counterparty multi-sign.
@@ -180,17 +182,17 @@ public interface TransactionSigner<P extends PrivateKeyable> {
   Signature counterpartyMultiSign(P privateKeyable, LoanSet transaction);
 
   /**
-   * Obtain a sponsor single-signature for the supplied transaction. Per rippled's Sponsorship amendment
-   * implementation, the sponsor signs the same serialized bytes (using the {@code STX} / 0x53545800 prefix) as the
-   * account-owner. Domain separation is achieved structurally: the sponsor's signature is placed into the
-   * {@link Transaction#sponsorSignature()} field rather than the transaction's {@code TxnSignature}, and the
-   * account-owner and sponsor use different key pairs.
+   * Obtain a sponsor single-signature for the supplied transaction. Per {@code fixCleanup3_4_0} (rippled PR #8162),
+   * the sponsor signs a payload bound to the sponsor role via the {@code SPN\0} prefix, so its signature cannot be
+   * replayed as the transaction's own or the counterparty's signature. The sponsor's signature is placed into the
+   * {@link Transaction#sponsorSignature()} field rather than the transaction's {@code TxnSignature}.
    *
    * <p>This method returns only the raw {@link Signature} rather than a {@link SingleSignedTransaction}
    * wrapper.</p>
    *
-   * <p>This method will be marked {@link Beta} until the featureSponsorship amendment is enabled on mainnet.
-   * Its API is subject to change.</p>
+   * <p>This method will be marked {@link Beta} until the featureSponsorship amendment is enabled on mainnet. The
+   * produced signature is only valid on a network where {@code fixCleanup3_4_0} is enabled. Its API is subject to
+   * change.</p>
    *
    * @param privateKeyable The {@link P} used to sign {@code transaction}.
    * @param transaction    The {@link Transaction} to sign as the sponsor.
@@ -202,17 +204,19 @@ public interface TransactionSigner<P extends PrivateKeyable> {
   <T extends Transaction> Signature sponsorSign(P privateKeyable, T transaction);
 
   /**
-   * Obtain a sponsor multi-signature for the supplied transaction. Unlike
+   * Obtain a sponsor multi-signature for the supplied transaction. Per {@code fixCleanup3_4_0} (rippled PR #8162), the
+   * resulting bytes use the sponsor multi-signing prefix ({@code SPM\0}) so the signature cannot be replayed as any
+   * other role, followed by the sponsor signer's account ID suffix. Unlike
    * {@link #multiSign(PrivateKeyable, Transaction)}, this method does <b>not</b> clear the {@code SigningPubKey}
-   * field, preserving the first-party signer's public key in the signed data. The resulting bytes use the same
-   * multi-signing prefix ({@code SMT\0}) and the sponsor signer's account ID suffix.
+   * field, preserving the first-party signer's public key in the signed data.
    *
    * <p>This is necessary for sponsored transactions where the sponsor must co-sign without overwriting
    * the transaction sender's signature. The sponsor's multi-signature is placed in the
    * {@link Transaction#sponsorSignature()} {@code Signers} array.</p>
    *
-   * <p>This method will be marked {@link Beta} until the featureSponsorship amendment is enabled on mainnet.
-   * Its API is subject to change.</p>
+   * <p>This method will be marked {@link Beta} until the featureSponsorship amendment is enabled on mainnet. The
+   * produced signature is only valid on a network where {@code fixCleanup3_4_0} is enabled. Its API is subject to
+   * change.</p>
    *
    * @param privateKeyable The {@link P} used to sign {@code transaction}.
    * @param transaction    The {@link Transaction} to sponsor multi-sign.

--- a/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/LoanSet.java
+++ b/xrpl4j-core/src/main/java/org/xrpl/xrpl4j/model/transactions/LoanSet.java
@@ -63,13 +63,16 @@ public interface LoanSet extends Transaction {
   /**
    * The signature of the counterparty over the transaction.
    *
-   * <p>This field is {@link Optional} because both parties must sign the same serialized transaction bytes,
-   * and {@code CounterpartySignature} is excluded from those bytes by design. The dual-signing flow is:
+   * <p>This field is {@link Optional} because the dual-signing flow needs an intermediate transaction that does not
+   * carry it yet, and because {@code CounterpartySignature} is not itself a signing field — attaching it does not
+   * change what either party signs. The flow is:
    * <ol>
    *   <li>The broker constructs a {@link LoanSet} with this field absent and signs it — the absent field
-   *       produces the canonical bytes that both parties will sign.</li>
-   *   <li>The counterparty signs the same bytes (over the same absent-field transaction) and returns their
-   *       signature.</li>
+   *       produces the canonical transaction content that both parties sign over.</li>
+   *   <li>The counterparty signs that same transaction content and returns their signature. Note that the two
+   *       signatures do not cover identical bytes: each is prefixed according to the role that made it — and, within
+   *       a role, according to whether it is a single- or multi-signature — so neither can be replayed in the other's
+   *       role. See the counterparty signing methods on {@code TransactionSigner} for the exact prefixes.</li>
    *   <li>The broker/counterparty assembles the final transaction by adding the counterparty signature here and
    *      submits it.</li>
    * </ol>

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodecTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodecTest.java
@@ -749,80 +749,121 @@ class XrplBinaryCodecTest {
   }
 
   // /////////////////
-  // encodeForMultiSigningWithSigningPubKey
+  // Role-specific signing prefixes (fixCleanup3_4_0, rippled PR #8162)
   // /////////////////
 
   @Test
-  void encodeForMultiSigningWithSigningPubKey() throws JsonProcessingException {
+  void encodeForSigningCounterpartyUsesCptPrefix() throws JsonProcessingException {
+    String json = objectMapper.writeValueAsString(createLoanSet());
+
+    String counterparty = encoder.encodeForSigningCounterparty(json);
+    String base = encoder.encodeForSigning(json);
+
+    // Bound to the counterparty role via the CPT ("CPT\0") prefix.
+    assertThat(counterparty).startsWith("43505400");
+    // Security invariant: only the 4-byte (8 hex char) prefix differs from a plain single-sign payload.
+    assertThat(counterparty.substring(8)).isEqualTo(base.substring(8));
+    assertThat(counterparty).doesNotStartWith(XrplBinaryCodec.TRX_SIGNATURE_PREFIX);
+  }
+
+  @Test
+  void encodeForSigningSponsorUsesSpnPrefix() throws JsonProcessingException {
+    String json = objectMapper.writeValueAsString(createLoanSet());
+
+    String sponsor = encoder.encodeForSigningSponsor(json);
+    String base = encoder.encodeForSigning(json);
+
+    // Bound to the sponsor role via the SPN ("SPN\0") prefix.
+    assertThat(sponsor).startsWith("53504E00");
+    // Security invariant: only the 4-byte (8 hex char) prefix differs from a plain single-sign payload.
+    assertThat(sponsor.substring(8)).isEqualTo(base.substring(8));
+    assertThat(sponsor).doesNotStartWith(XrplBinaryCodec.TRX_SIGNATURE_PREFIX);
+  }
+
+  @Test
+  void singleSignCounterpartyAndSponsorDifferOnlyByPrefix() throws JsonProcessingException {
+    String json = objectMapper.writeValueAsString(createLoanSet());
+
+    String counterparty = encoder.encodeForSigningCounterparty(json);
+    String sponsor = encoder.encodeForSigningSponsor(json);
+
+    // A signature made for one role cannot be replayed as another, yet the signed payloads differ only in the prefix.
+    assertThat(counterparty).isNotEqualTo(sponsor);
+    assertThat(counterparty.substring(8)).isEqualTo(sponsor.substring(8));
+  }
+
+  @Test
+  void encodeForMultiSigningCounterpartyUsesCpmPrefix() throws JsonProcessingException {
     String signerAccountId = "rJZdUusLDtY9NEsGea7ijqhVrXv98rYBYN";
     LoanSet loanSet = createLoanSet();
     String json = objectMapper.writeValueAsString(loanSet);
 
-    String withPubKeyResult = encoder.encodeForMultiSigningWithSigningPubKey(json, signerAccountId);
-    String multiSignResult = encoder.encodeForMultiSigning(json, signerAccountId);
+    String counterparty = encoder.encodeForMultiSigningCounterparty(json, signerAccountId);
+    String clearedMultiSign = encoder.encodeForMultiSigning(json, signerAccountId);
 
-    // Both should start with SMT prefix (4 bytes)
-    assertThat(withPubKeyResult).startsWith("534D5400");
-    assertThat(multiSignResult).startsWith("534D5400");
-
-    // Both should end with the same 20-byte account ID suffix
-    assertThat(withPubKeyResult.substring(withPubKeyResult.length() - 40))
-      .isEqualTo(multiSignResult.substring(multiSignResult.length() - 40));
-
-    // But they should differ because withPubKey preserves SigningPubKey while multiSign clears it
-    assertThat(withPubKeyResult).isNotEqualTo(multiSignResult);
-
-    // withPubKey result should be longer because it includes the non-empty SigningPubKey
-    assertThat(withPubKeyResult.length()).isGreaterThan(multiSignResult.length());
+    // Bound to the counterparty role via the CPM ("CPM\0") prefix.
+    assertThat(counterparty).startsWith("43504D00");
+    // Same account ID suffix as a plain multi-sign.
+    assertThat(counterparty.substring(counterparty.length() - 40))
+      .isEqualTo(clearedMultiSign.substring(clearedMultiSign.length() - 40));
+    // Preserves the first-party SigningPubKey, unlike encodeForMultiSigning which clears it.
+    assertThat(encoder.decode(counterparty)).contains(loanSet.signingPublicKey().base16Value());
   }
 
   @Test
-  void encodeForMultiSigningWithSigningPubKeyPreservesSigningPubKey() throws JsonProcessingException {
+  void encodeForMultiSigningSponsorUsesSpmPrefix() throws JsonProcessingException {
     String signerAccountId = "rJZdUusLDtY9NEsGea7ijqhVrXv98rYBYN";
     LoanSet loanSet = createLoanSet();
-    String signingPubKey = loanSet.signingPublicKey().base16Value();
     String json = objectMapper.writeValueAsString(loanSet);
 
-    String result = encoder.encodeForMultiSigningWithSigningPubKey(json, signerAccountId);
+    String sponsor = encoder.encodeForMultiSigningSponsor(json, signerAccountId);
+    String clearedMultiSign = encoder.encodeForMultiSigning(json, signerAccountId);
 
-    // Decode the result and verify SigningPubKey is present
-    String decoded = encoder.decode(result);
-    assertThat(decoded).contains(signingPubKey);
+    // Bound to the sponsor role via the SPM ("SPM\0") prefix.
+    assertThat(sponsor).startsWith("53504D00");
+    // Same account ID suffix as a plain multi-sign.
+    assertThat(sponsor.substring(sponsor.length() - 40))
+      .isEqualTo(clearedMultiSign.substring(clearedMultiSign.length() - 40));
+    // Preserves the first-party SigningPubKey, unlike encodeForMultiSigning which clears it.
+    assertThat(encoder.decode(sponsor)).contains(loanSet.signingPublicKey().base16Value());
   }
 
   @Test
-  void encodeForMultiSigningWithSigningPubKeyWithNonObjectJsonThrowsException() {
+  void multiSignCounterpartyAndSponsorDifferOnlyByPrefix() throws JsonProcessingException {
+    String signerAccountId = "rJZdUusLDtY9NEsGea7ijqhVrXv98rYBYN";
+    String json = objectMapper.writeValueAsString(createLoanSet());
+
+    String counterparty = encoder.encodeForMultiSigningCounterparty(json, signerAccountId);
+    String sponsor = encoder.encodeForMultiSigningSponsor(json, signerAccountId);
+
+    // A signature made for one role cannot be replayed as another, yet the signed payloads differ only in the prefix.
+    assertThat(counterparty).isNotEqualTo(sponsor);
+    assertThat(counterparty.substring(8)).isEqualTo(sponsor.substring(8));
+  }
+
+  @Test
+  void encodeForMultiSigningRolesWithNonObjectJsonThrowsException() {
     String signerAccountId = "rJZdUusLDtY9NEsGea7ijqhVrXv98rYBYN";
 
-    // Test with JSON array
-    String jsonArray = "[\"value1\", \"value2\"]";
-    Assertions.assertThatThrownBy(() -> encoder.encodeForMultiSigningWithSigningPubKey(jsonArray, signerAccountId))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("JSON object required for signing");
-
-    // Test with JSON primitive (string)
-    String jsonString = "\"just a string\"";
-    Assertions.assertThatThrownBy(() -> encoder.encodeForMultiSigningWithSigningPubKey(jsonString, signerAccountId))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("JSON object required for signing");
-
-    // Test with JSON primitive (number)
-    String jsonNumber = "12345";
-    Assertions.assertThatThrownBy(() -> encoder.encodeForMultiSigningWithSigningPubKey(jsonNumber, signerAccountId))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("JSON object required for signing");
+    for (String badJson : new String[] {"[\"value1\", \"value2\"]", "\"just a string\"", "12345"}) {
+      Assertions.assertThatThrownBy(() -> encoder.encodeForMultiSigningCounterparty(badJson, signerAccountId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("JSON object required for signing");
+      Assertions.assertThatThrownBy(() -> encoder.encodeForMultiSigningSponsor(badJson, signerAccountId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("JSON object required for signing");
+    }
   }
 
   @Test
-  void encodeForMultiSigningWithSigningPubKeyWithDifferentSigners() throws JsonProcessingException {
-    LoanSet loanSet = createLoanSet();
-    String json = objectMapper.writeValueAsString(loanSet);
+  void encodeForMultiSigningRolesWithDifferentSigners() throws JsonProcessingException {
+    String json = objectMapper.writeValueAsString(createLoanSet());
 
     String signer1 = "rJZdUusLDtY9NEsGea7ijqhVrXv98rYBYN";
     String signer2 = "rDgZZ3wyprx4ZqrGQUkquE9Fs2Xs8XBcdw";
 
-    String result1 = encoder.encodeForMultiSigningWithSigningPubKey(json, signer1);
-    String result2 = encoder.encodeForMultiSigningWithSigningPubKey(json, signer2);
+    String result1 = encoder.encodeForMultiSigningCounterparty(json, signer1);
+    String result2 = encoder.encodeForMultiSigningCounterparty(json, signer2);
 
     // The body should be the same (everything except the 20-byte account ID suffix)
     assertThat(result1.substring(0, result1.length() - 40))

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodecTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/codec/binary/XrplBinaryCodecTest.java
@@ -749,7 +749,7 @@ class XrplBinaryCodecTest {
   }
 
   // /////////////////
-  // Role-specific signing prefixes (fixCleanup3_4_0, rippled PR #8162)
+  // Role-specific signing prefixes (fixCleanup3_4_0)
   // /////////////////
 
   @Test

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/AbstractSignatureServiceTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/AbstractSignatureServiceTest.java
@@ -96,6 +96,8 @@ public class AbstractSignatureServiceTest {
     when(signatureUtilsMock.toSignableInnerBytes(any(), any())).thenReturn(UnsignedByteArray.empty());
     when(signatureUtilsMock.toMultiSignableInnerBytes(any(), any(), any())).thenReturn(UnsignedByteArray.empty());
     when(signatureUtilsMock.toCounterpartyMultiSignableBytes(any(), any())).thenReturn(UnsignedByteArray.empty());
+    when(signatureUtilsMock.toCounterpartySignableBytes(any())).thenReturn(UnsignedByteArray.empty());
+    when(signatureUtilsMock.toSponsorSignableBytes(Mockito.<Transaction>any())).thenReturn(UnsignedByteArray.empty());
 
     // Mock signatures need to return valid values for serialization
     UnsignedByteArray ed25519SigBytes = UnsignedByteArray.of(new byte[64]);
@@ -584,7 +586,7 @@ public class AbstractSignatureServiceTest {
     Signature actualSignature = signatureService.counterpartySign(TestConstants.getEdPrivateKey(), loanSetMock);
     assertThat(actualSignature).isEqualTo(ed25519SignatureMock);
 
-    verify(signatureUtilsMock).toSignableBytes(loanSetMock);
+    verify(signatureUtilsMock).toCounterpartySignableBytes(loanSetMock);
     verifyNoMoreInteractions(signatureUtilsMock);
   }
 
@@ -593,7 +595,7 @@ public class AbstractSignatureServiceTest {
     Signature actualSignature = signatureService.counterpartySign(TestConstants.getEcPrivateKey(), loanSetMock);
     assertThat(actualSignature).isEqualTo(secp256k1SignatureMock);
 
-    verify(signatureUtilsMock).toSignableBytes(loanSetMock);
+    verify(signatureUtilsMock).toCounterpartySignableBytes(loanSetMock);
     verifyNoMoreInteractions(signatureUtilsMock);
   }
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/AbstractTransactionSignerTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/AbstractTransactionSignerTest.java
@@ -105,6 +105,8 @@ public class AbstractTransactionSignerTest {
     when(signatureUtilsMock.toSignableInnerBytes(any(), any())).thenReturn(UnsignedByteArray.empty());
     when(signatureUtilsMock.toMultiSignableInnerBytes(any(), any(), any())).thenReturn(UnsignedByteArray.empty());
     when(signatureUtilsMock.toCounterpartyMultiSignableBytes(any(), any())).thenReturn(UnsignedByteArray.empty());
+    when(signatureUtilsMock.toCounterpartySignableBytes(any())).thenReturn(UnsignedByteArray.empty());
+    when(signatureUtilsMock.toSponsorSignableBytes(Mockito.<Transaction>any())).thenReturn(UnsignedByteArray.empty());
 
     when(signerMock.signingPublicKey()).thenReturn(publicKeyMock);
     when(signerMock.transactionSignature()).thenReturn(fauxEd25519Signature);
@@ -463,7 +465,7 @@ public class AbstractTransactionSignerTest {
     Signature signature = transactionSigner.counterpartySign(privateKeyableMock, loanSetMock);
     assertThat(signature).isEqualTo(fauxEd25519Signature);
 
-    verify(signatureUtilsMock).toSignableBytes(loanSetMock);
+    verify(signatureUtilsMock).toCounterpartySignableBytes(loanSetMock);
     verifyNoMoreInteractions(signatureUtilsMock);
   }
 
@@ -474,7 +476,7 @@ public class AbstractTransactionSignerTest {
     Signature signature = transactionSigner.counterpartySign(privateKeyableMock, loanSetMock);
     assertThat(signature).isEqualTo(fauxSecp256k1Signature);
 
-    verify(signatureUtilsMock).toSignableBytes(loanSetMock);
+    verify(signatureUtilsMock).toCounterpartySignableBytes(loanSetMock);
     verifyNoMoreInteractions(signatureUtilsMock);
   }
 
@@ -545,7 +547,7 @@ public class AbstractTransactionSignerTest {
     Signature signature = transactionSigner.sponsorSign(privateKeyableMock, payment);
     assertThat(signature).isEqualTo(fauxEd25519Signature);
 
-    verify(signatureUtilsMock).toSignableBytes(payment);
+    verify(signatureUtilsMock).toSponsorSignableBytes(payment);
     verifyNoMoreInteractions(signatureUtilsMock);
   }
 
@@ -564,7 +566,7 @@ public class AbstractTransactionSignerTest {
     Signature signature = transactionSigner.sponsorSign(privateKeyableMock, payment);
     assertThat(signature).isEqualTo(fauxSecp256k1Signature);
 
-    verify(signatureUtilsMock).toSignableBytes(payment);
+    verify(signatureUtilsMock).toSponsorSignableBytes(payment);
     verifyNoMoreInteractions(signatureUtilsMock);
   }
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtilsTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/SignatureUtilsTest.java
@@ -572,6 +572,70 @@ public class SignatureUtilsTest {
   }
 
   // ////////////////
+  // toCounterpartySignableBytes (LoanSet)
+  // ////////////////
+
+  @Test
+  void toCounterpartySignableBytesWithNullTransaction() {
+    assertThrows(NullPointerException.class, () -> signatureUtils.toCounterpartySignableBytes(null));
+  }
+
+  @Test
+  void toCounterpartySignableBytes() throws JsonProcessingException {
+    LoanSet loanSet = createLoanSet();
+
+    when(xrplBinaryCodecMock.encodeForSigningCounterparty(anyString())).thenReturn("CAFE1234");
+
+    UnsignedByteArray actual = signatureUtils.toCounterpartySignableBytes(loanSet);
+    assertThat(actual.hexValue()).isEqualTo("CAFE1234");
+
+    verify(objectMapperMock).writeValueAsString(loanSet);
+    verifyNoMoreInteractions(objectMapperMock);
+    verify(xrplBinaryCodecMock).encodeForSigningCounterparty(anyString());
+    verifyNoMoreInteractions(xrplBinaryCodecMock);
+  }
+
+  @Test
+  void toCounterpartySignableBytesWithJsonException() throws JsonProcessingException {
+    LoanSet loanSet = createLoanSet();
+    doThrow(new JsonParseException(mock(JsonParser.class), "", mock(JsonLocation.class)))
+      .when(objectMapperMock).writeValueAsString(loanSet);
+    assertThrows(RuntimeException.class, () -> signatureUtils.toCounterpartySignableBytes(loanSet));
+  }
+
+  // ////////////////
+  // toSponsorSignableBytes (Transaction)
+  // ////////////////
+
+  @Test
+  void toSponsorSignableBytesWithNullTransaction() {
+    assertThrows(NullPointerException.class, () -> signatureUtils.toSponsorSignableBytes(null));
+  }
+
+  @Test
+  void toSponsorSignableBytes() throws JsonProcessingException {
+    Payment payment = createPayment1();
+
+    when(xrplBinaryCodecMock.encodeForSigningSponsor(anyString())).thenReturn("CAFE1234");
+
+    UnsignedByteArray actual = signatureUtils.toSponsorSignableBytes(payment);
+    assertThat(actual.hexValue()).isEqualTo("CAFE1234");
+
+    verify(objectMapperMock).writeValueAsString(payment);
+    verifyNoMoreInteractions(objectMapperMock);
+    verify(xrplBinaryCodecMock).encodeForSigningSponsor(anyString());
+    verifyNoMoreInteractions(xrplBinaryCodecMock);
+  }
+
+  @Test
+  void toSponsorSignableBytesWithJsonException() throws JsonProcessingException {
+    Payment payment = createPayment1();
+    doThrow(new JsonParseException(mock(JsonParser.class), "", mock(JsonLocation.class)))
+      .when(objectMapperMock).writeValueAsString(payment);
+    assertThrows(RuntimeException.class, () -> signatureUtils.toSponsorSignableBytes(payment));
+  }
+
+  // ////////////////
   // toCounterpartyMultiSignableBytes (LoanSet)
   // ////////////////
 
@@ -591,7 +655,7 @@ public class SignatureUtilsTest {
   void toCounterpartyMultiSignableBytes() throws JsonProcessingException {
     LoanSet loanSet = createLoanSet();
 
-    when(xrplBinaryCodecMock.encodeForMultiSigningWithSigningPubKey(anyString(), anyString())).thenReturn("CAFE1234");
+    when(xrplBinaryCodecMock.encodeForMultiSigningCounterparty(anyString(), anyString())).thenReturn("CAFE1234");
 
     UnsignedByteArray actual = signatureUtils.toCounterpartyMultiSignableBytes(
       loanSet, sourcePublicKey.deriveAddress()
@@ -600,7 +664,7 @@ public class SignatureUtilsTest {
 
     verify(objectMapperMock).writeValueAsString(loanSet);
     verifyNoMoreInteractions(objectMapperMock);
-    verify(xrplBinaryCodecMock).encodeForMultiSigningWithSigningPubKey(anyString(), anyString());
+    verify(xrplBinaryCodecMock).encodeForMultiSigningCounterparty(anyString(), anyString());
     verifyNoMoreInteractions(xrplBinaryCodecMock);
   }
 
@@ -649,7 +713,7 @@ public class SignatureUtilsTest {
   void toSponsorMultiSignableBytes() throws JsonProcessingException {
     Payment payment = createPayment1();
 
-    when(xrplBinaryCodecMock.encodeForMultiSigningWithSigningPubKey(anyString(), anyString())).thenReturn("CAFE1234");
+    when(xrplBinaryCodecMock.encodeForMultiSigningSponsor(anyString(), anyString())).thenReturn("CAFE1234");
 
     UnsignedByteArray actual = signatureUtils.toSponsorMultiSignableBytes(
       payment, sourcePublicKey.deriveAddress()
@@ -658,7 +722,7 @@ public class SignatureUtilsTest {
 
     verify(objectMapperMock).writeValueAsString(payment);
     verifyNoMoreInteractions(objectMapperMock);
-    verify(xrplBinaryCodecMock).encodeForMultiSigningWithSigningPubKey(anyString(), anyString());
+    verify(xrplBinaryCodecMock).encodeForMultiSigningSponsor(anyString(), anyString());
     verifyNoMoreInteractions(xrplBinaryCodecMock);
   }
 

--- a/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/bc/BcDerivedKeySignatureServiceTest.java
+++ b/xrpl4j-core/src/test/java/org/xrpl/xrpl4j/crypto/signing/bc/BcDerivedKeySignatureServiceTest.java
@@ -1097,8 +1097,8 @@ class BcDerivedKeySignatureServiceTest {
       Signature signature = this.derivedKeySignatureService.sponsorSign(privateKeyReference, paymentTransaction);
       assertThat(signature).isNotNull();
       assertThat(signature.base16Value()).isEqualTo(
-        "F0968CC4FC05040788E3F5E28D8BFE21F34B059143D769B54F8668CBD805BDE5C7AAF748EC60DD877B193FD16CB32A91D9539" +
-          "C4C04851099C4B45E5FD1566401"
+        "A8F0B2A3B9D82E59FA542D2D3EED3A4CB93A79A0CAE75BB78610000C22F0C0EDA10540FAC463F68B6B41E78094675DF31EEB8" +
+          "17CE7671DBA2160F632B7D24D05"
       );
       // Verify signature is deterministic
       Signature signature2 = this.derivedKeySignatureService.sponsorSign(privateKeyReference, paymentTransaction);
@@ -1141,8 +1141,8 @@ class BcDerivedKeySignatureServiceTest {
       Signature signature = this.derivedKeySignatureService.sponsorSign(privateKeyReference, paymentTransaction);
       assertThat(signature).isNotNull();
       assertThat(signature.base16Value()).isEqualTo(
-        "3045022100CA3EE6AF48AA49EEF7964E4BF5E3FA879476FFE836F91740344415CD3B34A25B02205DCFC440B19BECBE3C5FF29F" +
-          "F0C662C33AE2DDD10AC4B1859C419D0BB32B8AC6"
+        "3044022068850A7470BCDE32C4A1D31A0D921D1D3716FC9E11B24F973ED827BC2153610C02200FF49D0F1B341F46ADAC58B9B14" +
+          "0933D8A07ECBBC00234D036A39E7DBE5DC8AC"
       );
       // Verify signature is deterministic for SECP256K1
       Signature signature2 = this.derivedKeySignatureService.sponsorSign(privateKeyReference, paymentTransaction);
@@ -1185,8 +1185,8 @@ class BcDerivedKeySignatureServiceTest {
       Signature signature = this.derivedKeySignatureService.sponsorMultiSign(privateKeyReference, paymentTransaction);
       assertThat(signature).isNotNull();
       assertThat(signature.base16Value()).isEqualTo(
-        "8DFF4D545A289D7F0659DB61759C1EFDA36093432F1B2B6E99BA3B8A5EF4343125B6470441CE7579F42FD9B29BAC728E087BA" +
-          "8260E911583B3B3B6038FF5740D"
+        "D56AACF5A60B02E6ED36480B5246C517B57886CAF2188D3916F194253DA1D81ED791026D5E624744F2EB9735FC7D2EF59F850" +
+          "0180DCA3D1FDE8BD928F0EC7104"
       );
       // Verify signature is deterministic
       Signature signature2 = this.derivedKeySignatureService.sponsorMultiSign(privateKeyReference, paymentTransaction);
@@ -1229,8 +1229,8 @@ class BcDerivedKeySignatureServiceTest {
       Signature signature = this.derivedKeySignatureService.sponsorMultiSign(privateKeyReference, paymentTransaction);
       assertThat(signature).isNotNull();
       assertThat(signature.base16Value()).isEqualTo(
-        "304502210088CBBE3DE6CCA7306072B28DF8785157E9D6A4037E6F895B7D93C4106C208EFF02204CE2EB8A9A1077358408201" +
-          "052D46EC7AB4BEA09CB981E2FEAB17812BBC52E96"
+        "3045022100E143879BEBA0179096D485B1864882F010D78E5A4E285EA378587EB2DB9DDC2402202B0B925B0671B34ED95EF162" +
+          "94B16579F5EF26A5E80A0D9BE4DBD8B8F48933BD"
       );
       // Verify signature is deterministic for SECP256K1
       Signature signature2 = this.derivedKeySignatureService.sponsorMultiSign(privateKeyReference, paymentTransaction);

--- a/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/LendingProtocolIT.java
+++ b/xrpl4j-integration-tests/src/test/java/org/xrpl/xrpl4j/tests/LendingProtocolIT.java
@@ -1,10 +1,13 @@
 package org.xrpl.xrpl4j.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.given;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.UnsignedInteger;
+import com.google.common.primitives.UnsignedLong;
+import org.awaitility.Durations;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.xrpl.xrpl4j.client.JsonRpcClientErrorException;
@@ -62,6 +65,8 @@ import org.xrpl.xrpl4j.model.transactions.VaultDeposit;
 import org.xrpl.xrpl4j.model.transactions.WithdrawalPolicy;
 import org.xrpl.xrpl4j.model.transactions.XrpCurrencyAmount;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -726,7 +731,9 @@ public class LendingProtocolIT extends AbstractIT {
       .counterpartySignature(counterpartySig)
       .build();
 
-    // Broker signs the final transaction (same signable bytes since CounterpartySignature is excluded)
+    // Broker signs the final transaction. CounterpartySignature is excluded from the signing fields, so attaching
+    // it above does not change what the broker signs. The two signatures still cover different bytes, though: the
+    // broker signs under the STX prefix and the counterparty under the role-bound CPT prefix (fixCleanup3_4_0).
     SingleSignedTransaction<LoanSet> signedLoanSet = signatureService.sign(
       loanBrokerKeyPair.privateKey(), loanSetFinal
     );
@@ -792,65 +799,6 @@ public class LendingProtocolIT extends AbstractIT {
     );
     LoanObject paidLoan = loanEntry.node();
     assertThat(paidLoan.paymentRemaining()).isEqualTo(UnsignedInteger.valueOf(2));
-
-    // ========== LOAN MANAGE - Impair ==========
-    loanBrokerAccountInfo = this.scanForResult(
-      () -> this.getValidatedAccountInfo(loanBrokerKeyPair.publicKey().deriveAddress())
-    );
-
-    LoanManage loanManageImpair = LoanManage.builder()
-      .account(loanBrokerKeyPair.publicKey().deriveAddress())
-      .fee(fee)
-      .sequence(loanBrokerAccountInfo.accountData().sequence())
-      .loanId(loanId)
-      .flags(LoanManageFlags.of(LoanManageFlags.LOAN_IMPAIR.getValue()))
-      .signingPublicKey(loanBrokerKeyPair.publicKey())
-      .build();
-
-    SingleSignedTransaction<LoanManage> signedImpair = signatureService.sign(
-      loanBrokerKeyPair.privateKey(), loanManageImpair
-    );
-    SubmitResult<LoanManage> impairResult =
-      xrplClient.submit(signedImpair);
-    assertThat(impairResult.engineResult()).isEqualTo(SUCCESS_STATUS);
-    this.scanForResult(
-      () -> this.getValidatedTransaction(signedImpair.hash(), LoanManage.class)
-    );
-
-    // Verify loan is impaired
-    loanEntry = xrplClient.ledgerEntry(
-      LedgerEntryRequestParams.index(loanId, LoanObject.class, LedgerSpecifier.VALIDATED)
-    );
-    assertThat(loanEntry.node().flags().lsfLoanImpaired()).isTrue();
-
-    // ========== LOAN MANAGE - Unimpair ==========
-    loanBrokerAccountInfo = this.scanForResult(
-      () -> this.getValidatedAccountInfo(loanBrokerKeyPair.publicKey().deriveAddress())
-    );
-
-    LoanManage loanManageUnimpair = LoanManage.builder()
-      .account(loanBrokerKeyPair.publicKey().deriveAddress())
-      .fee(fee)
-      .sequence(loanBrokerAccountInfo.accountData().sequence())
-      .loanId(loanId)
-      .flags(LoanManageFlags.of(LoanManageFlags.LOAN_UNIMPAIR.getValue()))
-      .signingPublicKey(loanBrokerKeyPair.publicKey())
-      .build();
-
-    SingleSignedTransaction<LoanManage> signedUnimpair = signatureService.sign(
-      loanBrokerKeyPair.privateKey(), loanManageUnimpair
-    );
-    SubmitResult<LoanManage> unimpairResult = xrplClient.submit(signedUnimpair);
-    assertThat(unimpairResult.engineResult()).isEqualTo(SUCCESS_STATUS);
-    this.scanForResult(
-      () -> this.getValidatedTransaction(signedUnimpair.hash(), LoanManage.class)
-    );
-
-    // Verify loan is no longer impaired
-    loanEntry = xrplClient.ledgerEntry(
-      LedgerEntryRequestParams.index(loanId, LoanObject.class, LedgerSpecifier.VALIDATED)
-    );
-    assertThat(loanEntry.node().flags().lsfLoanImpaired()).isFalse();
 
     // ========== LOAN PAY - Full payment ==========
     borrowerAccountInfo = this.scanForResult(
@@ -1016,6 +964,156 @@ public class LendingProtocolIT extends AbstractIT {
   /**
    * Helper method to verify that the LoanBroker from ledger_entry matches account_objects.
    */
+  // //////////////////////
+  // LoanManage impair/unimpair (kept separate from the lifecycle test because it requires an overdue loan)
+  // //////////////////////
+
+  @Test
+  void loanManageImpairAndUnimpair() throws JsonRpcClientErrorException, JsonProcessingException {
+    final KeyPair brokerKeyPair = createRandomAccountEd25519();
+    final KeyPair borrowerKeyPair = createRandomAccountEd25519();
+
+    final FeeResult feeResult = xrplClient.fee();
+    final XrpCurrencyAmount fee = FeeUtils.computeNetworkFees(feeResult).recommendedFee();
+
+    final Hash256 loanBrokerId = setupLoanBrokerAndXrpVault(brokerKeyPair, fee);
+    final UnsignedInteger loanSequence = xrplClient.ledgerEntry(
+      LedgerEntryRequestParams.index(loanBrokerId, LoanBrokerObject.class, LedgerSpecifier.VALIDATED)
+    ).node().loanSequence();
+
+    // PaymentInterval is pinned to rippled's 60-second minimum so the loan falls overdue almost immediately. That is
+    // safe here only because this test makes no payments after impairing — see awaitLoanPaymentLate().
+    final AccountInfoResult brokerAccountInfo = this.scanForResult(
+      () -> this.getValidatedAccountInfo(brokerKeyPair.publicKey().deriveAddress())
+    );
+    final LoanSet unsignedLoanSet = LoanSet.builder()
+      .account(brokerKeyPair.publicKey().deriveAddress())
+      .fee(FeeUtils.computeLoanSetNetworkFees(feeResult, UnsignedInteger.ZERO, UnsignedInteger.ZERO).recommendedFee())
+      .sequence(brokerAccountInfo.accountData().sequence())
+      .loanBrokerId(loanBrokerId)
+      .principalRequested(Amount.of("1000000"))
+      .counterparty(borrowerKeyPair.publicKey().deriveAddress())
+      .paymentTotal(UnsignedInteger.valueOf(3))
+      .paymentInterval(UnsignedInteger.valueOf(60))
+      .signingPublicKey(brokerKeyPair.publicKey())
+      .build();
+
+    final SingleSignedTransaction<LoanSet> brokerSigned = signatureService.sign(
+      brokerKeyPair.privateKey(), unsignedLoanSet
+    );
+    final Signature counterpartySig = signatureService.counterpartySign(
+      borrowerKeyPair.privateKey(), unsignedLoanSet
+    );
+    final CounterpartySignature counterpartySignature = CounterpartySignature.of(
+      borrowerKeyPair.publicKey(), counterpartySig
+    );
+    final LoanSet unsignedWithCounterparty = LoanSet.builder().from(unsignedLoanSet)
+      .counterpartySignature(counterpartySignature)
+      .build();
+    submitSingleSignedLoanSet(
+      SingleSignedTransaction.<LoanSet>builder()
+        .unsignedTransaction(unsignedWithCounterparty)
+        .signature(brokerSigned.signature())
+        .signedTransaction(
+          LoanSet.builder().from(unsignedWithCounterparty)
+            .transactionSignature(brokerSigned.signature())
+            .build()
+        )
+        .build()
+    );
+
+    final Hash256 loanId = xrplClient.ledgerEntry(
+      LedgerEntryRequestParams.loan(
+        LoanLedgerEntryParams.builder().loanBrokerId(loanBrokerId).loanSeq(loanSequence).build(),
+        LedgerSpecifier.VALIDATED
+      )
+    ).node().index();
+
+    // ========== LOAN MANAGE - Impair ==========
+    // Under fixCleanup3_4_0 a loan can only be impaired once its payment is actually late; impairing a current loan
+    // returns tecTOO_SOON (see rippled's LoanManage::impairLoan).
+    awaitLoanPaymentLate(loanId);
+
+    final LoanManage impair = LoanManage.builder()
+      .account(brokerKeyPair.publicKey().deriveAddress())
+      .fee(fee)
+      .sequence(this.scanForResult(
+        () -> this.getValidatedAccountInfo(brokerKeyPair.publicKey().deriveAddress())
+      ).accountData().sequence())
+      .loanId(loanId)
+      .flags(LoanManageFlags.of(LoanManageFlags.LOAN_IMPAIR.getValue()))
+      .signingPublicKey(brokerKeyPair.publicKey())
+      .build();
+
+    final SingleSignedTransaction<LoanManage> signedImpair = signatureService.sign(
+      brokerKeyPair.privateKey(), impair
+    );
+    assertThat(xrplClient.submit(signedImpair).engineResult()).isEqualTo(SUCCESS_STATUS);
+    this.scanForResult(() -> this.getValidatedTransaction(signedImpair.hash(), LoanManage.class));
+
+    assertThat(
+      xrplClient.ledgerEntry(
+        LedgerEntryRequestParams.index(loanId, LoanObject.class, LedgerSpecifier.VALIDATED)
+      ).node().flags().lsfLoanImpaired()
+    ).isTrue();
+
+    // ========== LOAN MANAGE - Unimpair ==========
+    final LoanManage unimpair = LoanManage.builder()
+      .account(brokerKeyPair.publicKey().deriveAddress())
+      .fee(fee)
+      .sequence(this.scanForResult(
+        () -> this.getValidatedAccountInfo(brokerKeyPair.publicKey().deriveAddress())
+      ).accountData().sequence())
+      .loanId(loanId)
+      .flags(LoanManageFlags.of(LoanManageFlags.LOAN_UNIMPAIR.getValue()))
+      .signingPublicKey(brokerKeyPair.publicKey())
+      .build();
+
+    final SingleSignedTransaction<LoanManage> signedUnimpair = signatureService.sign(
+      brokerKeyPair.privateKey(), unimpair
+    );
+    assertThat(xrplClient.submit(signedUnimpair).engineResult()).isEqualTo(SUCCESS_STATUS);
+    this.scanForResult(() -> this.getValidatedTransaction(signedUnimpair.hash(), LoanManage.class));
+
+    assertThat(
+      xrplClient.ledgerEntry(
+        LedgerEntryRequestParams.index(loanId, LoanObject.class, LedgerSpecifier.VALIDATED)
+      ).node().flags().lsfLoanImpaired()
+    ).isFalse();
+  }
+
+  /**
+   * Waits until the given loan's next payment is overdue, i.e. until the validated ledger's close time has advanced
+   * strictly past the loan's {@code NextPaymentDueDate}.
+   *
+   * <p>Under the {@code fixCleanup3_4_0} amendment, rippled only permits impairing a loan whose payment is actually
+   * late (see rippled's {@code LoanManage::impairLoan}, which otherwise returns {@code tecTOO_SOON}). A standalone
+   * rippled's close time advances much faster than wall-clock time, so pinning the loan to the 60-second minimum
+   * {@code PaymentInterval} keeps this wait well under a second.</p>
+   *
+   * @param loanId The {@link Hash256} identifying the loan to wait on.
+   *
+   * @throws JsonRpcClientErrorException If the loan cannot be read from the ledger.
+   */
+  private void awaitLoanPaymentLate(final Hash256 loanId) throws JsonRpcClientErrorException {
+    final UnsignedLong nextPaymentDueDate = UnsignedLong.valueOf(
+      xrplClient.ledgerEntry(
+        LedgerEntryRequestParams.index(loanId, LoanObject.class, LedgerSpecifier.VALIDATED)
+      ).node().nextPaymentDueDate()
+        .orElseThrow(() -> new IllegalStateException("Loan must have a NextPaymentDueDate in order to become late."))
+        .longValue()
+    );
+
+    given()
+      .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+      .atMost(Duration.of(1, ChronoUnit.MINUTES))
+      .await()
+      .until(() -> getValidatedLedger().ledger().closeTime()
+        .map(closeTime -> closeTime.compareTo(nextPaymentDueDate) > 0)
+        .orElse(false)
+      );
+  }
+
   private void assertLoanBrokerEntryEqualsObjectFromAccountObjects(
     Address owner,
     UnsignedInteger ownerSequence

--- a/xrpl4j-integration-tests/src/test/resources/xrpld/xrpld.cfg
+++ b/xrpl4j-integration-tests/src/test/resources/xrpld/xrpld.cfg
@@ -251,5 +251,7 @@ fixCleanup3_2_0
 BatchV1_1
 DynamicMPT
 ConfidentialTransfer
+fixCleanup3_3_0
 # XLS-68 sponsor
 Sponsor
+fixCleanup3_4_0


### PR DESCRIPTION
## Summary

Implements rippled [#8162](https://github.com/XRPLF/rippled/pull/8162) (amendment `fixCleanup3_4_0`), a **signature-portability security fix**. Before this fix, a transaction's own `TxnSignature`, its `CounterpartySignature` (Lending Protocol / `LoanSet`), and its `SponsorSignature` (XLS-68 Sponsor) all covered the *same* signing bytes, so a signature made for one role could be replayed in another — e.g. a lender's `CounterpartySignature` on a `LoanSet` copied into `SponsorSignature` to force the lender to pay a fee it never agreed to.

xrpl4j previously reused the generic `TxSign`/`TxMultiSign` prefixes for all four role-signing paths — i.e. it emitted exactly the forgeable signatures this PR eliminates. This change binds each role to a distinct hash prefix.

## Prefixes added

Verified byte-for-byte against rippled `HashPrefix.h` / `makeHashPrefix`, and consistent with the sibling SDK PRs (xrpl.js [#3462](https://github.com/XRPLF/xrpl.js/pull/3462), xrpl-py [#1036](https://github.com/XRPLF/xrpl-py/pull/1036)):

| Role | Single-sign | Multi-sign |
| --- | --- | --- |
| `CounterpartySignature` | `CPT` = `43505400` | `CPM` = `43504D00` |
| `SponsorSignature` | `SPN` = `53504E00` | `SPM` = `53504D00` |

## Changes

- **`XrplBinaryCodec`** — added the four prefix constants and role-specific encoders (`encodeForSigningCounterparty`/`Sponsor`, `encodeForMultiSigningCounterparty`/`Sponsor`), refactored so the *only* difference from the generic signing payload is the 4-byte prefix. Extended `decode()` to recognize the new prefixes.
- **`SignatureUtils`** — added `toCounterpartySignableBytes` / `toSponsorSignableBytes` and repointed the counterparty/sponsor multisign builders to the role encoders.
- **`AbstractTransactionSigner`** — routed `counterpartySign` / `sponsorSign` through the role-bound payloads (they previously used the generic single-sign path).
- **`TransactionSigner`** — corrected Javadoc that asserted the old `STX`/`SMT` prefixes, and documented that these signatures require `fixCleanup3_4_0` on the target network.
- **`LoanSet.counterpartySignature()`** — the Javadoc no longer claims both parties sign identical bytes. It deliberately does *not* hardcode `STX`/`CPT`, because the prefix depends on role **and** on single- vs multi-signing (`STX`/`SMT` for the broker, `CPT`/`CPM` for the counterparty) and all four combinations are supported; it states the rule and defers to `TransactionSigner`.
- **`TransactionVerifier.verify()`** — documented that it verifies the transaction's own signing payload only. Role signatures are signed over role-specific payloads, so passing one now returns `false` rather than validating it (see *Known limitation* below).
- **`xrpld.cfg`** — enabled `fixCleanup3_4_0` (and the previously-missing `fixCleanup3_3_0`) so the lending/sponsor integration tests exercise the fix.
- **`LendingProtocolIT`** — impair/unimpair moved out of `lendingProtocolLifecycle` into a new `loanManageImpairAndUnimpair` test, plus an `awaitLoanPaymentLate` helper. This is a forced consequence of enabling the amendment: `LoanManage.cpp:296-299` now returns `tecTOO_SOON` when impairing a loan whose payment is not yet late. Keeping it inline would also require bringing the loan *current* again before the closing full payment, which costs roughly +18s of wall clock; the extracted test makes no payments after impairing, so `PaymentInterval` can sit at rippled's 60-second minimum and the wait is ~0.7s (net cost +1.8s, measured).

## Breaking change

`XrplBinaryCodec.encodeForMultiSigningWithSigningPubKey(String, String)` is **removed** (it survives as a private 3-arg, prefix-parameterized helper). Its only purpose was counterparty/sponsor multi-signing, which is now split by role; leaving it public would keep a documented way to emit an `SMT`-prefixed payload bound to no role — exactly the forgeable bytes this PR removes.

It was never in a GA release, but it **was** public in `v7.0.0-rc1`, `v7.0.0-rc.1` and `v7.0.0-rc.2`, so this is a source/binary break for anyone building against the current RC line. The build has no japicmp/revapi to flag that automatically. Callers should use `encodeForMultiSigningCounterparty` / `encodeForMultiSigningSponsor`.

## Design notes

- Role prefixes are emitted **unconditionally** (the secure default; matches xrpl.js/xrpl-py), so a caller cannot accidentally produce an old-style, role-portable signature.
- Amendment availability, queried against each network's on-ledger `Amendments` object: **devnet** has `fixCleanup3_4_0`, `LendingProtocol`, `LendingProtocolV1_1` and `Sponsor` all enabled; **mainnet** and **testnet** have none of them. So there is currently no network where these APIs are usable but the old prefix is required. The residual risk is activation ordering — all are `DefaultNo` and voted independently, so a network could enable `Sponsor`/`LendingProtocol` before `fixCleanup3_4_0`. These methods are `@Beta`, so a rules/toggle parameter can be added later without a breaking change if that materialises.
- No `definitions.json` regeneration — rippled #8162 adds no new SFields; the prefixes are code constants like `BATCH_SIGNATURE_PREFIX`.
- Batch multi-sign (`BCM`, rippled [#8163](https://github.com/XRPLF/rippled/pull/8163)) is out of scope, matching the sibling SDKs (unmerged upstream).

## Known limitation

There is no role-aware verification API. `verify()` / `verifyMultiSigned()` cover the transaction's own signature only, so a `CounterpartySignature` or `SponsorSignature` cannot be validated locally; rippled validates it on submission. Note that `verify()` was never role-aware — it appeared to work for role signatures only because every role shared the same bytes, which is the defect this PR fixes, so the two cannot both be preserved. A correct role-aware API is not a mirror of the signing methods (multi-sign verification needs the counterparty's own SignerList quorum, which the SDK does not hold), and neither xrpl.js nor xrpl-py offers one. Deferred to a follow-up rather than designed in a security fix.

## Testing

- Codec tests pin each of the four prefixes exactly **and** assert that the remaining bytes equal the corresponding generic payload — i.e. the prefix is provably the only difference. A cross-role pair asserts the two payloads are not equal while their bodies are identical, which is the security property stated as a test.
- `SignatureUtils` / signer routing tests assert each role signer calls the role-specific builder and nothing else.
- Golden signature values pinned for **all eight** real-crypto paths in `BcDerivedKeySignatureServiceTest` — the four sponsor values were regenerated (the payload legitimately changed with `SPN`/`SPM`), and the four counterparty values, which previously asserted only non-emptiness, are now pinned too.
- Integration tests run against `rippleci/xrpld:develop` with `fixCleanup3_4_0` enabled:

```
xrpl4j-core         73,992 tests, 0 failures
LendingProtocolIT        7 tests, 0 failures   (CPT single-sign, CPM multi-sign)
SponsorshipIT           10 tests, 0 failures   (SPN, SPM)
checkstyle (core + integration-tests, tests included)   0 violations
```

Not covered: no test asserts that rippled *rejects* a role-swapped signature. rippled's own `LoanSecurity_test.cpp` covers that, and these ITs assert success paths by convention.

## Pre-existing CI failure

`build_devnet_its` is red, and is **already red on `main`** — the same six `LendingProtocolIT` tests fail identically at `main@15170cc8` with `tecNO_PERMISSION` from `LoanBrokerSet`, in shared setup this PR does not touch. Root cause: `LendingProtocolV1_1` requires a LoanBroker's vault to be closed-ended, but the ITs create open-ended vaults. Devnet has `LendingProtocolV1_1` enabled; the local `xrpld.cfg` does not list it, which masks the incompatibility locally. This PR's new test adds a seventh instance of the same pre-existing failure. Fixing it means reworking the IT vault fixtures (and then satisfying `LoanSet`'s `finalPayment + kLoanRedemptionBuffer > RedemptionDate` check), which belongs in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
